### PR TITLE
fix(node): flatten writeHead headers on Deno

### DIFF
--- a/src/adapters/_node/send.ts
+++ b/src/adapters/_node/send.ts
@@ -51,8 +51,7 @@ function writeHead(
   // https://github.com/nodejs/node/blob/v24.10.0/lib/_http_outgoing.js#L417
   // But it has an inconsistency in slow-path that does not unflattens!!
   // https://github.com/h3js/srvx/pull/40
-  // Deno does not support flatten in both cases.
-  const writeHeaders: any = globalThis.Deno ? rawHeaders : rawHeaders.flat();
+  const writeHeaders = rawHeaders.flat();
   if (!nodeRes.headersSent) {
     if (nodeRes.req?.httpVersion === "2.0") {
       // @ts-expect-error


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
resolves #202

#129 added a Deno-specific branch because the Deno node-compat tests introduced in #128 exposed issues after #40.

However, a version matrix shows that flattened headers are supported by all Deno versions where tuple-list headers work, and `rawHeaders.flat()` is the only shape that works on Deno 2.7.13.

Tested across Deno versions:

| deno | rawHeaders | flatten |
|---|---:|---:|
| <= 1.41.0 | ❌ | ❌ |
| 1.41.1–2.7.12 | ✅ | ✅ |
| 2.7.13 | ❌ | ✅ |


Deno’s docs describe `rawHeaders` as a flat list, not a list of tuples:

> The keys and values are in the same list. It is not a list of tuples.

https://docs.deno.com/api/node/http/~/IncomingMessage.prototype.rawHeaders


This removes the deno-specific branch and keep same behavior with node.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency in header handling across different runtime environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->