### PR TITLE
feat!: print listening url by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,6 @@ const server = serve({
     return new Response("👋 Hello there!");
   },
 });
-
-await server.ready();
-
-console.log(`🚀 Server ready at ${server.url}`);
 ```
 
 👉 **Visit the 📖 [Documentation](https://srvx.h3.dev/) to learn more.**

--- a/docs/.config/docs.yaml
+++ b/docs/.config/docs.yaml
@@ -17,12 +17,9 @@ landing:
     content: |
       import { serve } from "srvx";
 
-      const server = serve({
+      serve({
         port: 3000,
         fetch(request) {
           return new Response("👋 Hello there!");
         },
       });
-
-      await server.ready();
-      console.log(`🚀 Server ready at ${server.url}`);

--- a/docs/1.guide/1.index.md
+++ b/docs/1.guide/1.index.md
@@ -30,10 +30,6 @@ const server = serve({
     return new Response("👋 Hello there!");
   },
 });
-
-await server.ready();
-
-console.log(`🚀 Server ready at ${server.url}`);
 ```
 
 Install `srvx` as a dependency:

--- a/docs/1.guide/3.server.md
+++ b/docs/1.guide/3.server.md
@@ -35,22 +35,6 @@ Access to the sever options set during initialization.
 
 Get the computed server listening URL.
 
-**Example:**
-
-```js
-import { serve } from "srvx";
-
-const server = serve({
-  port: 3000,
-  fetch: (request) => new Response("👋 Hello there!"),
-});
-
-await server.ready();
-
-// Prints "Server ready at http://localhost:3000/"
-console.log(`🚀 Server ready at ${server.url}`);
-```
-
 ### `server.addr`
 
 Listening address (hostname or ipv4/ipv6).

--- a/docs/1.guide/4.plugins.md
+++ b/docs/1.guide/4.plugins.md
@@ -36,14 +36,12 @@ import { serve } from "srvx";
 
 import { logger } from "./plugins/logger";
 
