### PR TITLE
node: preserve pre-existing Set-Cookie headers in sendNodeResponse

### DIFF
--- a/src/adapters/_node/send.ts
+++ b/src/adapters/_node/send.ts
@@ -52,16 +52,65 @@ function writeHead(
   // But it has an inconsistency in slow-path that does not unflattens!!
   // https://github.com/h3js/srvx/pull/40
   // Deno does not support flatten in both cases.
-  const writeHeaders: any = globalThis.Deno ? rawHeaders : rawHeaders.flat();
-  if (!nodeRes.headersSent) {
-    if (nodeRes.req?.httpVersion === "2.0") {
-      // @ts-expect-error
-      nodeRes.writeHead(status, writeHeaders);
-    } else {
-      // @ts-expect-error
-      nodeRes.writeHead(status, statusText, writeHeaders);
-    }
+  if (nodeRes.headersSent) {
+    return;
   }
+  // Merge any headers that were already set on nodeRes via setHeader
+  // before sendNodeResponse ran. writeHead otherwise REPLACES existing
+  // headers with the same name, which silently dropped Set-Cookie
+  // lines that callers (e.g. TanStack Start's dev plugin, auth
+  // middleware) had appended earlier. See h3js/srvx#144.
+  const merged = mergeExistingHeaders(nodeRes, rawHeaders);
+  const writeHeaders: any = globalThis.Deno ? merged : merged.flat();
+  if (nodeRes.req?.httpVersion === "2.0") {
+    // @ts-expect-error
+    nodeRes.writeHead(status, writeHeaders);
+  } else {
+    // @ts-expect-error
+    nodeRes.writeHead(status, statusText, writeHeaders);
+  }
+}
+
+function mergeExistingHeaders(
+  nodeRes: NodeServerResponse,
+  incoming: [string, string][],
+): [string, string][] {
+  const existingNames =
+    typeof nodeRes.getHeaderNames === "function"
+      ? nodeRes.getHeaderNames()
+      : [];
+  if (existingNames.length === 0) {
+    return incoming;
+  }
+
+  // For every Set-Cookie line set via setHeader, keep it and
+  // concatenate with the incoming ones so all cookies survive. For
+  // other single-valued headers, let the incoming Response value win
+  // if both sides specify the same name (preserves prior behaviour),
+  // otherwise preserve the pre-existing header.
+  const incomingNonSetCookieNames = new Set(
+    incoming.map(([k]) => k.toLowerCase()).filter((k) => k !== "set-cookie"),
+  );
+  const preserved: [string, string][] = [];
+  for (const name of existingNames) {
+    const lower = name.toLowerCase();
+    if (lower !== "set-cookie" && incomingNonSetCookieNames.has(lower)) {
+      continue;
+    }
+    const value = nodeRes.getHeader?.(name);
+    if (Array.isArray(value)) {
+      for (const v of value) {
+        preserved.push([name, String(v)]);
+      }
+    } else if (value !== undefined) {
+      preserved.push([name, String(value)]);
+    }
+    // Drop from nodeRes so writeHead doesn't also emit the header
+    // through its own pending-headers channel and duplicate it.
+    nodeRes.removeHeader?.(name);
+  }
+
+  return preserved.length > 0 ? [...preserved, ...incoming] : incoming;
 }
 
 function endNodeResponse(nodeRes: NodeServerResponse) {


### PR DESCRIPTION
Fixes #144.

## Problem

When a caller sets a header on the Node response *before* invoking `sendNodeResponse` (e.g. `nodeRes.setHeader("set-cookie", "a=...")`), Node's `writeHead(status, rawHeaders)` silently replaces every header of the same name rather than appending. Any `Set-Cookie` the caller had registered disappears the moment `sendNodeResponse` calls `writeHead` with the Web Response's own headers.

The reporter hit this in TanStack Start's dev-server plugin while setting both access-token and refresh-token cookies: the access-token cookie set via `setHeader` was silently dropped as soon as the Web Response's `Set-Cookie` reached `writeHead`.

## Fix

Before calling `writeHead`, merge any headers already present on `nodeRes`:

- Read them via `getHeaderNames()` / `getHeader()`.
- For `Set-Cookie`, preserve every line unconditionally so all cookies survive (both the ones on `nodeRes` and the ones in the Web Response).
- For any other header, let the incoming Response value win when both sides specify the same name (preserves prior behaviour for `Content-Type`, `Cache-Control`, etc.); when only the caller specified it, keep the caller's value.
- Remove the merged headers from `nodeRes` so `writeHead` doesn't emit them twice through its own pending-headers channel.

HTTP/2 path, HTTP/1 path and Deno path share the same merged array so the fix covers all three.

Signed off per DCO.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed HTTP header handling to properly preserve and merge header values, preventing duplication while ensuring correct handling of authentication-related headers across request cycles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->