### PR TITLE
refactor!: use `process.getBuiltinModule` for node

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,6 @@
   },
   "packageManager": "pnpm@10.9.0",
   "engines": {
-    "node": ">=20.11.1"
+    "node": ">=20.16.0"
   }
 }

--- a/src/_node-compat/send.ts
+++ b/src/_node-compat/send.ts
@@ -1,6 +1,6 @@
 import { splitSetCookieString } from "cookie-es";
 
-import type { Duplex, Readable as NodeReadable } from "node:stream";
+import type { Readable as NodeReadable } from "node:stream";
 import type NodeHttp from "node:http";
 import type { NodeServerResponse } from "../types.ts";
 import type { NodeResponse } from "./response.ts";

--- a/src/_utils.node.ts
+++ b/src/_utils.node.ts
@@ -1,7 +1,5 @@
 // *** This file should be only imported in the runtime adapters with Node.js compatibility. ***
 
-import { readFileSync } from "node:fs";
-
 import type { ServerOptions } from "./types.ts";
 
 export function resolvePortAndHost(opts: ServerOptions): {
@@ -97,5 +95,6 @@ function resolveCertOrKey(value?: unknown): undefined | string {
   if (value.startsWith("-----BEGIN ")) {
     return value;
   }
+  const { readFileSync } = process.getBuiltinModule("node:fs");
   return readFileSync(value, "utf8");
 }

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,6 +1,3 @@
-import NodeHttp from "node:http";
-import NodeHttps from "node:https";
-import NodeHttp2 from "node:http2";
 import { sendNodeResponse } from "../_node-compat/send.ts";
 import { NodeRequest } from "../_node-compat/request.ts";
 import {
@@ -12,6 +9,9 @@ import {
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
 
+import type NodeHttp from "node:http";
+import type NodeHttps from "node:https";
+import type NodeHttp2 from "node:http2";
 import type {
   FetchHandler,
   NodeHttpHandler,
@@ -99,7 +99,8 @@ class NodeServer implements Server {
 
     if (isHttp2) {
       if (this.#isSecure) {
-        server = NodeHttp2.createSecureServer(
+        const { createSecureServer } = process.getBuiltinModule("node:http2");
+        server = createSecureServer(
           { allowHTTP1: true, ...this.serveOptions },
           handler,
         );
@@ -107,12 +108,14 @@ class NodeServer implements Server {
         throw new Error("node.http2 option requires tls certificate!");
       }
     } else if (this.#isSecure) {
-      server = NodeHttps.createServer(
+      const { createServer } = process.getBuiltinModule("node:https");
+      server = createServer(
         this.serveOptions as NodeHttps.ServerOptions,
         handler,
       );
     } else {
-      server = NodeHttp.createServer(
+      const { createServer } = process.getBuiltinModule("node:http");
+      server = createServer(
         this.serveOptions as NodeHttp.ServerOptions,
         handler,
       );


### PR DESCRIPTION
Having top level `node:` imports, can make issues when module graph being resolved even if they are not needed.

Using new [`process.getBuiltinModule`](https://nodejs.org/api/process.html#processgetbuiltinmoduleid) available in recent versions of Deno, Bun, and Node.js v22.3.0+, v20.16.0+, we can lazily and synchronously import Node.js API when needed.