### PR TITLE
fix: handle no env vars for colors

### DIFF
--- a/src/_color.ts
+++ b/src/_color.ts
@@ -1,6 +1,6 @@
 // Colors support for terminal output
 const noColor = /* @__PURE__ */ (() => {
-  const env = globalThis.process?.env;
+  const env = globalThis.process?.env ?? {};
   return env.NO_COLOR === "1" || env.TERM === "dumb";
 })();
 


### PR DESCRIPTION
Resolves #145 

I'm unsure what is the intent/defaults here, so I went for the easiest `?? {}` 