### PR TITLE
feat: experimental service-worker adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,13 @@
     "./bun": "./dist/adapters/bun.mjs",
     "./node": "./dist/adapters/node.mjs",
     "./cloudflare": "./dist/adapters/cloudflare.mjs",
+    "./service-worker": "./dist/adapters/service-worker.mjs",
     ".": {
       "types": "./dist/types.d.mts",
       "deno": "./dist/adapters/deno.mjs",
       "bun": "./dist/adapters/bun.mjs",
       "workerd": "./dist/adapters/cloudflare.mjs",
+      "web": "./dist/adapters/service-worker.mjs",
       "node": "./dist/adapters/node.mjs"
     }
   },
@@ -36,6 +38,7 @@
     "play:deno": "deno run -A playground/app.mjs",
     "play:mkcert": "openssl req -x509 -newkey rsa:2048 -nodes -keyout server.key -out server.crt -days 365 -subj /CN=srvx.local",
     "play:node": "node playground/app.mjs",
+    "play:sw": "pnpm build && pnpx serve playground",
     "release": "pnpm test && changelogen --release && npm publish && git push --follow-tags",
     "test": "pnpm lint && pnpm test:types && vitest run --coverage",
     "test:types": "tsc --noEmit --skipLibCheck"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
       "deno": "./dist/adapters/deno.mjs",
       "bun": "./dist/adapters/bun.mjs",
       "workerd": "./dist/adapters/cloudflare.mjs",
-      "web": "./dist/adapters/service-worker.mjs",
+      "browser": "./dist/adapters/service-worker.mjs",
       "node": "./dist/adapters/node.mjs"
     }
   },

--- a/playground/sw/index.html
+++ b/playground/sw/index.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Service Worker Example</title>
+  </head>
+  <body>
+    <p>Loading service worker...</p>
+    <script type="module">
+      if ("serviceWorker" in navigator) {
+        try {
+          // Register the new service worker
+          const newRegistration = await navigator.serviceWorker.register(
+            "./sw.mjs",
+            { type: "module" },
+          );
+          console.log(
+            "Service Worker registered with scope:",
+            newRegistration.scope,
+          );
+          // Reload the page without adding to history
+          location.replace(location.href);
+        } catch (error) {
+          console.error("Service Worker registration failed:", error);
+        }
+      } else {
+        console.log("Service Workers are not supported in this browser.");
+      }
+    </script>
+  </body>
+</html>

--- a/playground/sw/sw.mjs
+++ b/playground/sw/sw.mjs
@@ -1,0 +1,19 @@
+import { serve } from "../node_modules/srvx/dist/adapters/service-worker.mjs";
+
+const server = serve({
+  fetch(_request) {
+    return new Response(
+      `
+        <h1>👋 Hello there!</h1>
+        Learn more: <a href="https://srvx.unjs.io/" target="_blank">srvx.unjs.io</a>
+      `,
+      {
+        headers: {
+          "Content-Type": "text/html; charset=UTF-8",
+        },
+      },
+    );
+  },
+});
+
+server.ready().then(() => console.log(`🚀 Server ready!`));

--- a/src/adapters/service-worker.ts
+++ b/src/adapters/service-worker.ts
@@ -1,0 +1,74 @@
+import type { Server, ServerOptions, ServerRequest } from "../types.ts";
+import { wrapFetch } from "../_plugin.ts";
+
+export const Response = globalThis.Response;
+
+export type ServiceWorkerHandler = (
+  request: ServerRequest,
+  event: FetchEvent,
+) => Response | Promise<Response>;
+
+export function serve(options: ServerOptions): Server<ServiceWorkerHandler> {
+  return new ServiceWorkerServer(options);
+}
+
+class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
+  readonly runtime = "service-worker";
+  readonly options: ServerOptions;
+  readonly fetch: ServiceWorkerHandler;
+
+  constructor(options: ServerOptions) {
+    this.options = options;
+
+    const fetchHandler = wrapFetch(
+      this as unknown as Server,
+      this.options.fetch,
+    );
+
+    this.fetch = (request: Request, event: FetchEvent) => {
+      Object.defineProperties(request, {
+        runtime: {
+          enumerable: true,
+          value: { runtime: "service-worker", serviceWorker: { event } },
+        },
+      });
+      return Promise.resolve(fetchHandler(request));
+    };
+
+    if (!options.manual) {
+      this.serve();
+    }
+  }
+
+  serve() {
+    // Listen for the 'fetch' event to handle requests
+    addEventListener("fetch", async (event) => {
+      // skip if event url ends with file with extension
+      if (/\/[^/]*\.[a-zA-Z0-9]+$/.test(new URL(event.request.url).pathname)) {
+        return;
+      }
+      const response = await this.fetch(event.request, event);
+      if (response.status !== 404) {
+        event.respondWith(response);
+      }
+    });
+
+    // Listen for the 'install' event to update the service worker
+    globalThis.addEventListener("install", () => {
+      (globalThis as any).skipWaiting(); // Force the waiting service worker to become active
+    });
+
+    // Listen for the 'activate' event to claim clients
+    globalThis.addEventListener("activate", (event) => {
+      (event as FetchEvent).waitUntil((globalThis as any).clients?.claim?.()); // Take control of uncontrolled clients
+    });
+  }
+
+  ready(): Promise<Server<ServiceWorkerHandler>> {
+    return Promise.resolve().then(() => this);
+  }
+
+  close() {
+    return Promise.resolve();
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,7 +120,7 @@ export interface Server<Handler = ServerHandler> {
   /**
    * Current runtime name
    */
-  readonly runtime: "node" | "deno" | "bun" | "cloudflare";
+  readonly runtime: "node" | "deno" | "bun" | "cloudflare" | "service-worker";
 
   /**
    * Server options


### PR DESCRIPTION
This PR adds an experimental service-worker adapter to fill support for `browser` export condition.

Features:

- `serve` registers service worker and makes sure to reload and claim other clients
- skips for 404 responses and URLs with extension to be on safe side (might add option later)