### PR TITLE
refactor(node): rewrite FastResponse

### DIFF
--- a/src/adapters/_node/_common.ts
+++ b/src/adapters/_node/_common.ts
@@ -1,3 +1,29 @@
 export const kNodeInspect: symbol = /* @__PURE__ */ Symbol.for(
   "nodejs.util.inspect.custom",
 );
+
+export function inheritProps(target: any, source: any, sourceKey: any): void {
+  for (const key of Object.getOwnPropertyNames(source)) {
+    if (key in target) {
+      continue;
+    }
+    const desc = Object.getOwnPropertyDescriptor(source, key)!;
+    if (desc.get) {
+      Object.defineProperty(target, key, {
+        ...desc,
+        get() {
+          return this[sourceKey][key];
+        },
+      });
+    } else if (typeof desc.value === "function") {
+      Object.defineProperty(target, key, {
+        ...desc,
+        value(...args: unknown[]) {
+          return this[sourceKey][key](...args);
+        },
+      });
+    } else {
+      Object.defineProperty(target, key, desc);
+    }
+  }
+}

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -6,6 +6,7 @@ import type {
 import { Readable } from "node:stream";
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
+import { inheritProps } from "./_common.ts";
 
 export type NodeRequestContext = {
   req: NodeServerRequest;
@@ -96,29 +97,7 @@ export const NodeRequest = /* @__PURE__ */ (() => {
     }
   }
 
-  for (const key of Object.getOwnPropertyNames(NativeRequest.prototype)) {
-    if (key in NodeRequest.prototype) {
-      continue;
-    }
-    const desc = Object.getOwnPropertyDescriptor(NativeRequest.prototype, key)!;
-    if (desc.get) {
-      Object.defineProperty(NodeRequest.prototype, key, {
-        ...desc,
-        get() {
-          return this._request[key];
-        },
-      });
-    } else if (typeof desc.value === "function") {
-      Object.defineProperty(NodeRequest.prototype, key, {
-        ...desc,
-        value(...args: unknown[]) {
-          return this._request[key](...args);
-        },
-      });
-    } else {
-      Object.defineProperty(NodeRequest.prototype, key, desc);
-    }
-  }
+  inheritProps(NodeRequest.prototype, NativeRequest.prototype, "_request");
 
   Object.setPrototypeOf(NodeRequest.prototype, Request.prototype);
 

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -1,9 +1,21 @@
-import { splitSetCookieString } from "cookie-es";
-
 import type NodeHttp from "node:http";
 import type { Readable as NodeReadable } from "node:stream";
 
+import { splitSetCookieString } from "cookie-es";
+
+import { inheritProps } from "./_common.ts";
+
 export type NodeResponse = InstanceType<typeof NodeResponse>;
+
+// prettier-ignore
+export type PreparedNodeResponseBody = string | Buffer | Uint8Array | DataView | ReadableStream | NodeReadable | undefined | null
+
+export interface PreparedNodeResponse {
+  status: number;
+  statusText: string;
+  headers: NodeHttp.OutgoingHttpHeader[];
+  body: PreparedNodeResponseBody;
+}
 
 /**
  * Fast Response for Node.js runtime
@@ -15,333 +27,164 @@ export const NodeResponse: {
     body?: BodyInit | null,
     init?: ResponseInit,
   ): globalThis.Response & {
-    readonly nodeResponse: () => {
-      status: number;
-      statusText: string;
-      headers: NodeHttp.OutgoingHttpHeader[];
-      body:
-        | string
-        | Buffer
-        | Uint8Array
-        | DataView
-        | ReadableStream
-        | NodeReadable
-        | undefined
-        | null;
-    };
+    readonly nodeResponse: () => PreparedNodeResponse;
   };
 } = /* @__PURE__ */ (() => {
-  const CONTENT_TYPE = "content-type";
-  const JSON_TYPE = "application/json";
-  const JSON_HEADER = [[CONTENT_TYPE, JSON_TYPE]] as HeadersInit;
+  const NativeResponse = globalThis.Response;
 
-  const _Response = class Response implements globalThis.Response {
+  const STATUS_CODES =
+    globalThis.process?.getBuiltinModule("node:http")?.STATUS_CODES || {};
+
+  class NodeResponse implements Partial<Response> {
     #body?: BodyInit | null;
     #init?: ResponseInit;
+    #headers?: Headers;
+    #response?: globalThis.Response;
 
     constructor(body?: BodyInit | null, init?: ResponseInit) {
+      if (init instanceof NodeResponse) {
+        init = { ...init.#init, headers: new Headers(init.headers) };
+      } else if (init instanceof NativeResponse) {
+        init = { ...init, headers: new Headers(init.headers) };
+      }
       this.#body = body;
       this.#init = init;
     }
 
-    static json(data: any, init?: ResponseInit): Response {
-      if (init?.headers) {
-        if (!(init.headers as Record<string, string>)[CONTENT_TYPE]) {
-          const initHeaders = new Headers(init.headers);
-          if (!initHeaders.has(CONTENT_TYPE)) {
-            initHeaders.set(CONTENT_TYPE, JSON_TYPE);
-          }
-          init = { ...init, headers: initHeaders };
-        }
-      } else {
-        init = init ? { ...init } : {};
-        init.headers = JSON_HEADER;
+    get status(): number {
+      return this.#response?.status || this.#init?.status || 200;
+    }
+
+    get statusText(): string {
+      return this.#response?.statusText || STATUS_CODES[this.status] || "";
+    }
+
+    get headers(): Headers {
+      return (
+        this.#response?.headers ||
+        (this.#headers ??= new Headers(this.#init?.headers))
+      );
+    }
+
+    get ok(): boolean {
+      if (this.#response) {
+        return this.#response.ok;
       }
-      return new _Response(JSON.stringify(data), init);
+      const status = this.status;
+      return status >= 200 && status < 300;
     }
 
-    static error(): globalThis.Response {
-      return globalThis.Response.error();
+    get _response(): globalThis.Response {
+      if (this.#response) {
+        return this.#response;
+      }
+      this.#response = new NativeResponse(
+        this.#body,
+        this.#headers ? { ...this.#init, headers: this.#headers } : this.#init,
+      );
+      this.#init = undefined;
+      this.#headers = undefined;
+      this.#body = undefined;
+      return this.#response;
     }
 
-    static redirect(url: string | URL, status?: number): globalThis.Response {
-      return globalThis.Response.redirect(url, status);
-    }
-
-    /**
-     * Prepare Node.js response object
-     */
     nodeResponse() {
-      const status = this.#init?.status ?? 200;
-      const statusText = this.#init?.statusText ?? "";
+      // Status
+      const status = this.status;
+      const statusText = this.statusText;
 
-      const headers: NodeHttp.OutgoingHttpHeader[] = [];
-
-      const headersInit = this.#init?.headers;
-      if (this.#headersObj) {
-        for (const [key, value] of this.#headersObj) {
-          if (key === "set-cookie") {
-            for (const setCookie of splitSetCookieString(value)) {
-              headers.push(["set-cookie", setCookie]);
-            }
-          } else {
-            headers.push([key, value]);
-          }
+      // Body
+      let body: PreparedNodeResponseBody;
+      let contentType: string | undefined | null;
+      let contentLength: string | undefined | null;
+      if (this.#response) {
+        body = this.#response.body;
+      } else if (this.#body) {
+        if (this.#body instanceof ReadableStream) {
+          body = this.#body;
+        } else if (typeof this.#body === "string") {
+          body = this.#body;
+          contentType = "text/plain; charset=UTF-8";
+          contentLength = String(Buffer.byteLength(this.#body));
+        } else if (this.#body instanceof ArrayBuffer) {
+          body = Buffer.from(this.#body);
+          contentLength = String(this.#body.byteLength);
+        } else if (this.#body instanceof Uint8Array) {
+          body = Buffer.from(this.#body);
+          contentLength = String(this.#body.byteLength);
+        } else if (this.#body instanceof DataView) {
+          body = Buffer.from(this.#body.buffer);
+          contentLength = String(this.#body.byteLength);
+        } else if (this.#body instanceof Blob) {
+          body = this.#body.stream();
+          contentType = this.#body.type;
+          contentLength = String(this.#body.size);
+        } else if (
+          typeof (this.#body as unknown as NodeReadable).pipe === "function"
+        ) {
+          body = this.#body as unknown as NodeReadable;
+        } else {
+          body = this._response.body;
         }
-      } else if (headersInit) {
-        const headerEntries = Array.isArray(headersInit)
-          ? headersInit
-          : headersInit.entries
-            ? (headersInit as Headers).entries()
-            : Object.entries(headersInit);
+      }
+
+      // Headers
+      const rawNodeHeaders: NodeHttp.OutgoingHttpHeader[] = [];
+      const initHeaders = this.#init?.headers;
+      const headerEntries =
+        this.#response?.headers ||
+        this.#headers ||
+        (initHeaders
+          ? Array.isArray(initHeaders)
+            ? initHeaders
+            : initHeaders?.entries
+              ? (initHeaders as Headers).entries()
+              : // prettier-ignore
+                Object.entries(initHeaders).map(([k, v]) => [k.toLowerCase(), v])
+          : undefined);
+      let hasContentTypeHeader: boolean | undefined;
+      let hasContentLength: boolean | undefined;
+      if (headerEntries) {
         for (const [key, value] of headerEntries) {
           if (key === "set-cookie") {
             for (const setCookie of splitSetCookieString(value)) {
-              headers.push(["set-cookie", setCookie]);
+              rawNodeHeaders.push(["set-cookie", setCookie]);
             }
-          } else {
-            headers.push([key, value]);
+            continue;
+          }
+          rawNodeHeaders.push([key, value]);
+          if (key === "content-type") {
+            hasContentTypeHeader = true;
+          } else if (key === "content-length") {
+            hasContentLength = true;
           }
         }
       }
-
-      const bodyInit = this.#body as BodyInit | null | undefined | NodeReadable;
-      // prettier-ignore
-      let body: string | Buffer | Uint8Array | DataView | ReadableStream<Uint8Array> | NodeReadable | undefined | null;
-      if (bodyInit) {
-        if (typeof bodyInit === "string") {
-          body = bodyInit;
-        } else if (bodyInit instanceof ReadableStream) {
-          body = bodyInit;
-        } else if (bodyInit instanceof ArrayBuffer) {
-          body = Buffer.from(bodyInit);
-        } else if (bodyInit instanceof Uint8Array) {
-          body = Buffer.from(bodyInit);
-        } else if (bodyInit instanceof DataView) {
-          body = Buffer.from(bodyInit.buffer);
-        } else if (bodyInit instanceof Blob) {
-          body = bodyInit.stream();
-          if (bodyInit.type) {
-            headers.push(["content-type", bodyInit.type]);
-          }
-        } else if (typeof (bodyInit as NodeReadable).pipe === "function") {
-          body = bodyInit as NodeReadable;
-        } else {
-          const res = new globalThis.Response(bodyInit as BodyInit);
-          body = res.body as ReadableStream<Uint8Array<ArrayBuffer>>;
-          for (const [key, value] of res.headers) {
-            headers.push([key, value]);
-          }
-        }
+      if (contentType && !hasContentTypeHeader) {
+        rawNodeHeaders.push(["content-type", contentType]);
+      }
+      if (contentLength && !hasContentLength) {
+        rawNodeHeaders.push(["content-length", contentLength]);
       }
 
       // Free up memory
-      this.#body = undefined;
       this.#init = undefined;
-      this.#headersObj = undefined;
-      this.#responseObj = undefined;
+      this.#headers = undefined;
+      this.#response = undefined;
 
       return {
         status,
         statusText,
-        headers,
+        headers: rawNodeHeaders,
         body,
       };
     }
+  }
 
-    // ... the rest is for interface compatibility only and usually not to be used ...
+  inheritProps(NodeResponse.prototype, NativeResponse.prototype, "_response");
 
-    /** Lazy initialized response instance */
-    #responseObj?: globalThis.Response;
+  Object.setPrototypeOf(NodeResponse, NativeResponse);
+  Object.setPrototypeOf(NodeResponse.prototype, NativeResponse.prototype);
 
-    /** Lazy initialized headers instance */
-    #headersObj?: Headers;
-
-    clone(): globalThis.Response {
-      if (this.#responseObj) {
-        return this.#responseObj.clone();
-      }
-      if (this.#headersObj) {
-        return new _Response(this.#body, {
-          ...this.#init,
-          headers: this.#headersObj,
-        });
-      }
-      return new _Response(this.#body, this.#init);
-    }
-
-    get #response(): globalThis.Response {
-      if (!this.#responseObj) {
-        this.#responseObj = this.#headersObj
-          ? new globalThis.Response(this.#body, {
-              ...this.#init,
-              headers: this.#headersObj,
-            })
-          : new globalThis.Response(this.#body, this.#init);
-        // Free up memory
-        this.#body = undefined;
-        this.#init = undefined;
-        this.#headersObj = undefined;
-      }
-      return this.#responseObj;
-    }
-
-    get headers(): Headers {
-      if (this.#responseObj) {
-        return this.#responseObj.headers; // Reuse instance
-      }
-      if (!this.#headersObj) {
-        this.#headersObj = new Headers(this.#init?.headers);
-      }
-      return this.#headersObj;
-    }
-
-    get ok(): boolean {
-      if (this.#responseObj) {
-        return this.#responseObj.ok;
-      }
-      const status = this.#init?.status ?? 200;
-      return status >= 200 && status < 300;
-    }
-
-    get redirected(): boolean {
-      if (this.#responseObj) {
-        return this.#responseObj.redirected;
-      }
-      return false;
-    }
-
-    get status(): number {
-      if (this.#responseObj) {
-        return this.#responseObj.status;
-      }
-      return this.#init?.status ?? 200;
-    }
-
-    get statusText(): string {
-      if (this.#responseObj) {
-        return this.#responseObj.statusText;
-      }
-      return this.#init?.statusText ?? "";
-    }
-
-    get type(): ResponseType {
-      if (this.#responseObj) {
-        return this.#responseObj.type;
-      }
-      return "default";
-    }
-
-    get url(): string {
-      if (this.#responseObj) {
-        return this.#responseObj.url;
-      }
-      return "";
-    }
-
-    // --- body ---
-
-    #fastBody<T extends object>(
-      as: new (...args: any[]) => T,
-    ): T | null | false {
-      const bodyInit = this.#body;
-      if (bodyInit === null || bodyInit === undefined) {
-        return null; // No body
-      }
-      if (bodyInit instanceof as) {
-        return bodyInit; // Fast path
-      }
-      return false; // Not supported
-    }
-
-    get body(): ReadableStream<Uint8Array<ArrayBuffer>> | null {
-      if (this.#responseObj) {
-        return this.#responseObj.body as ReadableStream<
-          Uint8Array<ArrayBuffer>
-        >; // Reuse instance
-      }
-      const fastBody = this.#fastBody(ReadableStream);
-      if (fastBody !== false) {
-        return fastBody as ReadableStream<Uint8Array<ArrayBuffer>>; // Fast path
-      }
-      return this.#response.body as ReadableStream<Uint8Array<ArrayBuffer>>; // Slow path
-    }
-
-    get bodyUsed(): boolean {
-      if (this.#responseObj) {
-        return this.#responseObj.bodyUsed;
-      }
-      return false;
-    }
-
-    arrayBuffer(): Promise<ArrayBuffer> {
-      if (this.#responseObj) {
-        return this.#responseObj.arrayBuffer(); // Reuse instance
-      }
-      const fastBody = this.#fastBody(ArrayBuffer);
-      if (fastBody !== false) {
-        return Promise.resolve(fastBody || new ArrayBuffer(0)); // Fast path
-      }
-      return this.#response.arrayBuffer(); // Slow path
-    }
-
-    blob(): Promise<Blob> {
-      if (this.#responseObj) {
-        return this.#responseObj.blob(); // Reuse instance
-      }
-      const fastBody = this.#fastBody(Blob);
-      if (fastBody !== false) {
-        return Promise.resolve(fastBody || new Blob()); // Fast path
-      }
-      return this.#response.blob(); // Slow path
-    }
-
-    bytes(): Promise<Uint8Array<ArrayBuffer>> {
-      if (this.#responseObj) {
-        return this.#responseObj.bytes() as Promise<Uint8Array<ArrayBuffer>>; // Reuse instance
-      }
-      const fastBody = this.#fastBody(Uint8Array);
-      if (fastBody !== false) {
-        return Promise.resolve(fastBody || new Uint8Array()); // Fast path
-      }
-      return this.#response.bytes() as Promise<Uint8Array<ArrayBuffer>>; // Slow path
-    }
-
-    formData(): Promise<FormData> {
-      if (this.#responseObj) {
-        return this.#responseObj.formData(); // Reuse instance
-      }
-      const fastBody = this.#fastBody(FormData);
-      if (fastBody !== false) {
-        // TODO: Content-Type should be one of "multipart/form-data" or "application/x-www-form-urlencoded"
-        return Promise.resolve(fastBody || new FormData()); // Fast path
-      }
-      return this.#response.formData(); // Slow path
-    }
-
-    text(): Promise<string> {
-      if (this.#responseObj) {
-        return this.#responseObj.text(); // Reuse instance
-      }
-      const bodyInit = this.#body;
-      if (bodyInit === null || bodyInit === undefined) {
-        return Promise.resolve(""); // No body
-      }
-      if (typeof bodyInit === "string") {
-        return Promise.resolve(bodyInit); // Fast path
-      }
-      return this.#response.text(); // Slow path
-    }
-
-    json(): Promise<any> {
-      if (this.#responseObj) {
-        return this.#responseObj.json(); // Reuse instance
-      }
-      return this.text().then((text) => JSON.parse(text));
-    }
-  };
-
-  Object.setPrototypeOf(_Response.prototype, globalThis.Response.prototype);
-
-  return _Response;
+  return NodeResponse as any;
 })();


### PR DESCRIPTION
This PR rewrites FastResponse wrapper:
- simpler and smaller
- Always set status text
- Always set default `content-type` and `content-length` headers
- Inherit full proto keys of current undici Response 

(this adds little perf overhead but probably worth it)