### PR TITLE
feat: support `upgrade` hook (experimental)

### DIFF
--- a/src/_node-compat/request.ts
+++ b/src/_node-compat/request.ts
@@ -1,8 +1,18 @@
 import type NodeHttp from "node:http";
+import type NodeStream from "node:stream";
 import type { ServerRequest, ServerRuntimeContext } from "../types.ts";
 import { kNodeInspect } from "./_common.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { NodeRequestURL } from "./url.ts";
+
+export type NodeRequestContext = {
+  req: NodeHttp.IncomingMessage;
+  res?: NodeHttp.ServerResponse;
+  upgrade?: {
+    socket: NodeStream.Duplex;
+    header: Buffer;
+  };
+};
 
 export const NodeRequest = /* @__PURE__ */ (() => {
   const _Request = class Request {
@@ -21,10 +31,7 @@ export const NodeRequest = /* @__PURE__ */ (() => {
     _node: { req: NodeHttp.IncomingMessage; res?: NodeHttp.ServerResponse };
     runtime: ServerRuntimeContext;
 
-    constructor(nodeCtx: {
-      req: NodeHttp.IncomingMessage;
-      res?: NodeHttp.ServerResponse;
-    }) {
+    constructor(nodeCtx: NodeRequestContext) {
       this._node = nodeCtx;
       this.runtime = {
         name: "node",
@@ -210,10 +217,7 @@ export const NodeRequest = /* @__PURE__ */ (() => {
 
   return _Request;
 })() as unknown as {
-  new (nodeCtx: {
-    req: NodeHttp.IncomingMessage;
-    res: NodeHttp.ServerResponse;
-  }): ServerRequest;
+  new (nodeCtx: NodeRequestContext): ServerRequest;
 };
 
 async function _readStream(stream: ReadableStream) {

--- a/src/_ws.ts
+++ b/src/_ws.ts
@@ -1,0 +1,16 @@
+import type { ServerPlugin } from "./types.ts";
+
+export const wsUpgradePlugin: ServerPlugin = (server) => {
+  const upgradeHandler = server.options.upgrade;
+  if (!upgradeHandler) {
+    return {};
+  }
+  return {
+    fetch(request, next) {
+      if (request.headers.get("upgrade") === "websocket") {
+        return upgradeHandler(request);
+      }
+      return next();
+    },
+  };
+};

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -7,6 +7,7 @@ import {
   resolveTLSOptions,
 } from "../_utils.node.ts";
 import { wrapFetch } from "../_plugin.ts";
+import { wsUpgradePlugin } from "../_ws.ts";
 
 export { FastURL as URL } from "../_url.ts";
 
@@ -28,7 +29,7 @@ class BunServer implements Server<BunFetchHandler> {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(this);
+    const fetchHandler = wrapFetch(this, [wsUpgradePlugin]);
 
     this.fetch = (request, server) => {
       Object.defineProperties(request, {

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -6,6 +6,7 @@ import type {
 import type * as CF from "@cloudflare/workers-types";
 import { wrapFetch } from "../_plugin.ts";
 import { errorPlugin } from "../_error.ts";
+import { wsUpgradePlugin } from "../_ws.ts";
 
 export const URL: typeof globalThis.URL = globalThis.URL;
 
@@ -26,7 +27,10 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(this as unknown as Server, [errorPlugin]);
+    const fetchHandler = wrapFetch(this as unknown as Server, [
+      errorPlugin,
+      wsUpgradePlugin,
+    ]);
 
     this.fetch = (request, env, context) => {
       Object.defineProperties(request, {

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -6,6 +6,7 @@ import {
   resolveTLSOptions,
 } from "../_utils.node.ts";
 import { wrapFetch } from "../_plugin.ts";
+import { wsUpgradePlugin } from "../_ws.ts";
 
 export { FastURL as URL } from "../_url.ts";
 
@@ -32,7 +33,7 @@ class DenoServer implements Server<DenoFetchHandler> {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = wrapFetch(this);
+    const fetchHandler = wrapFetch(this, [wsUpgradePlugin]);
 
     this.fetch = (request, info) => {
       Object.defineProperties(request, {

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -20,7 +20,6 @@ import {
 } from "../_utils.node.ts";
 import { wrapFetch } from "../_plugin.ts";
 import { errorPlugin } from "../_error.ts";
-import { wsUpgradePlugin } from "../_ws.ts";
 
 export { FastURL as URL } from "../_url.ts";
 
@@ -65,10 +64,7 @@ class NodeServer implements Server {
   constructor(options: ServerOptions) {
     this.options = options;
 
-    const fetchHandler = (this.fetch = wrapFetch(this, [
-      errorPlugin,
-      wsUpgradePlugin,
-    ]));
+    const fetchHandler = (this.fetch = wrapFetch(this, [errorPlugin]));
 
     const handler = (
       nodeReq: NodeHttp.IncomingMessage,

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -98,13 +98,14 @@ class NodeServer implements Server {
       : NodeHttp.createServer(this.serveOptions, handler);
 
     // Listen to upgrade events if there is a hook
-    if (this.options.upgrade) {
+    const upgradeHandler = this.options.upgrade;
+    if (upgradeHandler) {
       server.on("upgrade", (nodeReq, socket, header) => {
         const request = new NodeRequest({
           req: nodeReq,
           upgrade: { socket, header },
         });
-        const res = fetchHandler(request);
+        const res = upgradeHandler(request);
         return res instanceof Promise
           ? res.then((resolvedRes) =>
               sendNodeUpgradeResponse(socket, resolvedRes),

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,11 @@ export interface ServerOptions {
   fetch: ServerHandler;
 
   /**
+   * Handle websocket upgrades
+   */
+  upgrade?: ServerHandler;
+
+  /**
    * Server plugins.
    */
   plugins?: (ServerPlugin | ServerPluginInstance)[];


### PR DESCRIPTION
This PR is initial attempt to support unified websocket upgrade support.

- For Node.js, with `uprade` hook a Request proxy is created that adds upgrade details (duplex and head data)
- For deno, bun and cloudflare, if the request has `upgrade` header with `websocket` value and `upgrade` hook is defined, it will be called.

The next step is adding a unified `.upgrade(request)` support to srvx adapters, which can be auto-integrated.

(bun requires additional `bun.websocket`, we need to make a srvx plugin anyway to support crossws universally)