### PR TITLE
feat(service-worker): self-register support

### DIFF
--- a/playground/sw/index.html
+++ b/playground/sw/index.html
@@ -7,26 +7,6 @@
   </head>
   <body>
     <p>Loading service worker...</p>
-    <script type="module">
-      if ("serviceWorker" in navigator) {
-        try {
-          // Register the new service worker
-          const newRegistration = await navigator.serviceWorker.register(
-            "./sw.mjs",
-            { type: "module" },
-          );
-          console.log(
-            "Service Worker registered with scope:",
-            newRegistration.scope,
-          );
-          // Reload the page without adding to history
-          location.replace(location.href);
-        } catch (error) {
-          console.error("Service Worker registration failed:", error);
-        }
-      } else {
-        console.log("Service Workers are not supported in this browser.");
-      }
-    </script>
+    <script type="module" src="./sw.mjs"></script>
   </body>
 </html>

--- a/playground/sw/sw.mjs
+++ b/playground/sw/sw.mjs
@@ -1,6 +1,7 @@
 import { serve } from "../node_modules/srvx/dist/adapters/service-worker.mjs";
 
 const server = serve({
+  serviceWorker: { url: import.meta.url },
   fetch(_request) {
     return new Response(
       `

--- a/src/adapters/service-worker.ts
+++ b/src/adapters/service-worker.ts
@@ -8,6 +8,9 @@ export type ServiceWorkerHandler = (
   event: FetchEvent,
 ) => Response | Promise<Response>;
 
+const isMainThread = () =>
+  typeof navigator !== "undefined" && "serviceWorker" in navigator;
+
 export function serve(options: ServerOptions): Server<ServiceWorkerHandler> {
   return new ServiceWorkerServer(options);
 }
@@ -16,6 +19,9 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
   readonly runtime = "service-worker";
   readonly options: ServerOptions;
   readonly fetch: ServiceWorkerHandler;
+
+  #fetchListener?: (event: FetchEvent) => void | Promise<void>;
+  #listeningPromise?: Promise<any>;
 
   constructor(options: ServerOptions) {
     this.options = options;
@@ -41,8 +47,29 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
   }
 
   serve() {
+    if (isMainThread()) {
+      const swURL = this.options.serviceWorker?.url;
+      if (!swURL) {
+        throw new Error(
+          "Service worker URL is not provided. Please set the `serviceWorker.url` serve option or manually register.",
+        );
+      }
+      // Not a service worker, so self-register the service worker
+      this.#listeningPromise = navigator.serviceWorker
+        .register(swURL, {
+          type: "module",
+          scope: this.options.serviceWorker?.scope,
+        })
+        .then((registration) => {
+          registration.addEventListener("updatefound", () => {
+            location.replace(location.href);
+          });
+        });
+      return;
+    }
+
     // Listen for the 'fetch' event to handle requests
-    addEventListener("fetch", async (event) => {
+    this.#fetchListener = async (event) => {
       // skip if event url ends with file with extension
       if (/\/[^/]*\.[a-zA-Z0-9]+$/.test(new URL(event.request.url).pathname)) {
         return;
@@ -51,24 +78,41 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
       if (response.status !== 404) {
         event.respondWith(response);
       }
-    });
+    };
+    addEventListener("fetch", this.#fetchListener);
 
     // Listen for the 'install' event to update the service worker
     globalThis.addEventListener("install", () => {
-      (globalThis as any).skipWaiting(); // Force the waiting service worker to become active
+      // Force the waiting service worker to become active
+      (globalThis as any).skipWaiting();
     });
 
     // Listen for the 'activate' event to claim clients
     globalThis.addEventListener("activate", (event) => {
-      (event as FetchEvent).waitUntil((globalThis as any).clients?.claim?.()); // Take control of uncontrolled clients
+      // Take control of uncontrolled clients
+      (event as FetchEvent).waitUntil((globalThis as any).clients?.claim?.());
     });
   }
 
   ready(): Promise<Server<ServiceWorkerHandler>> {
-    return Promise.resolve().then(() => this);
+    return Promise.resolve(this.#listeningPromise).then(() => this);
   }
 
-  close() {
-    return Promise.resolve();
+  async close() {
+    if (this.#fetchListener) {
+      removeEventListener("fetch", this.#fetchListener!);
+    }
+
+    // unregister the service worker
+    if (isMainThread()) {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      for (const registration of registrations) {
+        if (registration.active) {
+          await registration.unregister();
+        }
+      }
+    } else {
+      await (globalThis as any).registration.unregister();
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -114,6 +114,22 @@ export interface ServerOptions {
    * @docs https://docs.deno.com/api/deno/~/Deno.serve
    */
   deno?: Deno.ServeOptions;
+
+  /**
+   * Service worker options
+   */
+  serviceWorker?: {
+    /**
+     * The path to the service worker file to be registered.
+     */
+    url?: string;
+
+    /**
+     * The scope of the service worker.
+     *
+     */
+    scope?: string;
+  };
 }
 
 export interface Server<Handler = ServerHandler> {


### PR DESCRIPTION
Followup from #53

Simply importing service-worker entry allows self register and unregister.

(bigger logic should be lazy loaded in this usage scenario for best perf)