### PR TITLE
 fix(node): sync `NodeRequestURL.pathname` changes back to `node req.url`

### DIFF
--- a/src/_url.ts
+++ b/src/_url.ts
@@ -21,7 +21,7 @@ export type URLInit = {
  * - Triggering the setters or getters on other props will deoptimize to full URL parsing.
  * - Changes to `searchParams` will be discarded as we don't track them.
  */
-export const FastURL: { new (url: string | URLInit): URL } =
+export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
   /* @__PURE__ */ (() => {
     const NativeURL = globalThis.URL;
 

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -2,7 +2,9 @@ import type { NodeServerRequest, NodeServerResponse } from "../../types.ts";
 import { FastURL } from "../../_url.ts";
 
 export class NodeRequestURL extends FastURL {
-  constructor({ req }: { req: NodeServerRequest; res?: NodeServerResponse }) {
+  #req: NodeServerRequest;
+
+  constructor({ req }: { req: NodeServerRequest }) {
     const path = req.url || "/";
     if (path[0] === "/") {
       const qIndex = path.indexOf("?");
@@ -30,5 +32,15 @@ export class NodeRequestURL extends FastURL {
     } else {
       super(path);
     }
+    this.#req = req;
+  }
+
+  override get pathname(): string {
+    return super.pathname;
+  }
+
+  override set pathname(value: string) {
+    this._url.pathname = value;
+    this.#req.url = this._url.pathname + this._url.search;
   }
 }


### PR DESCRIPTION
When (internal) `webReq._url.pathname` being updated (h3 uses this for `withBase` util), this PR makes sure node source gets updated.