### PR TITLE
chore: swtich to tsgo

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "test": "pnpm lint && pnpm test:types && vitest run --coverage",
     "test:node-compat:deno": "deno run vitest test/node.test",
     "test:node-compat:bun": "bun test test/node.test.ts",
-    "test:types": "tsc --noEmit --skipLibCheck",
+    "test:types": "tsgo --noEmit --skipLibCheck",
     "vitest": "vitest"
   },
   "resolutions": {
@@ -69,6 +69,7 @@
     "@types/node": "^25.0.3",
     "@types/node-forge": "^1.3.14",
     "@types/serviceworker": "^0.0.172",
+    "@typescript/native-preview": "^7.0.0-dev.20260114",
     "@vitest/coverage-v8": "^4.0.16",
     "@whatwg-node/server": "^0.10.17",
     "automd": "^0.4.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 4.20251230.0
       '@hono/node-server':
         specifier: ^1.19.7
-        version: 1.19.7(hono@4.11.3)
+        version: 1.19.7(hono@4.11.4)
       '@mitata/counters':
         specifier: ^0.0.8
         version: 0.0.8
@@ -41,6 +41,9 @@ importers:
       '@types/serviceworker':
         specifier: ^0.0.172
         version: 0.0.172
+      '@typescript/native-preview':
+        specifier: ^7.0.0-dev.20260114
+        version: 7.0.0-dev.20260114.1
       '@vitest/coverage-v8':
         specifier: ^4.0.16
         version: 4.0.16(vitest@4.0.16(@types/node@25.0.3)(jiti@2.6.1))
@@ -82,7 +85,7 @@ importers:
         version: 1.3.3
       obuild:
         specifier: ^0.4.9
-        version: 0.4.9(magicast@0.5.1)(typescript@5.9.3)
+        version: 0.4.9(@typescript/native-preview@7.0.0-dev.20260114.1)(magicast@0.5.1)(typescript@5.9.3)
       prettier:
         specifier: ^3.7.4
         version: 3.7.4
@@ -148,7 +151,7 @@ importers:
     devDependencies:
       hono:
         specifier: latest
-        version: 4.11.3
+        version: 4.11.4
       srvx:
         specifier: link:../..
         version: link:../..
@@ -1208,6 +1211,45 @@ packages:
     resolution: {integrity: sha512-mM/JRQOzhVN1ykejrvwnBRV3+7yTKK8tVANVN3o1O0t0v7o+jqdVu9crPy5Y9dov15TJk/FTIgoUGHrTOVL3Zg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-M4t1jMeKB0MKVDHHDHbhKi6RP2VbhE9iA2ih362SLx3dfas9nU3QLVnQClRMX8hfZtFucppSY3M2FCa3amKNgQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-JnJV6AHhO37+o+RuK8opQ5sll0swoTLepDhlDvLU/pkuo5BbZl4AyAHDGZR1hxhCmrgPTGsmr4LSQ2TxpgknSw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-eZwbwGWDclPDJAMXzpexuZBc2ZSq86T2UPDyLehKDCfrdrZcBunfYkBLX7vHnIjzbCopanMXGWVUn4eE0uK7tw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-bdY1aBmiawgH7vOXXrjEINhTDtss5DrlmuKmcm40lSLGOnhkZGlHSHktZej2K+b/lWKUc/a62iD/5627yXo/5g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-4uFSvsNSko9augp/bw9PEXtdV1gg8aesrnUfIm6xYab+CmE3+PMbNncp53lZEow8Tp+lcGYNOPPFF0SQHwkcRg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-oEQFvvgzfWoMpzkFIjgNuUrZuzbPxLKt2IAnc2M91nrFhOPRa2Cf74M8+mFUXVA5wLyg8M5YW1Q2JKL0olxqcg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-kYymlGjzvujMrq8/mjg0akfq4rMMXWeqDp/hKNXKPK463CFzvla1KmF9jEEGDEasMb38rA6c7tHdzwX9yHS+ew==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260114.1':
+    resolution: {integrity: sha512-s7G8VkqtBB8I/VX/EUfknefv+R4zIjjKpDZbyjkAozydwYvPXQlkvEz7Gs819Z28p+agcs5+tTNECJFqjK8DPg==}
+    hasBin: true
+
   '@vitest/coverage-v8@4.0.16':
     resolution: {integrity: sha512-2rNdjEIsPRzsdu6/9Eq0AYAzYdpP6Bx9cje9tL3FE5XzXRQF1fNU9pe/1yE8fCrS0HD+fBtt6gLPh6LI57tX7A==}
     peerDependencies:
@@ -1901,8 +1943,8 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
-  hono@4.11.3:
-    resolution: {integrity: sha512-PmQi306+M/ct/m5s66Hrg+adPnkD5jiO6IjA7WhWw0gSBSo1EcRegwuI1deZ+wd5pzCGynCcn2DprnE4/yEV4w==}
+  hono@4.11.4:
+    resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
     engines: {node: '>=16.9.0'}
 
   html-escaper@2.0.2:
@@ -3030,9 +3072,9 @@ snapshots:
       '@fastify/forwarded': 3.0.1
       ipaddr.js: 2.2.0
 
-  '@hono/node-server@1.19.7(hono@4.11.3)':
+  '@hono/node-server@1.19.7(hono@4.11.4)':
     dependencies:
-      hono: 4.11.3
+      hono: 4.11.4
 
   '@humanfs/core@0.19.1': {}
 
@@ -3579,6 +3621,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.51.0
       eslint-visitor-keys: 4.2.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260114.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260114.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260114.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260114.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260114.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260114.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260114.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260114.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260114.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260114.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260114.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260114.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260114.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260114.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260114.1
 
   '@vitest/coverage-v8@4.0.16(vitest@4.0.16(@types/node@25.0.3)(jiti@2.6.1))':
     dependencies:
@@ -4461,7 +4534,7 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
-  hono@4.11.3: {}
+  hono@4.11.4: {}
 
   html-escaper@2.0.2: {}
 
@@ -4748,7 +4821,7 @@ snapshots:
 
   obug@2.1.1: {}
 
-  obuild@0.4.9(magicast@0.5.1)(typescript@5.9.3):
+  obuild@0.4.9(@typescript/native-preview@7.0.0-dev.20260114.1)(magicast@0.5.1)(typescript@5.9.3):
     dependencies:
       c12: 3.3.3(magicast@0.5.1)
       consola: 3.4.2
@@ -4761,7 +4834,7 @@ snapshots:
       pathe: 2.0.3
       pretty-bytes: 7.1.0
       rolldown: 1.0.0-beta.55
-      rolldown-plugin-dts: 0.19.2(rolldown@1.0.0-beta.55)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.19.2(@typescript/native-preview@7.0.0-dev.20260114.1)(rolldown@1.0.0-beta.55)(typescript@5.9.3)
       tinyglobby: 0.2.15
     transitivePeerDependencies:
       - '@ts-macro/tsc'
@@ -5025,7 +5098,7 @@ snapshots:
 
   rfdc@1.4.1: {}
 
-  rolldown-plugin-dts@0.19.2(rolldown@1.0.0-beta.55)(typescript@5.9.3):
+  rolldown-plugin-dts@0.19.2(@typescript/native-preview@7.0.0-dev.20260114.1)(rolldown@1.0.0-beta.55)(typescript@5.9.3):
     dependencies:
       '@babel/generator': 7.28.5
       '@babel/parser': 7.28.5
@@ -5037,6 +5110,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-beta.55
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260114.1
       typescript: 5.9.3
     transitivePeerDependencies:
       - oxc-resolver


### PR DESCRIPTION
Type checking is now almost 2x faster thanks to moving to native `tsgo`

```log
Benchmark 1: pnpm test:types
  Time (mean ± σ):      1.116 s ±  0.010 s    [User: 1.435 s, System: 0.159 s]
  Range (min … max):    1.101 s …  1.136 s    10 runs

Benchmark 2: pnpm test:tscheck
  Time (mean ± σ):     605.7 ms ±   8.3 ms    [User: 651.5 ms, System: 170.6 ms]
  Range (min … max):   593.9 ms … 619.8 ms    10 runs

Summary
  pnpm test:tscheck ran
    1.84 ± 0.03 times faster than pnpm test:types
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type checking tooling for development workflows.
  * Added new TypeScript preview package to development dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->