### PR TITLE
types: allow augmenting `req.runtime.cloudflare.env`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,3 @@
-/// <reference types="./cf.d.ts" />
-import type * as NodeHttp from "node:http";
 import type * as NodeHttps from "node:https";
 import type * as NodeHttp2 from "node:http2";
 import type * as NodeNet from "node:net";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type * as NodeHttp from "node:http";
 import type * as NodeHttps from "node:https";
 import type * as NodeHttp2 from "node:http2";
 import type * as NodeNet from "node:net";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+/// <reference types="./cf.d.ts" />
 import type * as NodeHttp from "node:http";
 import type * as NodeHttps from "node:https";
 import type * as NodeHttp2 from "node:http2";
@@ -5,7 +6,9 @@ import type * as NodeNet from "node:net";
 import type * as Bun from "bun";
 import type * as CF from "@cloudflare/workers-types";
 
+// Utils
 type MaybePromise<T> = T | Promise<T>;
+type IsAny<T> = 0 extends 1 & T ? true : false;
 
 // ----------------------------------------------------------------------------
 // srvx API
@@ -266,8 +269,10 @@ export interface ServerRuntimeContext {
    * Underlying Cloudflare request context.
    */
   cloudflare?: {
-    env: unknown;
     context: CF.ExecutionContext;
+    env: IsAny<typeof import("cloudflare:workers")> extends true
+      ? typeof import("cloudflare:workers").env
+      : Record<string, unknown>;
   };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -270,8 +270,8 @@ export interface ServerRuntimeContext {
   cloudflare?: {
     context: CF.ExecutionContext;
     env: IsAny<typeof import("cloudflare:workers")> extends true
-      ? typeof import("cloudflare:workers").env
-      : Record<string, unknown>;
+      ? Record<string, unknown>
+      : typeof import("cloudflare:workers").env;
   };
 }
 

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,0 +1,15 @@
+import { describe, test, expectTypeOf } from "vitest";
+import type { ServerRequest } from "../src/types.ts";
+
+describe("types", () => {
+  describe("ServerRequest", () => {
+    const request = new Request("http://_") as ServerRequest;
+    describe("cloudflare", () => {
+      test("env", () => {
+        expectTypeOf(request.runtime?.cloudflare?.env).toEqualTypeOf<
+          undefined | { TEST: string }
+        >();
+      });
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "noEmit": true,
     "erasableSyntaxOnly": true
   },
-  "include": ["src", "test"]
+  "include": ["src", "test", "types.d.ts"]
 }

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,5 @@
+declare module "cloudflare:workers" {
+  export const env: {
+    TEST: string;
+  };
+}


### PR DESCRIPTION
resolves #82

Example: (`cloudflare.d.ts`)

```ts
declare module "cloudflare:workers" {
  export const env: {
    TEST: string;
  };
}
```

docs for new `cloudflare:workers.env`: https://developers.cloudflare.com/workers/runtime-apis/bindings/#how-to-access-env

(thanks to @danielroe for `IsAny` util ❤️ )