### PR TITLE
fix(aws-lambda-streaming): handle empty body

### DIFF
--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -178,14 +178,17 @@ export async function awsStreamResponse(
 
   // awslambda is a global provided by Lambda runtime
   const writer = (globalThis as any).awslambda.HttpResponseStream.from(responseStream, metadata);
-
-  if (!response.body) {
-    writer.end();
-    return;
-  }
+  const body =
+    response.body ??
+    new ReadableStream<string>({
+      start(controller) {
+        controller.enqueue("");
+        controller.close();
+      },
+    });
 
   try {
-    await streamToNodeStream(response.body, writer);
+    await streamToNodeStream(body, writer);
   } finally {
     writer.end();
   }

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -953,8 +953,9 @@ describe("[AWS Lambda] Request Utils", () => {
 
       await awsStreamResponse(response, mockStream);
 
-      expect(getChunks().length).toBe(0);
+      expect(getChunks()).toEqual([""]);
       expect(isEndCalled()).toBe(true);
+      expect(mockWriter.write).toHaveBeenCalledWith("");
       expect(mockWriter.end).toHaveBeenCalled();
     });
 
@@ -1175,6 +1176,42 @@ describe("[AWS Lambda] Request Utils", () => {
       expect(request.url).toContain("/api/v2");
       expect(request.url).toContain("foo=bar");
       expect((getMetadata() as any).statusCode).toBe(200);
+    });
+
+    test("should close the stream for redirects without a response body", async () => {
+      const { mockStream, mockWriter, getChunks, getMetadata } = createMockResponseStream();
+
+      const fetchHandler = vi.fn().mockResolvedValue(
+        new Response(null, {
+          status: 302,
+          headers: {
+            location: "/",
+          },
+        }),
+      );
+
+      const event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/redirect",
+        headers: { host: "api.example.com" },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: {} as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      await handleLambdaEventWithStream(fetchHandler, event, mockStream, createMockContext());
+
+      expect((getMetadata() as any).statusCode).toBe(302);
+      expect((getMetadata() as any).headers.location).toBe("/");
+      expect(getChunks()).toEqual([""]);
+      expect(mockWriter.write).toHaveBeenCalledWith("");
+      expect(mockWriter.end).toHaveBeenCalled();
     });
 
     test("should handle fetch handler errors", async () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Resolves #204 

When the request body is `null` the response stream doesn't close. This breaks responses like redirects that don't have a body:
```
return new Response(null, {
   status: 302,
   headers: {
     location: "/",
   },
});
```

This PR adds in the conditional logic to create a response body if none exists.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced handling of AWS Lambda responses that lack a response body, ensuring proper stream closure and metadata delivery
  * Improved streaming behavior for responses without body content (such as redirects), maintaining correct status codes and headers in the stream

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/srvx/pull/205)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->