### PR TITLE
refactor: reimplement `FastURL`

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "bench:node": "node test/bench-node/_run.mjs",
     "bench:url:bun": "bun run ./test/url.bench.ts",
     "bench:url:deno": "deno run -A ./test/url.bench.ts",
-    "bench:url:node": "pnpm --expose-gc --allow-natives-syntax ./test/url.bench.ts",
+    "bench:url:node": "pnpm --expose-gc --allow-natives-syntax node ./test/url.bench.ts",
     "build": "obuild",
     "dev": "vitest dev",
     "lint": "eslint . && prettier -c .",

--- a/src/_inherit.ts
+++ b/src/_inherit.ts
@@ -1,0 +1,35 @@
+export function lazyInherit(target: any, source: any, sourceKey: any): void {
+  for (const key of Object.getOwnPropertyNames(source)) {
+    const targetDesc = Object.getOwnPropertyDescriptor(target, key)!;
+    const desc = Object.getOwnPropertyDescriptor(source, key)!;
+    let modified = false;
+    if (desc.get) {
+      modified = true;
+      desc.get =
+        targetDesc?.get ||
+        function () {
+          // @ts-expect-error
+          return this[sourceKey][key];
+        };
+    }
+    if (desc.set) {
+      modified = true;
+      desc.set =
+        targetDesc?.set ||
+        function (value) {
+          // @ts-expect-error
+          this[sourceKey][key] = value;
+        };
+    }
+    if (typeof desc.value === "function") {
+      modified = true;
+      desc.value = function (...args: unknown[]) {
+        // @ts-expect-error
+        return this[sourceKey][key](...args);
+      };
+    }
+    if (modified) {
+      Object.defineProperty(target, key, desc);
+    }
+  }
+}

--- a/src/_url.ts
+++ b/src/_url.ts
@@ -125,6 +125,14 @@ export const FastURL: { new (url: string | URLInit): URL } =
         }
         return this.#searchParams;
       }
+
+      toString(): string {
+        return this.href;
+      }
+
+      toJSON(): string {
+        return this.href;
+      }
     };
 
     lazyInherit(FastURL.prototype, NativeURL.prototype, "_url");

--- a/src/_url.ts
+++ b/src/_url.ts
@@ -1,127 +1,136 @@
+import { lazyInherit } from "./_inherit.ts";
+
+export type URLInit = {
+  protocol: string;
+  host: string;
+  pathname: string;
+  search: string;
+};
+
 /**
- * Wrapper for URL with fast path access to `.pathname` and `.search` props.
+ * Wrapper for URL with fast path access to `.pathname`, `.search` and `.searchParams` props.
  *
- * **NOTE:** It is assumed that the input URL is already ecoded and formatted from an HTTP request and contains no hash.
+ * **NOTES:**
  *
- * **NOTE:** Triggering the setters or getters on other props will deoptimize to full URL parsing.
+ * - It is assumed that the input URL is already ecoded and formatted from an HTTP request and contains no hash.
+ * - Triggering the setters or getters on other props will deoptimize to full URL parsing.
+ * - Changes to `searchParams` will be discarded as we don't track them.
  */
