### PR TITLE
refactor(tracing): rename tracing channel `h3.fetch` to `h3.request`

### DIFF
--- a/examples/tracing/server.ts
+++ b/examples/tracing/server.ts
@@ -10,7 +10,7 @@ export default {
 // --- debug tracing channels ---
 
 debugChannel("srvx.middleware");
-debugChannel("srvx.fetch");
+debugChannel("srvx.request");
 
 function debugChannel(name: string) {
   const { tracingChannel } = process.getBuiltinModule("node:diagnostics_channel");

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -19,7 +19,7 @@ export type RequestEvent = {
  * Tracing plugin that adds diagnostics channel tracing to middleware and fetch handlers.
  *
  * This plugin wraps all middleware and the fetch handler with tracing instrumentation,
- * allowing you to subscribe to `srvx.fetch` and `srvx.middleware` tracing channels.
+ * allowing you to subscribe to `srvx.request` and `srvx.middleware` tracing channels.
  *
  * @example
  * ```ts
@@ -44,7 +44,7 @@ export function tracingPlugin(opts: { middleware?: boolean; fetch?: boolean } = 
 
     // Wrap the fetch handler with tracing
     if (opts.fetch !== false) {
-      const fetchChannel = tracingChannel<unknown, RequestEvent>("srvx.fetch");
+      const fetchChannel = tracingChannel<unknown, RequestEvent>("srvx.request");
       const originalFetch = server.options.fetch;
       server.options.fetch = (request) => {
         return fetchChannel.tracePromise(async () => await originalFetch(request), {

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -21,7 +21,7 @@ describe("tracing channels", () => {
   it("should emit fetch tracing events", async () => {
     const events: Array<{ type: string; method?: string }> = [];
 
-    const fetchChannel = tracingChannel("srvx.fetch");
+    const fetchChannel = tracingChannel("srvx.request");
 
     const startHandler = (data: any) => {
       events.push({ type: "fetch.start", method: data.request.method });
@@ -355,7 +355,7 @@ describe("tracing channels", () => {
   it("should emit fetch events when no middleware present", async () => {
     const events: Array<string> = [];
 
-    const fetchChannel = tracingChannel("srvx.fetch");
+    const fetchChannel = tracingChannel("srvx.request");
 
     const startHandler = () => {
       events.push("fetch.start");


### PR DESCRIPTION
We discussed that `.request` better describes what this does and more in line with other frameworks/conventions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tracing channel naming from "srvx.fetch" to "srvx.request" for fetch event tracing to improve consistency and clarity in event categorization within the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->