### PR TITLE
fix: correct path parsing in parsePath function

### DIFF
--- a/src/_node-compat/url.ts
+++ b/src/_node-compat/url.ts
@@ -214,11 +214,14 @@ export const NodeRequestURL: {
 
 function parsePath(input: string): [pathname: string, search: string] {
   const url = (input || "/").replace(/\\/g, "/");
-  const qIndex = url.indexOf("?");
+
+  const path = url.replace(/^.*?:\/\//, "");
+
+  const qIndex = path.indexOf("?");
   if (qIndex === -1) {
-    return [url, ""];
+    return [path, ""];
   }
-  return [url.slice(0, qIndex), url.slice(qIndex)];
+  return [path.slice(0, qIndex), path.slice(qIndex)];
 }
 
 function parseHost(host: string | undefined): [hostname: string, port: string] {

--- a/src/_node-compat/url.ts
+++ b/src/_node-compat/url.ts
@@ -95,7 +95,7 @@ export const NodeRequestURL: {
     // pathname
     get pathname() {
       if (this._pathname === undefined) {
-        const [pathname, search] = parsePath(this._node.req.url || "/");
+        const [pathname, search] = parsePathWithoutURL(this._node.req.url || "/");
         this._pathname = pathname;
         if (this._search === undefined) {
           this._search = search;
@@ -117,7 +117,7 @@ export const NodeRequestURL: {
     // search
     get search() {
       if (this._search === undefined) {
-        const [pathname, search] = parsePath(this._node.req.url || "/");
+        const [pathname, search] = parsePathWithoutURL(this._node.req.url || "/");
         this._search = search;
         if (this._pathname === undefined) {
           this._pathname = pathname;
@@ -211,7 +211,7 @@ export const NodeRequestURL: {
 
   return _URL;
 })();
-function parsePath(input: string): [pathname: string, search: string] {
+function parsePathWithoutURL(input: string): [pathname: string, search: string] {
   const normalized = (input || "/").replace(/\\/g, "/");
 
   // Remove protocol (e.g., http://)

--- a/src/_node-compat/url.ts
+++ b/src/_node-compat/url.ts
@@ -211,17 +211,23 @@ export const NodeRequestURL: {
 
   return _URL;
 })();
-
 function parsePath(input: string): [pathname: string, search: string] {
-  const url = (input || "/").replace(/\\/g, "/");
+  const normalized = (input || "/").replace(/\\/g, "/");
 
-  const path = url.replace(/^.*?:\/\//, "");
+  // Remove protocol (e.g., http://)
+  const withoutProtocol = normalized.replace(/^([a-z]+:)?\/\//i, "");
 
-  const qIndex = path.indexOf("?");
+  // Remove domain if present
+  const firstSlash = withoutProtocol.indexOf("/");
+  const pathWithQuery =
+    firstSlash === -1 ? "/" : withoutProtocol.slice(firstSlash);
+
+  const qIndex = pathWithQuery.indexOf("?");
   if (qIndex === -1) {
-    return [path, ""];
+    return [pathWithQuery, ""];
   }
-  return [path.slice(0, qIndex), path.slice(qIndex)];
+
+  return [pathWithQuery.slice(0, qIndex), pathWithQuery.slice(qIndex)];
 }
 
 function parseHost(host: string | undefined): [hostname: string, port: string] {


### PR DESCRIPTION
fix the following issue.

input -> `http://localhost:3000/api`

```ts
const [pathname, search] = parsePath(this._node.req.url || "/");
console.log("pathname", pathname); // http://localhost:3000/api
console.log("search", search); // search 
```