### PR TITLE
fix(static): use path separator instead of hardcoded slash

### DIFF
--- a/src/static.ts
+++ b/src/static.ts
@@ -1,7 +1,7 @@
 import type { ServerMiddleware } from "./types.ts";
 import type { Transform } from "node:stream";
 
-import { extname, join, resolve } from "node:path";
+import { extname, join, resolve, sep } from "node:path";
 import { readFile, stat } from "node:fs/promises";
 import { createReadStream, ReadStream } from "node:fs";
 import { FastResponse } from "srvx";
@@ -55,7 +55,7 @@ const COMMON_MIME_TYPES: Record<string, string> = {
 };
 
 export const serveStatic = (options: ServeStaticOptions): ServerMiddleware => {
-  const dir = resolve(options.dir) + "/";
+  const dir = resolve(options.dir) + sep;
   const methods = new Set((options.methods || ["GET", "HEAD"]).map((m) => m.toUpperCase()));
 
   return async (req, next) => {


### PR DESCRIPTION
Fixes https://github.com/h3js/srvx/issues/189

### Root cause

Prior to https://github.com/h3js/srvx/pull/190/changes/a317982d0f94d16d79b32156176b87348ef51163, dir was built with a hardcoded "/" suffix:

```ts
  const dir = resolve(options.dir) + "/";
```

On Windows, `resolve()` and `join()` both produce backslash paths, but `dir` ended with a forward slash, so `startsWith` always returned false, causing every file request to be skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static file serving to use platform-specific path handling, ensuring proper file access across Windows, macOS, and Linux environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->