### PR TITLE
feat(cli): export handleFetch util

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -102,7 +102,6 @@ export async function main(mainOpts: MainOpts): Promise<void> {
 
 export async function handleFetch(options: CLIOptions): Promise<never> {
   try {
-
     if (!options._fetch) {
       console.error("No fetch handler found!");
       process.exit(1);
@@ -167,7 +166,7 @@ export async function handleFetch(options: CLIOptions): Promise<never> {
       console.error(">");
     }
 
-    const res = await options._fetch(req) ?? renderError("No fetch handler exported", 501);
+    const res = (await options._fetch(req)) ?? renderError("No fetch handler exported", 501);
 
     // Verbose: print response info
     if (options._verbose) {
@@ -231,7 +230,7 @@ async function handleServerFetch(options: CLIOptions): Promise<Response> {
   return handleFetch({
     ...options,
     _fetch: loaded.fetch,
-  })
+  });
 }
 
 async function serve() {


### PR DESCRIPTION
Expose `handleFetch` from the `cli` to use in other http frameworks like Vercube. 

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for server-provided fetch handlers in CLI fetch operations, enabling more flexible request handling through server configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->