### PR TITLE
feat: better `toNodeHandler` / `toFetchHandler` utils

### DIFF
--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -1,0 +1,80 @@
+import type {
+  FetchHandler,
+  NodeHttpHandler,
+  NodeServerRequest,
+  NodeServerResponse,
+  ServerRequest,
+} from "../../types.ts";
+import { fetchNodeHandler } from "../node.ts";
+import { NodeRequest } from "./request.ts";
+import { sendNodeResponse } from "./send.ts";
+
+type AdapterMeta = {
+  __nodeHandler?: NodeHttpHandler;
+  __fetchHandler?: FetchHandler;
+};
+
+/**
+ * Converts a Fetch API handler to a Node.js HTTP handler.
+ */
+export function toNodeHandler(
+  handler: FetchHandler & AdapterMeta,
+): NodeHttpHandler & AdapterMeta {
+  if (handler.__nodeHandler) {
+    return handler.__nodeHandler;
+  }
+
+  function convertedNodeHandler(
+    nodeReq: NodeServerRequest,
+    nodeRes: NodeServerResponse,
+  ) {
+    const request = new NodeRequest({ req: nodeReq, res: nodeRes });
+    const res = handler(request);
+    return res instanceof Promise
+      ? res.then((resolvedRes) => sendNodeResponse(nodeRes, resolvedRes))
+      : sendNodeResponse(nodeRes, res);
+  }
+
+  (convertedNodeHandler as AdapterMeta).__fetchHandler = handler;
+  assignFnName(convertedNodeHandler, handler, " (converted to Node handler)");
+
+  return convertedNodeHandler;
+}
+
+/**
+ * Converts a Node.js HTTP handler into a Fetch API handler.
+ *
+ * @experimental Behavior might be unstable.
+ */
+export function toFetchHandler(
+  handler: NodeHttpHandler & AdapterMeta,
+): FetchHandler & AdapterMeta {
+  if (handler.__fetchHandler) {
+    return handler.__fetchHandler;
+  }
+
+  function convertedNodeHandler(req: ServerRequest): Promise<Response> {
+    return fetchNodeHandler(handler as NodeHttpHandler, req);
+  }
+
+  (convertedNodeHandler as AdapterMeta).__nodeHandler =
+    handler as NodeHttpHandler;
+  assignFnName(convertedNodeHandler, handler, " (converted to Web handler)");
+
+  return convertedNodeHandler;
+}
+
+// --- utils ---
+
+type Fn = (...args: any[]) => any;
+function assignFnName(target: Fn, source: Fn, suffix: string) {
+  if (source.name) {
+    try {
+      Object.defineProperty(target, "name", {
+        value: `${source.name}${suffix}`,
+      });
+    } catch {
+      /* safe to ignore */
+    }
+  }
+}

--- a/src/adapters/_node/web/fetch.ts
+++ b/src/adapters/_node/web/fetch.ts
@@ -1,8 +1,4 @@
-import type {
-  ServerRequest,
-  NodeHttpHandler,
-  FetchHandler,
-} from "../../../types.ts";
+import type { ServerRequest, NodeHttpHandler } from "../../../types.ts";
 
 import { WebIncomingMessage } from "./incoming.ts";
 import { WebRequestSocket } from "./socket.ts";
@@ -50,19 +46,4 @@ export async function fetchNodeHandler(
       statusText: "Internal Server Error",
     });
   }
-}
-
-/**
- * Converts a Node.js HTTP handler into a Fetch API handler.
- *
- * @experimental Behavior might be unstable.
- */
-export function toWebHandler(
-  handler: NodeHttpHandler | FetchHandler,
-): FetchHandler {
-  if (handler.length === 1) {
-    return handler as FetchHandler;
-  }
-  return (req: ServerRequest) =>
-    fetchNodeHandler(handler as NodeHttpHandler, req);
 }

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -18,8 +18,6 @@ import type NodeHttp from "node:http";
 import type NodeHttps from "node:https";
 import type NodeHttp2 from "node:http2";
 import type {
-  FetchHandler,
-  NodeHttpHandler,
   NodeServerRequest,
   NodeServerResponse,
   Server,
@@ -28,30 +26,16 @@ import type {
 } from "../types.ts";
 
 export { FastURL } from "../_url.ts";
-
 export { NodeRequest } from "./_node/request.ts";
 export { NodeRequestHeaders, NodeResponseHeaders } from "./_node/headers.ts";
-export {
-  NodeResponse,
-  NodeResponse as FastResponse,
-} from "./_node/response.ts";
-
+export { NodeResponse } from "./_node/response.ts";
+export { NodeResponse as FastResponse } from "./_node/response.ts";
 export { sendNodeResponse } from "./_node/send.ts";
-
-export { fetchNodeHandler, toWebHandler } from "./_node/web/fetch.ts";
+export { fetchNodeHandler } from "./_node/web/fetch.ts";
+export { toNodeHandler, toFetchHandler } from "./_node/adapter.ts";
 
 export function serve(options: ServerOptions): Server {
   return new NodeServer(options);
-}
-
-export function toNodeHandler(fetchHandler: FetchHandler): NodeHttpHandler {
-  return (nodeReq, nodeRes) => {
-    const request = new NodeRequest({ req: nodeReq, res: nodeRes });
-    const res = fetchHandler(request);
-    return res instanceof Promise
-      ? res.then((resolvedRes) => sendNodeResponse(nodeRes, resolvedRes))
-      : sendNodeResponse(nodeRes, res);
-  };
 }
 
 // https://nodejs.org/api/http.html


### PR DESCRIPTION
Followup on #125

This PR makes two consistent `toNodeHandler` and `toFetchHandler` utils with new features:

- Original handlers are attached
- When used recusively, original handler will be used instead of double wrapping
- Original name will be preserved in wrapper fn name
- 