### PR TITLE
refactor!: remove experimental ws upgrade

### DIFF
--- a/src/_node-compat/request.ts
+++ b/src/_node-compat/request.ts
@@ -2,7 +2,6 @@ import { kNodeInspect } from "./_common.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { NodeRequestURL } from "./url.ts";
 
-import type NodeStream from "node:stream";
 import type {
   NodeServerRequest,
   NodeServerResponse,
@@ -13,10 +12,6 @@ import type {
 export type NodeRequestContext = {
   req: NodeServerRequest;
   res?: NodeServerResponse;
-  upgrade?: {
-    socket: NodeStream.Duplex;
-    header: Buffer;
-  };
 };
 
 export const NodeRequest = /* @__PURE__ */ (() => {

--- a/src/_node-compat/send.ts
+++ b/src/_node-compat/send.ts
@@ -65,28 +65,6 @@ function writeHead(
   }
 }
 
-export async function sendNodeUpgradeResponse(
-  socket: Duplex,
-  res: Response,
-): Promise<void> {
-  const head = [
-    `HTTP/1.1 ${res.status || 200} ${res.statusText || ""}`,
-    ...[...res.headers.entries()].map(
-      ([key, value]) =>
-        `${encodeURIComponent(key)}: ${encodeURIComponent(value)}`,
-    ),
-  ];
-  socket.write(head.join("\r\n") + "\r\n\r\n");
-  if (res.body) {
-    for await (const chunk of res.body) {
-      socket.write(chunk);
-    }
-  }
-  return new Promise<void>((resolve) => {
-    socket.end(resolve);
-  });
-}
-
 function endNodeResponse(nodeRes: NodeServerResponse) {
   return new Promise<void>((resolve) => nodeRes.end(resolve));
 }

--- a/src/_plugins.ts
+++ b/src/_plugins.ts
@@ -15,17 +15,3 @@ export const errorPlugin: ServerPlugin = (server) => {
     }
   });
 };
-
-export const wsUpgradePlugin: ServerPlugin = (server) => {
-  const upgradeHandler = server.options.upgrade;
-  if (!upgradeHandler) {
-    return;
-  }
-  server.options.middleware ??= [];
-  server.options.middleware.unshift((req, next) => {
-    if (req.headers.get("upgrade") === "websocket") {
-      return upgradeHandler(req);
-    }
-    return next();
-  });
-};

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -7,7 +7,6 @@ import {
   resolveTLSOptions,
 } from "../_utils.node.ts";
 import { wrapFetch } from "../_middleware.ts";
-import { wsUpgradePlugin } from "../_plugins.ts";
 
 export { FastURL } from "../_url.ts";
 export const FastResponse: typeof globalThis.Response = Response;
@@ -29,7 +28,6 @@ class BunServer implements Server<BunFetchHandler> {
     this.options = options;
 
     for (const plugin of options.plugins || []) plugin(this);
-    wsUpgradePlugin(this);
 
     const fetchHandler = wrapFetch(this);
 

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -5,7 +5,7 @@ import type {
 } from "../types.ts";
 import type * as CF from "@cloudflare/workers-types";
 import { wrapFetch } from "../_middleware.ts";
-import { errorPlugin, wsUpgradePlugin } from "../_plugins.ts";
+import { errorPlugin } from "../_plugins.ts";
 
 export const FastURL: typeof globalThis.URL = URL;
 export const FastResponse: typeof globalThis.Response = Response;
@@ -26,7 +26,6 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
     this.options = options;
 
     for (const plugin of options.plugins || []) plugin(this as any as Server);
-    wsUpgradePlugin(this as unknown as Server);
     errorPlugin(this as unknown as Server);
 
     const fetchHandler = wrapFetch(this as unknown as Server);

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -6,7 +6,6 @@ import {
   resolveTLSOptions,
 } from "../_utils.node.ts";
 import { wrapFetch } from "../_middleware.ts";
-import { wsUpgradePlugin } from "../_plugins.ts";
 
 export { FastURL } from "../_url.ts";
 export const FastResponse: typeof globalThis.Response = Response;
@@ -33,7 +32,6 @@ class DenoServer implements Server<DenoFetchHandler> {
     this.options = options;
 
     for (const plugin of options.plugins || []) plugin(this);
-    wsUpgradePlugin(this);
 
     const fetchHandler = wrapFetch(this);
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,10 +1,7 @@
 import NodeHttp from "node:http";
 import NodeHttps from "node:https";
 import NodeHttp2 from "node:http2";
-import {
-  sendNodeResponse,
-  sendNodeUpgradeResponse,
-} from "../_node-compat/send.ts";
+import { sendNodeResponse } from "../_node-compat/send.ts";
 import { NodeRequest } from "../_node-compat/request.ts";
 import {
   fmtURL,
@@ -119,23 +116,6 @@ class NodeServer implements Server {
         this.serveOptions as NodeHttp.ServerOptions,
         handler,
       );
-    }
-
-    // Listen to upgrade events if there is a hook
-    const upgradeHandler = this.options.upgrade;
-    if (upgradeHandler) {
-      server.on("upgrade", (nodeReq, socket, header) => {
-        const request = new NodeRequest({
-          req: nodeReq,
-          upgrade: { socket, header },
-        });
-        const res = upgradeHandler(request);
-        return res instanceof Promise
-          ? res.then((resolvedRes) =>
-              sendNodeUpgradeResponse(socket, resolvedRes),
-            )
-          : sendNodeUpgradeResponse(socket, res);
-      });
     }
 
     this.node = { server, handler };

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,11 +49,6 @@ export interface ServerOptions {
   fetch: ServerHandler;
 
   /**
-   * Handle websocket upgrades.
-   */
-  upgrade?: ServerHandler;
-
-  /**
    * Handle lifecycle errors.
    *
    * @note This handler will set built-in Bun and Deno error handler.
@@ -252,10 +247,6 @@ export interface ServerRuntimeContext {
   node?: {
     req: NodeServerRequest;
     res?: NodeServerResponse;
-    upgrade?: {
-      socket: NodeStream.Duplex;
-      header: Buffer;
-    };
   };
 
   /**


### PR DESCRIPTION
This PR removes the experimental upgrade (#63) introduced in 0.6x

The reason is that true cross-platform websocket support (specially for runtimes like bun that has different top level API) needs [crossws](https://crossws.h3.dev/) the small stubs for upgrade header handling and node wrapper was causing duplicate logic.