### PR TITLE
feat: support `req.rawBody: Buffer` in google cloud functions

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -206,8 +206,7 @@ export function patchGlobalRequest(): typeof Request {
 }
 
 function readBody(req: NodeServerRequest): Promise<any> {
-  // Google Cloud Functions provides req.rawBody as a Buffer with the original request body
-  // See: https://cloud.google.com/functions/docs/samples/functions-http-content
+  // https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/5ce5e513d739fdb8388fb0e8b6fd5f52d59604f2/src/server.ts#L62
   if ("rawBody" in req && Buffer.isBuffer(req.rawBody)) {
     return Promise.resolve(req.rawBody);
   }


### PR DESCRIPTION
## Fix

**Resolves** #139 

This PR updates `readBody` to fall back to `req.rawBody` when present, ensuring the request body can still be read correctly in Google Cloud Functions.

## Context
In the Google Cloud Functions environment, the official [functions-framework-nodejs](https://github.com/GoogleCloudPlatform/functions-framework-nodejs) **automatically parses the request body**.

As a result:
* The parsed JSON body is available on `req.body`
* The original raw buffer is preserved on `req.rawBody` (see implementation in [server.ts](https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/148866281ef3886f4d1816da6cca705bd047156a/src/server.ts#L62))

Because the body is consumed during this automatic parsing step, the request stream is already closed. This means `req.on(...)` will not emit any events, and the logic in [h3js/srvx](https://github.com/h3js/srvx/blob/v0.10.1/src/adapters/_node/request.ts#L222) never runs as expected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized request body handling to short‑circuit and reuse pre-buffered request bodies, improving performance and reducing unnecessary streaming overhead when available.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->