### PR TITLE
fix: safer access to `process.getBuiltinModule`

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -15,7 +15,7 @@ export type NodeRequestContext = {
 export const NodeRequest: {
   new (nodeCtx: NodeRequestContext): ServerRequest;
 } = /* @__PURE__ */ (() => {
-  const { Readable } = process.getBuiltinModule("node:stream");
+  let Readable: typeof import("node:stream").Readable;
 
   const NativeRequest = ((globalThis as any)._Request ??=
     globalThis.Request) as typeof globalThis.Request;
@@ -90,6 +90,10 @@ export const NodeRequest: {
       if (!this.#request) {
         const method = this.method;
         const hasBody = !(method === "GET" || method === "HEAD");
+        if (hasBody && !Readable) {
+          Readable =
+            globalThis.process.getBuiltinModule("node:stream").Readable;
+        }
         this.#request = new PatchedRequest(this.url, {
           method,
           headers: this.headers,

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -30,7 +30,7 @@ export const NodeResponse: {
   const NativeResponse = globalThis.Response;
 
   const STATUS_CODES =
-    globalThis.process?.getBuiltinModule("node:http")?.STATUS_CODES || {};
+    globalThis.process?.getBuiltinModule?.("node:http")?.STATUS_CODES || {};
 
   class NodeResponse implements Partial<Response> {
     #body?: BodyInit | null;


### PR DESCRIPTION
In case that `srvx/node` is accessed outside of node.js compatible runtimes for any reasons, we should avoid global init code depending on Node.js APIs (process.getBuiltinModule)