### PR TITLE
feat: generic adapter

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "./bun": "./dist/adapters/bun.mjs",
     "./node": "./dist/adapters/node.mjs",
     "./cloudflare": "./dist/adapters/cloudflare.mjs",
+    "./generic": "./dist/adapters/generic.mjs",
     "./service-worker": "./dist/adapters/service-worker.mjs",
     ".": {
       "types": "./dist/types.d.mts",
@@ -20,7 +21,8 @@
       "bun": "./dist/adapters/bun.mjs",
       "workerd": "./dist/adapters/cloudflare.mjs",
       "browser": "./dist/adapters/service-worker.mjs",
-      "node": "./dist/adapters/node.mjs"
+      "node": "./dist/adapters/node.mjs",
+      "default": "./dist/adapters/generic.mjs"
     }
   },
   "types": "./dist/types.d.mts",

--- a/src/adapters/generic.ts
+++ b/src/adapters/generic.ts
@@ -1,0 +1,41 @@
+import type { Server, ServerHandler, ServerOptions } from "../types.ts";
+import { wrapFetch } from "../_plugin.ts";
+
+export const Response: typeof globalThis.Response = globalThis.Response;
+
+export function serve(options: ServerOptions): Server {
+  return new GenericServer(options);
+}
+
+class GenericServer implements Server {
+  readonly runtime = "generic";
+  readonly options: ServerOptions;
+  readonly fetch: ServerHandler;
+
+  constructor(options: ServerOptions) {
+    this.options = options;
+
+    const fetchHandler = wrapFetch(
+      this as unknown as Server,
+      this.options.fetch,
+    );
+
+    this.fetch = (request: Request) => {
+      return Promise.resolve(fetchHandler(request));
+    };
+
+    if (!options.manual) {
+      this.serve();
+    }
+  }
+
+  serve(): void {}
+
+  ready(): Promise<Server> {
+    return Promise.resolve(this);
+  }
+
+  close(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/adapters/generic.ts
+++ b/src/adapters/generic.ts
@@ -23,10 +23,6 @@ class GenericServer implements Server {
     this.fetch = (request: Request) => {
       return Promise.resolve(fetchHandler(request));
     };
-
-    if (!options.manual) {
-      this.serve();
-    }
   }
 
   serve(): void {}

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,7 +136,13 @@ export interface Server<Handler = ServerHandler> {
   /**
    * Current runtime name
    */
-  readonly runtime: "node" | "deno" | "bun" | "cloudflare" | "service-worker";
+  readonly runtime:
+    | "node"
+    | "deno"
+    | "bun"
+    | "cloudflare"
+    | "service-worker"
+    | "generic";
 
   /**
    * Server options


### PR DESCRIPTION
In case using `srvx` with default condition or only needing srvx for API compatibility (for example bypass in tests), generic adapter exposes server with `.fetch` method without any listener.