### PR TITLE
fix(node): handle multiple close calls

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -157,7 +157,7 @@ class NodeServer implements Server {
       this.#wait.wait(),
       new Promise<void>((resolve, reject) => {
         const server = this.node?.server;
-        if (!server) {
+        if (!server || !server.listening) {
           return resolve();
         }
         if (closeAll && "closeAllConnections" in server) {

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -62,6 +62,7 @@ for (const config of testConfigs) {
     afterAll(async () => {
       await client.agent?.close?.();
       await server!.close(true);
+      await server!.close(true); // test idempotency
     });
 
     addTests({


### PR DESCRIPTION
When server.close is called multiple times (or close called when listening is manual and it has not been listening yet) this PR fixes issue with node adapter to no-op.

Bun and Deno already do have this behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed close behavior to properly handle servers that exist but are not yet listening.

* **Tests**
  * Added test coverage to verify idempotent close operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->