### PR TITLE
refactor!: use esm imports for node entry

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -6,6 +6,7 @@ import type {
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
+import { Readable } from "node:stream";
 
 export type NodeRequestContext = {
   req: NodeServerRequest;
@@ -15,8 +16,6 @@ export type NodeRequestContext = {
 export const NodeRequest: {
   new (nodeCtx: NodeRequestContext): ServerRequest;
 } = /* @__PURE__ */ (() => {
-  let Readable: typeof import("node:stream").Readable;
-
   const NativeRequest = ((globalThis as any)._Request ??=
     globalThis.Request) as typeof globalThis.Request;
 
@@ -99,10 +98,6 @@ export const NodeRequest: {
       if (!this.#request) {
         const method = this.method;
         const hasBody = !(method === "GET" || method === "HEAD");
-        if (hasBody && !Readable) {
-          Readable =
-            globalThis.process.getBuiltinModule("node:stream").Readable;
-        }
         this.#request = new PatchedRequest(this.url, {
           method,
           headers: this.headers,

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -10,6 +10,10 @@ import {
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
 
+import nodeHTTP from "node:http";
+import nodeHTTPS from "node:https";
+import nodeHTTP2 from "node:http2";
+
 import type NodeHttp from "node:http";
 import type NodeHttps from "node:https";
 import type NodeHttp2 from "node:http2";
@@ -106,8 +110,7 @@ class NodeServer implements Server {
 
     if (isHttp2) {
       if (this.#isSecure) {
-        const { createSecureServer } = process.getBuiltinModule("node:http2");
-        server = createSecureServer(
+        server = nodeHTTP2.createSecureServer(
           { allowHTTP1: true, ...this.serveOptions },
           handler,
         );
@@ -115,14 +118,12 @@ class NodeServer implements Server {
         throw new Error("node.http2 option requires tls certificate!");
       }
     } else if (this.#isSecure) {
-      const { createServer } = process.getBuiltinModule("node:https");
-      server = createServer(
+      server = nodeHTTPS.createServer(
         this.serveOptions as NodeHttps.ServerOptions,
         handler,
       );
     } else {
-      const { createServer } = process.getBuiltinModule("node:http");
-      server = createServer(
+      server = nodeHTTP.createServer(
         this.serveOptions as NodeHttp.ServerOptions,
         handler,
       );


### PR DESCRIPTION
srvx were using optional `globalThis.process.getBuiltInModule` to access node built-ins since some cases (h3) would directly import `srvx/node` in universal code outside of node. It is not a case since https://github.com/h3js/h3/pull/1215 therefore we can simplify it. 