### PR TITLE
feat!: fetch middleware via plugins

### DIFF
--- a/docs/1.guide/4.plugins.md
+++ b/docs/1.guide/4.plugins.md
@@ -4,69 +4,36 @@ icon: clarity:plugin-line
 
 # Server plugins
 
-Plugins allow creating reusable interceptors to modify server options and behavior.
+Plugins allow creating reusable middleware to intercept request lifecycle.
 
 ## Example
 
-This is a simple logging plugin:
-
 ```ts
-import type { ServerPlugin } from "srvx";
+import { serve, type ServerPlugin } from "srvx";
 
-export const logger: ServerPlugin = (server) => {
+const logRequests: ServerPlugin = (server) => {
   console.log(`Logger plugin enabled for ${server.runtime}`);
   return {
-    name: "logger",
-    request: (req) => {
+    name: "log",
+    fetch: (req, next) => {
       console.log(`[request] [${req.method}] ${req.url}`);
-    },
-    response: (req, res) => {
-      console.log(
-        `[response] [${req.method}] ${req.url} ${res.status} ${res.statusText}`,
-      );
+      return next();
     },
   };
 };
-```
 
-We can use it in main server using `plugins` option:
-
-```ts
-import { serve } from "srvx";
-
-import { logger } from "./plugins/logger";
+const xPoweredBy: ServerPlugin = {
+  fetch: (req, next) => {
+    const res = await next();
+    res.headers.set("X-Powered-By", "srvx");
+    return res;
+  },
+};
 
 serve({
-  plugins: [logger],
+  plugins: [logRequests, xPoweredBy],
   fetch(request) {
     return new Response(`👋 Hello there.`);
   },
 });
-```
-
-## Defining plugins
-
-```ts
-import type { ServerPlugin } from "srvx";
-
-const myPlugin: ServerPlugin = (server) => {
-  // You can use server argument to:
-  // - Modify global options using server.options
-  // - Access to the runtime-specific server instance
-  // - Decide hooks based on server.runtime value
-
-  // Return plugin instance
-  return {
-    // Plugin display name
-    name: "my-plugin",
-
-    // Intercept incoming request
-    // You can return a Response value to early return (eg: auth and validation)
-    request: (request) => {},
-
-    // Intercept final response
-    // You can use to modify response
-    response: (request, response) => {},
-  };
-};
 ```

