### PR TITLE
fix(node): only use `req.headers` in `FastResponse` when initialized

### DIFF
--- a/test/_fixture.ts
+++ b/test/_fixture.ts
@@ -64,6 +64,19 @@ export const fixture: (
             },
           );
         }
+        case "/headers/response/mutation": {
+          const headers: Record<string, string> = {
+            "x-test-header-1": "1",
+          };
+          const res = new _Response("", {
+            headers: headers,
+          });
+
+          res.headers.set("x-test-header-2", "2");
+          headers["x-ignored-mutation"] = "true";
+
+          return res;
+        }
         case "/body/binary": {
           return new _Response(req.body);
         }
@@ -120,6 +133,13 @@ export const fixture: (
               },
             }) as any,
           );
+        }
+        case "/clone-response": {
+          const res = new _Response("", {});
+          if (req.headers.get("x-clone-with-headers") === "true") {
+            res.headers.set("x-clone-with-headers", "true");
+          }
+          return res.clone();
         }
         case "/abort": {
           req.signal.addEventListener("abort", () => {

--- a/test/_tests.ts
+++ b/test/_tests.ts
@@ -1,3 +1,5 @@
+import { execa } from "execa";
+import * as http from "node:http";
 import { describe, expect, test } from "vitest";
 
 export function addTests(opts: {
@@ -38,6 +40,14 @@ export function addTests(opts: {
     expect(response.headers.get("content-type")).toMatch(/^application\/json/);
     expect(response.headers.get("x-req-foo")).toBe("bar");
     expect(response.headers.get("x-req-bar")).toBe("baz");
+  });
+
+  test("response headers mutated", async () => {
+    const response = await fetch(url("/headers/response/mutation"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("x-ignored")).toBeNull();
+    expect(response.headers.get("x-test-header-1")).toBe("1");
+    expect(response.headers.get("x-test-header-2")).toBe("2");
   });
 
   test("POST works (binary body)", async () => {
@@ -134,6 +144,23 @@ export function addTests(opts: {
       const res = await fetch(url("/response/Uint8Array"));
       expect(res.status).toBe(200);
       expect(await res.text()).toEqual("hello!");
+    });
+  });
+
+  describe("response cloning", () => {
+    test("clone simple response", async () => {
+      const response = await fetch(url("/clone-response"));
+      expect(response.status).toBe(200);
+    });
+
+    test("clone with headers", async () => {
+      const response = await fetch(url("/clone-response"), {
+        headers: {
+          "x-clone-with-headers": "true",
+        },
+      });
+      expect(response.status).toBe(200);
+      expect(response.headers.get("x-clone-with-headers")).toBe("true");
     });
   });
 }


### PR DESCRIPTION
Resolves #78

Also made sure to prioritize `#headersObj` when using `res.clone()` or on internal access of `#response`. We are already on slow paths there, but gets more slow with the extra clone of the headers.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
