### PR TITLE
perf(node): fast req body methods

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -48,14 +48,14 @@ export const NodeRequest: {
   }
 
   class Request implements Partial<ServerRequest> {
-    #req: NodeServerRequest;
     runtime: ServerRequest["runtime"];
 
+    #req: NodeServerRequest;
+    #url?: URL;
+    #bodyStream?: ReadableStream | null;
     #request?: globalThis.Request;
     #headers?: NodeRequestHeaders;
-    #abortSignal?: AbortController;
-
-    #url?: URL;
+    #abortController?: AbortController;
 
     constructor(ctx: NodeRequestContext) {
       this.#req = ctx.req;
@@ -74,48 +74,96 @@ export const NodeRequest: {
     }
 
     get method(): string {
+      if (this.#request) {
+        return this.#request.method;
+      }
       return this.#req.method || "GET";
     }
 
     get _url() {
-      return (this.#url ||= new NodeRequestURL({
-        req: this.runtime!.node!.req,
-      }));
+      return (this.#url ||= new NodeRequestURL({ req: this.#req }));
+    }
+
+    set _url(url: URL) {
+      this.#url = url;
     }
 
     get url(): string {
+      if (this.#request) {
+        return this.#request.url;
+      }
       return this._url.href;
     }
 
     get headers(): Headers {
+      if (this.#request) {
+        return this.#request.headers;
+      }
       return (this.#headers ||= new NodeRequestHeaders(this.#req));
     }
 
-    get signal() {
-      if (!this.#abortSignal) {
-        this.#abortSignal = new AbortController();
+    get _abortController() {
+      if (!this.#abortController) {
+        this.#abortController = new AbortController();
         const req = this.#req;
         const abort = (err?: any) => {
-          this.#abortSignal?.abort(err);
+          this.#abortController?.abort?.(err);
         };
         req.once("error", abort);
         req.once("end", abort);
       }
-      return this.#abortSignal.signal;
+      return this.#abortController;
+    }
+
+    get signal() {
+      return this.#request
+        ? this.#request.signal
+        : this._abortController.signal;
+    }
+
+    get body(): ReadableStream | null {
+      if (this.#request) {
+        return this.#request.body;
+      }
+      if (this.#bodyStream === undefined) {
+        const method = this.method;
+        const hasBody = !(method === "GET" || method === "HEAD");
+        this.#bodyStream = hasBody
+          ? (Readable.toWeb(this.#req) as unknown as ReadableStream)
+          : null;
+      }
+      return this.#bodyStream;
+    }
+
+    text() {
+      if (this.#request) {
+        return this.#request.text();
+      }
+      if (this.#bodyStream !== undefined) {
+        return this.#bodyStream
+          ? new Response(this.#bodyStream).text()
+          : Promise.resolve("");
+      }
+      return readBody(this.#req).then((buf) => buf.toString());
+    }
+
+    json() {
+      if (this.#request) {
+        return this.#request.json();
+      }
+      return this.text().then((text) => JSON.parse(text));
     }
 
     get _request(): globalThis.Request {
       if (!this.#request) {
-        const method = this.method;
-        const hasBody = !(method === "GET" || method === "HEAD");
         this.#request = new PatchedRequest(this.url, {
-          method,
+          method: this.method,
           headers: this.headers,
-          signal: this.signal,
-          body: hasBody
-            ? (Readable.toWeb(this.#req) as unknown as ReadableStream)
-            : undefined,
+          body: this.body,
+          signal: this._abortController.signal,
         });
+        this.#headers = undefined;
+        this.#bodyStream = undefined;
       }
 
       return this.#request;
@@ -128,3 +176,21 @@ export const NodeRequest: {
 
   return Request as any;
 })();
+
+function readBody(req: NodeServerRequest): Promise<any> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    const onData = (chunk: any) => {
+      chunks.push(chunk);
+    };
+    const onError = (err: any) => {
+      reject(err);
+    };
+    const onEnd = () => {
+      req.off("error", onError);
+      req.off("data", onData);
+      resolve(Buffer.concat(chunks));
+    };
+    req.on("data", onData).once("end", onEnd).once("error", onError);
+  });
+}

--- a/test/_fixture.ts
+++ b/test/_fixture.ts
@@ -53,7 +53,7 @@ export const fixture: (
       req.signal.addEventListener("abort", () => {
         aborts.push({
           request: `${req.method} ${url.pathname}`,
-          reason: req.signal.reason.toString(),
+          reason: req.signal.reason?.toString(),
         });
       });
 

--- a/test/bench-node/_handler.mjs
+++ b/test/bench-node/_handler.mjs
@@ -1,10 +1,34 @@
-export function fetchHandler(req) {
-  return new Response("Hello!", {
-    headers: { "x-test": req.headers.get("x-test") },
+import { json } from "node:stream/consumers";
+
+export async function fetchHandler(req) {
+  const body = await req.json();
+  return new Response(JSON.stringify(body), {
+    headers: {
+      "x-test": req.headers.get("x-test"),
+      "Content-Type": "application/json;charset=UTF-8",
+    },
   });
 }
 
-export function nodeHandler(_req, res) {
-  res.setHeader("x-test", _req.headers["x-test"] || "");
-  res.end("Hello!");
+export async function nodeHandler(req, res) {
+  const body = await readBody(req);
+  res.setHeader("x-test", req.headers["x-test"] || "");
+  res.setHeader("Content-Type", "application/json;charset=UTF-8");
+  res.end(JSON.stringify(body));
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    req
+      .on("data", (chunk) => {
+        chunks.push(chunk);
+      })
+      .on("end", () => {
+        resolve(JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}"));
+      })
+      .on("error", (err) => {
+        reject(err);
+      });
+  });
 }

--- a/test/bench-node/_run.mjs
+++ b/test/bench-node/_run.mjs
@@ -45,20 +45,26 @@ for (const name of names) {
   await new Promise((resolve) => setTimeout(resolve, 200));
 
   const res = await fetch("http://localhost:3000", {
-    method: "GET",
-    headers: { "x-test": "123" },
+    method: "POST",
+    body: JSON.stringify({ message: "Hello!" }),
+    headers: { "x-test": "123", "Content-Type": "application/json" },
   });
 
   assert.equal(res.status, 200, `${name} - invalid status code`);
-  assert.equal(await res.text(), "Hello!");
+  assert.equal((await res.json()).message, "Hello!");
+  assert.equal(
+    res.headers.get("content-type"),
+    "application/json;charset=UTF-8",
+  );
   assert.equal(
     res.headers.get("x-test"),
     "123",
     `${name} - missing custom header`,
   );
 
+  // https://github.com/hatoo/oha
   const stdout = execSync(
-    'oha http://localhost:3000 --no-tui --output-format json -z 3sec -H "x-test: 123"',
+    `oha http://localhost:3000 --no-tui --output-format json -z 3sec -H "x-test: 123" -m POST -T "application/json" -d '{"message":"Hello!"}'`,
     {
       encoding: "utf8",
     },


### PR DESCRIPTION
This PR adds back fast paths for `NodeRequest.json()` and `NodeRequest.text()`.