--- a/src/_plugin.ts
+++ b/src/_plugin.ts
@@ -1,99 +1,41 @@
 import type {
-  ServerPluginInstance,
   Server,
   ServerRequest,
   ServerHandler,
+  ServerMiddleware,
+  ServerPlugin,
 } from "./types.ts";
 
 export function wrapFetch(
   server: Server,
-  fetchHandler: ServerHandler,
+  basePlugins?: ServerPlugin[],
 ): ServerHandler {
-  const plugins = server.options.plugins;
+  const plugins = [
+    ...(basePlugins || []),
+    ...(server.options.plugins || []),
+  ].map((plugin) => (typeof plugin === "function" ? plugin(server) : plugin));
 
-  if (!plugins?.length) {
-    return fetchHandler;
+  const middleware = plugins
+    .filter((plugin) => plugin.fetch)
+    .map((plugin) => plugin.fetch!);
+
+  const fetchHandler = server.options.fetch;
+
+  return middleware.length === 0
+    ? fetchHandler
+    : (request) => callMiddleware(request, fetchHandler, middleware, 0);
+}
+
+function callMiddleware(
+  request: ServerRequest,
+  fetchHandler: ServerHandler,
+  middleware: ServerMiddleware[],
+  index: number,
+): Response | Promise<Response> {
+  if (index === middleware.length) {
+    return fetchHandler(request);
   }
-
-  const requestHooks: NonNullable<ServerPluginInstance["request"]>[] = [];
-  const responseHooks: NonNullable<ServerPluginInstance["response"]>[] = [];
-
-  for (const ctor of plugins) {
-    const plugin = typeof ctor === "function" ? ctor(server) : ctor;
-    if (plugin.request) {
-      requestHooks.push(plugin.request);
-    }
-    if (plugin.response) {
-      responseHooks.push(plugin.response);
-    }
-  }
-
-  const hasRequestHooks = requestHooks.length > 0;
-  const hasResponseHooks = responseHooks.length > 0;
-
-  if (!hasRequestHooks && !hasResponseHooks) {
-    return fetchHandler;
-  }
-
-  return (request: ServerRequest) => {
-    let resValue: undefined | Response;
-    let resPromise: undefined | Promise<Response | void>;
-
-    // Request hooks
-    if (hasRequestHooks) {
-      for (const reqHook of requestHooks) {
-        if (resPromise) {
-          resPromise = resPromise.then((res) => res || reqHook(request));
-        } else {
-          const res = reqHook(request);
-          if (res) {
-            if (res instanceof Promise) {
-              resPromise = res;
-            } else {
-              return res;
-            }
-          }
-        }
-      }
-    }
-
-    // User handler
-    if (resPromise) {
-      resPromise = resPromise.then((res) => res || fetchHandler(request));
-    } else {
-      const res = fetchHandler(request);
-      if (res instanceof Promise) {
-        resPromise = res;
-      } else {
-        resValue = res;
-      }
-    }
-
-    // Response hooks
-    if (hasResponseHooks) {
-      for (const resHook of responseHooks) {
-        if (resPromise) {
-          resPromise = resPromise.then((res) => {
-            if (res) {
-              resValue = res;
-            }
-            return resHook(request, resValue!);
-          });
-        } else {
-          const res = resHook(request, resValue!);
-          if (res) {
-            if (res instanceof Promise) {
-              resPromise = res;
-            } else {
-              resValue = res;
-            }
-          }
-        }
-      }
-    }
-
-    return (
-      resPromise ? resPromise.then((res) => res || resValue) : resValue
-    ) as Response | Promise<Response>;
-  };
+  return middleware[index](request, () =>
+    callMiddleware(request, fetchHandler, middleware, index + 1),
+  );
 }

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -28,7 +28,7 @@ class BunServer implements Server<BunFetchHandler> {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(this, this.options.fetch);
+    const fetchHandler = wrapFetch(this);
 
     this.fetch = (request, server) => {
       Object.defineProperties(request, {

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types.ts";
 import type * as CF from "@cloudflare/workers-types";
 import { wrapFetch } from "../_plugin.ts";
-import { wrapFetchOnError } from "../_error.ts";
+import { errorPlugin } from "../_error.ts";
 
 export const URL: typeof globalThis.URL = globalThis.URL;
 
@@ -26,10 +26,7 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(
-      this as unknown as Server,
-      wrapFetchOnError(this.options.fetch, this.options.onError),
-    );
+    const fetchHandler = wrapFetch(this as unknown as Server, [errorPlugin]);
 
     this.fetch = (request, env, context) => {
       Object.defineProperties(request, {

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -32,7 +32,7 @@ class DenoServer implements Server<DenoFetchHandler> {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(this, this.options.fetch);
+    const fetchHandler = wrapFetch(this);
 
     this.fetch = (request, info) => {
       Object.defineProperties(request, {

--- a/src/adapters/generic.ts
+++ b/src/adapters/generic.ts
@@ -1,6 +1,6 @@
 import type { Server, ServerHandler, ServerOptions } from "../types.ts";
 import { wrapFetch } from "../_plugin.ts";
-import { wrapFetchOnError } from "../_error.ts";
+import { errorPlugin } from "../_error.ts";
 
 export const URL: typeof globalThis.URL = globalThis.URL;
 
@@ -18,10 +18,7 @@ class GenericServer implements Server {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(
-      this as unknown as Server,
-      wrapFetchOnError(this.options.fetch, this.options.onError),
-    );
+    const fetchHandler = wrapFetch(this as unknown as Server, [errorPlugin]);
 
     this.fetch = (request: Request) => {
       return Promise.resolve(fetchHandler(request));

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -16,7 +16,7 @@ import {
   resolvePortAndHost,
 } from "../_utils.node.ts";
 import { wrapFetch } from "../_plugin.ts";
-import { wrapFetchOnError } from "../_error.ts";
+import { errorPlugin } from "../_error.ts";
 
 export { FastURL as URL } from "../_url.ts";
 
@@ -61,12 +61,7 @@ class NodeServer implements Server {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(
-      this,
-      wrapFetchOnError(this.options.fetch, this.options.onError),
-    );
-
-    this.fetch = fetchHandler;
+    const fetchHandler = (this.fetch = wrapFetch(this, [errorPlugin]));
 
     const handler = (
       nodeReq: NodeHttp.IncomingMessage,

--- a/src/adapters/service-worker.ts
+++ b/src/adapters/service-worker.ts
@@ -1,7 +1,7 @@
 /* eslint-disable unicorn/prefer-global-this */
 import type { Server, ServerOptions, ServerRequest } from "../types.ts";
 import { wrapFetch } from "../_plugin.ts";
-import { wrapFetchOnError } from "../_error.ts";
+import { errorPlugin } from "../_error.ts";
 
 export const URL: typeof globalThis.URL = globalThis.URL;
 
@@ -32,10 +32,7 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(
-      this as unknown as Server,
-      wrapFetchOnError(this.options.fetch, this.options.onError),
-    );
+    const fetchHandler = wrapFetch(this as unknown as Server, [errorPlugin]);
 
     this.fetch = (request: Request, event: FetchEvent) => {
       Object.defineProperties(request, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,26 +216,14 @@ export interface Server<Handler = ServerHandler> {
 
 export type ServerPlugin = (server: Server) => ServerPluginInstance;
 
+export type ServerMiddleware = (
+  request: ServerRequest,
+  next: () => Response | Promise<Response>,
+) => Response | Promise<Response>;
+
 export interface ServerPluginInstance {
-  /**
-   * Plugin display name
-   */
   name?: string;
-
-  /**
-   * Hook to allow running logic before user fetch handler
-   * If an response value is returned, user fetch handler and the next plugins will be skipped.
-   */
-  request?: (request: ServerRequest) => MaybePromise<Response | void>;
-
-  /**
-   * Hook to allow running logic after user fetch handler
-   * If a response value is returned, user response and the next plugins will be skipped.
-   */
-  response?: (
-    request: ServerRequest,
-    response: Response,
-  ) => MaybePromise<void | Response>;
+  fetch?: ServerMiddleware;
 }
 
 // ----------------------------------------------------------------------------

--- a/test/node-fast.test.ts
+++ b/test/node-fast.test.ts
@@ -19,6 +19,6 @@ describe("node (fast-res)", () => {
   });
 
   addTests((path) => server!.url! + path.slice(1), {
-    runtime: "node",
+    runtime: "node-fast",
   });
 });


### PR DESCRIPTION
Plugins with split `onRequest`/`onResponse` hooks can be a little faster due to linear executation and single wrapper but are also limited since there could not be corelation between request and response interception. For example we cannot implement a plugin for async context support.

This PR changes plugin format to simple `{ fetch(request, next) }` middleware system.

Note: found an issue with node-fast response headers interception support. Fixing in next PRs.