### PR TITLE
fix: add missing `Server.serve` type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -224,6 +224,12 @@ export interface Server<Handler = ServerHandler> {
   readonly fetch: Handler;
 
   /**
+   * Start listening for incoming requests.
+   * When `manual` option is enabled, this method needs to be called explicitly to begin accepting connections.
+   */
+  serve(): void | Promise<Server<Handler>>;
+
+  /**
    * Returns a promise that resolves when the server is ready.
    */
   ready(): Promise<Server<Handler>>;


### PR DESCRIPTION
Currently, when using the server with the `manual` option enabled, the server won’t start automatically - you need to call the `serve()` method explicitly.
Even though this method exists in all adapters, it was missing from the  types, which made it invisible and could cause type errors.

This change adds `serve()` to the server interface, so it’s now properly typed and discoverable when working in manual mode.