-const server = serve({
+serve({
   plugins: [logger],
   fetch(request) {
     return new Response(`👋 Hello there.`);
   },
 });
-
-await server.ready();
 ```
 
 ## Defining plugins

--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -56,6 +56,10 @@ Enabling this option allows multiple processes to bind to the same port, which i
 > [!NOTE]
 > Despite Node.js built-in behavior that has `exclusive` flag enabled by default, srvx uses non-exclusive mode for consistency.
 
+### `silent`
+
+If enabled, no server listening message will be printed (enabled by default when `TEST` environment variable is set).
+
 ### `protocol`
 
 The protocol to use for the server.

--- a/playground/app.mjs
+++ b/playground/app.mjs
@@ -1,6 +1,6 @@
 import { serve } from "srvx";
 
-const server = serve({
+serve({
   // protocol: "https",
   tls: { cert: "server.crt", key: "server.key" },
   port: 3000,
@@ -18,5 +18,3 @@ const server = serve({
     );
   },
 });
-
-server.ready().then(() => console.log(`🚀 Server ready at ${server.url}`));

--- a/playground/sw/sw.mjs
+++ b/playground/sw/sw.mjs
@@ -1,6 +1,6 @@
 import { serve } from "../node_modules/srvx/dist/adapters/service-worker.mjs";
 
-const server = serve({
+serve({
   serviceWorker: { url: import.meta.url },
   fetch(_request) {
     return new Response(
@@ -16,5 +16,3 @@ const server = serve({
     );
   },
 });
-
-server.ready().then(() => console.log(`🚀 Server ready!`));

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -29,6 +29,33 @@ export function fmtURL(
   return `http${secure ? "s" : ""}://${host}:${port}/`;
 }
 
+export function printListening(
+  opts: ServerOptions,
+  url: string | undefined,
+): void {
+  if (!url || (opts.silent ?? globalThis.process?.env?.TEST)) {
+    return;
+  }
+
+  const _url = new URL(url);
+  const allInterfaces = _url.hostname === "[::]" || _url.hostname === "0.0.0.0";
+  if (allInterfaces) {
+    _url.hostname = "localhost";
+    url = _url.href;
+  }
+
+  let listeningOn = `➜ Listening on:`;
+  let additionalInfo = allInterfaces ? " (all interfaces)" : "";
+
+  if (globalThis.process.stdout?.isTTY) {
+    listeningOn = `\u001B[32m${listeningOn}\u001B[0m`; // ANSI green
+    url = `\u001B[36m${url}\u001B[0m`; // ANSI cyan
+    additionalInfo = `\u001B[2m${additionalInfo}\u001B[0m`; // ANSI dim
+  }
+
+  console.log(`  ${listeningOn} ${url}${additionalInfo}`);
+}
+
 export function resolveTLSOptions(opts: ServerOptions):
   | {
       cert: string;

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -1,6 +1,6 @@
 import type { BunFetchHandler, Server, ServerOptions } from "../types.ts";
 import type * as bun from "bun";
-import { resolvePort, resolveTLSOptions } from "../_utils.ts";
+import { printListening, resolvePort, resolveTLSOptions } from "../_utils.ts";
 import { wrapFetch } from "../_plugin.ts";
 
 export const Response: typeof globalThis.Response = globalThis.Response;
@@ -63,6 +63,7 @@ class BunServer implements Server<BunFetchHandler> {
     if (!this.bun!.server) {
       this.bun!.server = Bun.serve(this.serveOptions);
     }
+    printListening(this.options, this.url);
     return Promise.resolve(this);
   }
 

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -1,5 +1,10 @@
 import type { DenoFetchHandler, Server, ServerOptions } from "../types.ts";
-import { fmtURL, resolvePort, resolveTLSOptions } from "../_utils.ts";
+import {
+  fmtURL,
+  printListening,
+  resolvePort,
+  resolveTLSOptions,
+} from "../_utils.ts";
 import { wrapFetch } from "../_plugin.ts";
 
 export const Response: typeof globalThis.Response = globalThis.Response;
@@ -73,6 +78,7 @@ class DenoServer implements Server<DenoFetchHandler> {
           if (this.options.deno?.onListen) {
             this.options.deno.onListen(info);
           }
+          printListening(this.options, this.url);
           onListenPromise.resolve();
         },
       },

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -9,7 +9,12 @@ import NodeHttp from "node:http";
 import NodeHttps from "node:https";
 import { sendNodeResponse } from "../_node-compat/send.ts";
 import { NodeRequest } from "../_node-compat/request.ts";
-import { fmtURL, resolvePort, resolveTLSOptions } from "../_utils.ts";
+import {
+  fmtURL,
+  printListening,
+  resolvePort,
+  resolveTLSOptions,
+} from "../_utils.ts";
 import { wrapFetch } from "../_plugin.ts";
 
 export {
@@ -70,7 +75,7 @@ class NodeServer implements Server {
     const tls = resolveTLSOptions(this.options);
     this.serveOptions = {
       port: resolvePort(this.options.port, globalThis.process?.env.PORT),
-      host: this.options.hostname,
+      host: this.options.hostname || "0.0.0.0",
       exclusive: !this.options.reusePort,
       ...(tls
         ? { cert: tls.cert, key: tls.key, passphrase: tls.passphrase }
@@ -98,7 +103,10 @@ class NodeServer implements Server {
       return Promise.resolve(this.#listeningPromise).then(() => this);
     }
     this.#listeningPromise = new Promise<void>((resolve) => {
-      this.node!.server!.listen(this.serveOptions, () => resolve());
+      this.node!.server!.listen(this.serveOptions, () => {
+        printListening(this.options, this.url);
+        resolve();
+      });
     });
   }
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -75,7 +75,7 @@ class NodeServer implements Server {
     const tls = resolveTLSOptions(this.options);
     this.serveOptions = {
       port: resolvePort(this.options.port, globalThis.process?.env.PORT),
-      host: this.options.hostname || "0.0.0.0",
+      host: this.options.hostname,
       exclusive: !this.options.reusePort,
       ...(tls
         ? { cert: tls.cert, key: tls.key, passphrase: tls.passphrase }

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,11 @@ export interface ServerOptions {
   protocol?: "http" | "https";
 
   /**
+   * If set to `true`, server will not print the listening address.
+   */
+  silent?: boolean;
+
+  /**
    * TLS server options.
    */
   tls?: {

--- a/test/bench-node/srvx-fast.mjs
+++ b/test/bench-node/srvx-fast.mjs
@@ -1,10 +1,8 @@
 import { serve, Response } from "srvx";
 
-const server = await serve({
+serve({
   port: 3000,
   fetch() {
     return new Response("Hello!");
   },
 });
-
-await server.ready();


### PR DESCRIPTION
Showing server listening URL is almost common for all usages. This PR adds a new built-in utl that prints listening message for Node, Bun and Deno.

Print is auto disabled for testing environments and when `silent` option is set. Still releasing as major as it requires manual update in current projects.

![image](https://github.com/user-attachments/assets/521cc68d-f2d7-4e3f-a8c3-fb9fc0768618)
