### PR TITLE
fix: handle non-parsable URLs in printListening

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -38,15 +38,21 @@ export function printListening(
     return;
   }
 
-  const _url = new URL(url);
-  const allInterfaces = _url.hostname === "[::]" || _url.hostname === "0.0.0.0";
-  if (allInterfaces) {
-    _url.hostname = "localhost";
-    url = _url.href;
+  let additionalInfo = "";
+  try {
+    const _url = new URL(url);
+    const allInterfaces =
+      _url.hostname === "[::]" || _url.hostname === "0.0.0.0";
+    if (allInterfaces) {
+      _url.hostname = "localhost";
+      url = _url.href;
+      additionalInfo = " (all interfaces)";
+    }
+  } catch {
+    // URL is not parsable (e.g., unix socket), use as-is
   }
 
   let listeningOn = `➜ Listening on:`;
-  let additionalInfo = allInterfaces ? " (all interfaces)" : "";
 
   if (globalThis.process.stdout?.isTTY) {
     listeningOn = `\u001B[32m${listeningOn}\u001B[0m`; // ANSI green


### PR DESCRIPTION
URLs like unix socket paths cannot be parsed by the URL constructor.
Wrap the parsing in try-catch to gracefully fall back to printing as-is.

It fixes issues with Phusion Passenger. Example: https://github.com/pi0/passenger-app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of server listening URL display with better error handling for edge cases like Unix sockets.
  * Enhanced clarity when server binds to all network interfaces.
  * Fixed potential parsing failures when displaying server startup information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->