### PR TITLE
fix(node, deno): use flatten headers only for node

### DIFF
--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -9,7 +9,7 @@ export type PreparedNodeResponseBody = string | Buffer | Uint8Array | DataView |
 export interface PreparedNodeResponse {
   status: number;
   statusText: string;
-  headers: NodeHttp.OutgoingHttpHeader[];
+  headers: [string, string][];
   body: PreparedNodeResponseBody;
 }
 
@@ -132,7 +132,7 @@ export const NodeResponse: {
       }
 
       // Headers
-      const rawNodeHeaders: NodeHttp.OutgoingHttpHeader[] = [];
+      const headers: [string, string][] = [];
       const initHeaders = this.#init?.headers;
       const headerEntries =
         this.#response?.headers ||
@@ -151,10 +151,10 @@ export const NodeResponse: {
         for (const [key, value] of headerEntries) {
           if (Array.isArray(value)) {
             for (const v of value) {
-              rawNodeHeaders.push([key, v]);
+              headers.push([key, v]);
             }
           } else {
-            rawNodeHeaders.push([key, value]);
+            headers.push([key, value]);
           }
           if (key === "content-type") {
             hasContentTypeHeader = true;
@@ -164,10 +164,10 @@ export const NodeResponse: {
         }
       }
       if (contentType && !hasContentTypeHeader) {
-        rawNodeHeaders.push(["content-type", contentType]);
+        headers.push(["content-type", contentType]);
       }
       if (contentLength && !hasContentLength) {
-        rawNodeHeaders.push(["content-length", String(contentLength)]);
+        headers.push(["content-length", String(contentLength)]);
       }
 
       // Free up memory
@@ -179,7 +179,7 @@ export const NodeResponse: {
       return {
         status,
         statusText,
-        headers: rawNodeHeaders,
+        headers,
         body,
       };
     }

--- a/test/_tests.ts
+++ b/test/_tests.ts
@@ -60,16 +60,11 @@ export function addTests(opts: {
       unsetHeader: null,
     });
 
-    // TODO
-    if (opts.runtime !== "deno-node-compat") {
-      expect(response.headers.has("content-type")).toBe(true);
-      expect(response.headers.get("content-type")).toMatch(
-        /^application\/json/,
-      );
+    expect(response.headers.has("content-type")).toBe(true);
+    expect(response.headers.get("content-type")).toMatch(/^application\/json/);
 
-      expect(response.headers.get("x-req-foo")).toBe("bar");
-      expect(response.headers.get("x-req-bar")).toBe("baz");
-    }
+    expect(response.headers.get("x-req-foo")).toBe("bar");
+    expect(response.headers.get("x-req-bar")).toBe("baz");
   });
 
   test("response headers mutated", async () => {
@@ -77,11 +72,8 @@ export function addTests(opts: {
     expect(response.status).toBe(200);
     expect(response.headers.get("x-ignored")).toBeNull();
 
-    // TODO
-    if (opts.runtime !== "deno-node-compat") {
-      expect(response.headers.get("x-test-header-1")).toBe("1");
-      expect(response.headers.get("x-test-header-2")).toBe("2");
-    }
+    expect(response.headers.get("x-test-header-1")).toBe("1");
+    expect(response.headers.get("x-test-header-2")).toBe("2");
   });
 
   test("POST works (binary body)", async () => {
@@ -147,7 +139,7 @@ export function addTests(opts: {
     const aborts = await res.json();
     // console.log(aborts.map((a: any) => `${a.request}`).join("\n"));
 
-    // TODO
+    // Deno Node.js compat behaves differently!!!
     if (opts.runtime !== "deno-node-compat") {
       expect(aborts.length).toBe(expectedAbortCount);
     }
@@ -169,10 +161,7 @@ export function addTests(opts: {
       expect(response.status).toBe(200);
       expect(await response.text()).toBe("ok");
 
-      // TODO
-      if (opts.runtime !== "deno-node-compat") {
-        expect(response.headers.get("x-plugin-header")).toBe("1");
-      }
+      expect(response.headers.get("x-plugin-header")).toBe("1");
     });
   });
 
@@ -216,10 +205,7 @@ export function addTests(opts: {
       });
       expect(response.status).toBe(200);
 
-      // TODO
-      if (opts.runtime !== "deno-node-compat") {
-        expect(response.headers.get("x-clone-with-headers")).toBe("true");
-      }
+      expect(response.headers.get("x-clone-with-headers")).toBe("true");
     });
   });
 


### PR DESCRIPTION
followup on #40 (fixes deno issues with node compat layer discovered in 128) 

(more info in code comments)