-export const FastURL: { new (url: string): URL } = /* @__PURE__ */ (() => {
-  const FastURL = class URL implements globalThis.URL {
-    #originalURL: string;
-    #parsedURL: globalThis.URL | undefined;
+export const FastURL: { new (url: string | URLInit): URL } =
+  /* @__PURE__ */ (() => {
+    const NativeURL = globalThis.URL;
 
-    _pathname?: string;
-    _urlqindex?: number;
-    _query?: URLSearchParams;
-    _search?: string;
+    const FastURL = class URL implements Partial<globalThis.URL> {
+      #parsedURL: globalThis.URL | undefined;
 
-    constructor(url: string) {
-      this.#originalURL = url;
-    }
+      #href?: string;
+      #protocol?: string;
+      #host?: string;
+      #pathname?: string;
+      #search?: string;
+      #searchParams?: URLSearchParams;
+      #pos?: { pathname: number; query: number };
 
-    get _url(): globalThis.URL {
-      if (!this.#parsedURL) {
-        this.#parsedURL = new globalThis.URL(this.#originalURL);
-      }
-      return this.#parsedURL;
-    }
-
-    toString(): string {
-      return this._url.toString();
-    }
-
-    toJSON(): string {
-      return this.toString();
-    }
-
-    get pathname() {
-      if (this.#parsedURL) {
-        return this.#parsedURL.pathname;
-      }
-      if (this._pathname === undefined) {
-        const url = this.#originalURL;
-        const protoIndex = url.indexOf("://");
-        if (protoIndex === -1) {
-          return this._url.pathname; // deoptimize
-        }
-        const pIndex = url.indexOf("/", protoIndex + 4 /* :// */);
-        if (pIndex === -1) {
-          return this._url.pathname; // deoptimize
-        }
-        const qIndex = (this._urlqindex = url.indexOf("?", pIndex));
-        this._pathname = url.slice(pIndex, qIndex === -1 ? undefined : qIndex);
-      }
-      return this._pathname!;
-    }
-
-    set pathname(value: string) {
-      this._pathname = undefined; // invalidate cache
-      this._url.pathname = value;
-    }
-
-    get searchParams() {
-      if (this.#parsedURL) {
-        return this.#parsedURL.searchParams;
-      }
-      if (!this._query) {
-        this._query = new URLSearchParams(this.search);
-      }
-      return this._query;
-    }
-
-    get search() {
-      if (this.#parsedURL) {
-        return this.#parsedURL.search;
-      }
-      if (this._search === undefined) {
-        const qIndex = this._urlqindex;
-        if (qIndex === -1 || qIndex === this.#originalURL.length - 1) {
-          this._search = "";
+      constructor(url: string | URLInit) {
+        if (typeof url === "string") {
+          this.#href = url;
         } else {
-          this._search =
-            qIndex === undefined
-              ? this._url.search // deoptimize (mostly unlikely unless pathname is not accessed)
-              : this.#originalURL.slice(qIndex);
+          this.#protocol = url.protocol;
+          this.#host = url.host;
+          this.#pathname = url.pathname;
+          this.#search = url.search;
         }
       }
-      return this._search;
-    }
 
-    set search(value: string) {
-      this._search = undefined; // invalidate cache
-      this._query = undefined; // invalidate cache
-      this._url.search = value;
-    }
+      get _url(): globalThis.URL {
+        if (this.#parsedURL) {
+          return this.#parsedURL;
+        }
+        this.#parsedURL = new NativeURL(this.href);
+        this.#href = undefined;
+        this.#protocol = undefined;
+        this.#host = undefined;
+        this.#pathname = undefined;
+        this.#search = undefined;
+        this.#searchParams = undefined;
+        this.#pos = undefined;
+        return this.#parsedURL;
+      }
 
-    declare hash: string;
-    declare host: string;
-    declare hostname: string;
-    declare href: string;
-    declare origin: string;
-    declare password: string;
-    declare port: string;
-    declare protocol: string;
-    declare username: string;
-  };
+      get href(): string {
+        if (this.#parsedURL) {
+          return this.#parsedURL.href;
+        }
+        if (!this.#href) {
+          this.#href = `${this.#protocol || "http:"}//${this.#host || "localhost"}${this.#pathname || "/"}${this.#search || ""}`;
+        }
+        return this.#href!;
+      }
 
-  // prettier-ignore
-  const slowProps = [
-    "hash", "host", "hostname", "href", "origin",
-    "password", "port", "protocol", "username"
-  ] as const;
+      #getPos(): { pathname: number; query: number } {
+        if (!this.#pos) {
+          const url = this.href;
+          const protoIndex = url.indexOf("://");
+          const pIndex =
+            protoIndex === -1
+              ? -1 /* deoptimize */
+              : url.indexOf("/", protoIndex + 4);
+          const qIndex = pIndex === -1 ? -1 : url.indexOf("?", pIndex);
+          this.#pos = { pathname: pIndex, query: qIndex };
+        }
+        return this.#pos;
+      }
 
-  for (const prop of slowProps) {
-    Object.defineProperty(FastURL.prototype, prop, {
-      get() {
-        return this._url[prop];
-      },
-      set(value) {
-        this._url[prop] = value;
-      },
-    });
-  }
+      get pathname() {
+        if (this.#parsedURL) {
+          return this.#parsedURL.pathname;
+        }
+        if (this.#pathname === undefined) {
+          const pos = this.#getPos();
+          if (pos.pathname === -1) {
+            return this._url.pathname; // deoptimize
+          }
+          this.#pathname = this.href.slice(
+            pos.pathname,
+            pos.query === -1 ? undefined : pos.query,
+          );
+        }
+        return this.#pathname;
+      }
 
-  Object.setPrototypeOf(FastURL, globalThis.URL);
+      get search() {
+        if (this.#parsedURL) {
+          return this.#parsedURL.search;
+        }
+        if (this.#search === undefined) {
+          const pos = this.#getPos();
+          if (pos.pathname === -1) {
+            return this._url.search; // deoptimize
+          }
+          const url = this.href;
+          this.#search =
+            pos.query === -1 || pos.query === url.length - 1
+              ? ""
+              : url.slice(pos.query);
+        }
+        return this.#search;
+      }
 
-  return FastURL as unknown as { new (url: string): URL };
-})();
+      get searchParams() {
+        if (this.#parsedURL) {
+          return this.#parsedURL.searchParams;
+        }
+        if (!this.#searchParams) {
+          this.#searchParams = new URLSearchParams(this.search);
+        }
+        return this.#searchParams;
+      }
+    };
+
+    lazyInherit(FastURL.prototype, NativeURL.prototype, "_url");
+
+    Object.setPrototypeOf(FastURL.prototype, NativeURL.prototype);
+    Object.setPrototypeOf(FastURL, NativeURL);
+
+    return FastURL as any;
+  })();

