### PR TITLE
build!: remove `/types` subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    "./types": "./dist/types.d.mts",
     "./deno": "./dist/adapters/deno.mjs",
     "./bun": "./dist/adapters/bun.mjs",
     "./node": "./dist/adapters/node.mjs",


### PR DESCRIPTION
All types are also exported from main subpath `srvx`, it can be confusing sicne they are also re-exported from `srvx/types` subpath (for older reasons)