--- a/src/adapters/_node/_common.ts
+++ b/src/adapters/_node/_common.ts
@@ -1,29 +1,3 @@
 export const kNodeInspect: symbol = /* @__PURE__ */ Symbol.for(
   "nodejs.util.inspect.custom",
 );
-
-export function inheritProps(target: any, source: any, sourceKey: any): void {
-  for (const key of Object.getOwnPropertyNames(source)) {
-    if (key in target) {
-      continue;
-    }
-    const desc = Object.getOwnPropertyDescriptor(source, key)!;
-    if (desc.get) {
-      Object.defineProperty(target, key, {
-        ...desc,
-        get() {
-          return this[sourceKey][key];
-        },
-      });
-    } else if (typeof desc.value === "function") {
-      Object.defineProperty(target, key, {
-        ...desc,
-        value(...args: unknown[]) {
-          return this[sourceKey][key](...args);
-        },
-      });
-    } else {
-      Object.defineProperty(target, key, desc);
-    }
-  }
-}

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -5,7 +5,7 @@ import type {
 } from "../../types.ts";
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
-import { inheritProps } from "./_common.ts";
+import { lazyInherit } from "../../_inherit.ts";
 
 export type NodeRequestContext = {
   req: NodeServerRequest;
@@ -104,7 +104,7 @@ export const NodeRequest: {
     }
   }
 
-  inheritProps(NodeRequest.prototype, NativeRequest.prototype, "_request");
+  lazyInherit(NodeRequest.prototype, NativeRequest.prototype, "_request");
 
   Object.setPrototypeOf(NodeRequest.prototype, PatchedRequest.prototype);
 

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -2,8 +2,7 @@ import type NodeHttp from "node:http";
 import type { Readable as NodeReadable } from "node:stream";
 
 import { splitSetCookieString } from "cookie-es";
-
-import { inheritProps } from "./_common.ts";
+import { lazyInherit } from "../../_inherit.ts";
 
 // prettier-ignore
 export type PreparedNodeResponseBody = string | Buffer | Uint8Array | DataView | ReadableStream | NodeReadable | undefined | null
@@ -187,7 +186,7 @@ export const NodeResponse: {
     }
   }
 
-  inheritProps(NodeResponse.prototype, NativeResponse.prototype, "_response");
+  lazyInherit(NodeResponse.prototype, NativeResponse.prototype, "_response");
 
   Object.setPrototypeOf(NodeResponse, NativeResponse);
   Object.setPrototypeOf(NodeResponse.prototype, NativeResponse.prototype);

--- a/test/url.bench.ts
+++ b/test/url.bench.ts
@@ -1,11 +1,13 @@
 import { bench, compact, summary, group, run, do_not_optimize } from "mitata";
 import { FastURL } from "../src/_url.ts";
 
-const input = "https://user:password@example.com/path/to/resource?query=string";
+const input =
+  "https://user:password@example.com:8080/path/to/resource?query=string";
 
 const scenarios = {
   pathname: (url: URL) => do_not_optimize([url.pathname]),
   params: (url: URL) => do_not_optimize([url.searchParams.get("query")]),
+  protocol: (url: URL) => do_not_optimize([url.protocol]),
   "pathname+params": (url: URL) =>
     do_not_optimize([url.pathname, url.searchParams.get("query")]),
   "pathname+params+username": (url: URL) =>
@@ -16,16 +18,32 @@ const scenarios = {
     ]),
 };
 
+const benchnames = process.argv[2]?.split(",");
+
 for (const [name, fn] of Object.entries(scenarios)) {
   group(name, () => {
+    if (benchnames && !benchnames.includes(name)) {
+      return;
+    }
+
+    // Ensure both implementations return the same result
+    const evaledFn = new Function(
+      `return ${fn.toString().replace(/do_not_optimize/g, "")}[0]`,
+    )() as (url: URL) => any;
+    const nativeRes = evaledFn(new URL(input));
+    const fastRes = evaledFn(new FastURL(input));
+    if (JSON.stringify(nativeRes) !== JSON.stringify(fastRes)) {
+      throw new Error(
+        `FastURL result is different from URL: ${JSON.stringify(
+          nativeRes,
+        )} !== ${JSON.stringify(fastRes)}`,
+      );
+    }
+
     summary(() => {
       compact(() => {
-        bench("globalThis.URL", () => do_not_optimize(fn(new URL(input)))).gc(
-          "inner",
-        );
-        bench("FastURL", () => do_not_optimize(fn(new FastURL(input)))).gc(
-          "inner",
-        );
+        bench("globalThis.URL", () => do_not_optimize(fn(new URL(input))));
+        bench("FastURL", () => do_not_optimize(fn(new FastURL(input))));
       });
     });
   });


### PR DESCRIPTION
Similar to #109 and #110 this PR rewrites `FastURL` implementation to fully inherit `URL` prototype. 

Also few minor fast paths improved.

Also inherit util improved to partially inherit (so internally we don't need both getter setter)