### PR TITLE
fix(node): do not crash on asterisk-form request targets

### DIFF
--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -13,37 +13,57 @@ export class NodeRequestURL extends FastURL {
 
   constructor({ req }: { req: NodeServerRequest }) {
     const path = req.url || "/";
-    if (path[0] === "/") {
-      const qIndex = path.indexOf("?");
-      const pathname = qIndex === -1 ? path : path?.slice(0, qIndex) || "/";
-      const search = qIndex === -1 ? "" : path?.slice(qIndex) || "";
 
-      let host = req.headers.host || (req.headers[":authority"] as string);
-      if (host && !HOST_RE.test(host)) {
-        host = "_invalid_";
-      } else if (!host) {
-        if (req.socket) {
-          host = `${req.socket.localFamily === "IPv6" ? "[" + req.socket.localAddress + "]" : req.socket.localAddress}:${req.socket?.localPort || "80"}`;
-        } else {
-          host = "localhost";
-        }
+    let host = req.headers.host || (req.headers[":authority"] as string);
+    if (host && !HOST_RE.test(host)) {
+      host = "_invalid_";
+    } else if (!host) {
+      if (req.socket) {
+        host = `${req.socket.localFamily === "IPv6" ? "[" + req.socket.localAddress + "]" : req.socket.localAddress}:${req.socket?.localPort || "80"}`;
+      } else {
+        host = "localhost";
       }
+    }
 
-      const protocol =
-        (req.socket as any)?.encrypted ||
-        req.headers["x-forwarded-proto"] === "https" ||
-        req.headers[":scheme"] === "https"
-          ? "https:"
-          : "http:";
+    const protocol =
+      (req.socket as any)?.encrypted ||
+      req.headers["x-forwarded-proto"] === "https" ||
+      req.headers[":scheme"] === "https"
+        ? "https:"
+        : "http:";
 
+    if (path[0] === "/") {
+      // origin-form: /path?query
+      const qIndex = path.indexOf("?");
       super({
         protocol,
         host,
-        pathname,
-        search,
+        pathname: qIndex === -1 ? path : path.slice(0, qIndex) || "/",
+        search: qIndex === -1 ? "" : path.slice(qIndex) || "",
       });
-    } else {
+    } else if (URL.canParse(path)) {
+      // absolute-form (e.g. proxy request)
       super(path);
+    } else {
+      // Anything else llhttp admits but URL cannot parse — notably the
+      // asterisk-form request-target (RFC 9110 §7.1, `OPTIONS *`) and
+      // similar non-conforming targets like `**` or `*foo`. These have
+      // no Fetch URL representation. Preserve the literal as a pathname
+      // (prefixed with "/") so handlers can still observe it, falling
+      // back to "/" if even that won't parse — never crash the process.
+      const qIndex = path.indexOf("?");
+      const rawPath = qIndex === -1 ? path : path.slice(0, qIndex);
+      const rawQuery = qIndex === -1 ? "" : path.slice(qIndex);
+      const candidate = "/" + rawPath;
+      const synthesized = URL.canParse(`${protocol}//${host}${candidate}${rawQuery}`)
+        ? candidate
+        : "/";
+      super({
+        protocol,
+        host,
+        pathname: synthesized,
+        search: synthesized === candidate ? rawQuery : "",
+      });
     }
     this.#req = req;
   }

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -41,29 +41,13 @@ export class NodeRequestURL extends FastURL {
         pathname: qIndex === -1 ? path : path.slice(0, qIndex) || "/",
         search: qIndex === -1 ? "" : path.slice(qIndex) || "",
       });
-    } else if (URL.canParse(path)) {
+    } else if (path === "*") {
+      // RFC 9110 §7.1 asterisk-form (`OPTIONS *`): surface as `/*`, matching
+      // Deno. Other non-conforming targets are rejected by the adapter.
+      super({ protocol, host, pathname: "/*", search: "" });
+    } else {
       // absolute-form (e.g. proxy request)
       super(path);
-    } else {
-      // Anything else llhttp admits but URL cannot parse — notably the
-      // asterisk-form request-target (RFC 9110 §7.1, `OPTIONS *`) and
-      // similar non-conforming targets like `**` or `*foo`. These have
-      // no Fetch URL representation. Preserve the literal as a pathname
-      // (prefixed with "/") so handlers can still observe it, falling
-      // back to "/" if even that won't parse — never crash the process.
-      const qIndex = path.indexOf("?");
-      const rawPath = qIndex === -1 ? path : path.slice(0, qIndex);
-      const rawQuery = qIndex === -1 ? "" : path.slice(qIndex);
-      const candidate = "/" + rawPath;
-      const synthesized = URL.canParse(`${protocol}//${host}${candidate}${rawQuery}`)
-        ? candidate
-        : "/";
-      super({
-        protocol,
-        host,
-        pathname: synthesized,
-        search: synthesized === candidate ? rawQuery : "",
-      });
     }
     this.#req = req;
   }

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -65,6 +65,21 @@ class NodeServer implements Server {
     const fetchHandler = (this.fetch = wrapFetch(this));
 
     const handler = (nodeReq: NodeServerRequest, nodeRes: NodeServerResponse) => {
+      // Reject request-targets llhttp admits but that aren't valid Fetch URLs:
+      // anything that isn't origin-form (/...), absolute-form, or the RFC 9110
+      // §7.1 asterisk-form (`*`). Bun/Deno reject these at the parser layer;
+      // Node leaves it to us. (Hot path is a single char compare.)
+      const reqUrl = nodeReq.url;
+      if (
+        reqUrl &&
+        reqUrl[0] !== "/" &&
+        reqUrl !== "*" &&
+        !URL.canParse(reqUrl)
+      ) {
+        nodeRes.statusCode = 400;
+        nodeRes.end();
+        return;
+      }
       const request = new NodeRequest({ req: nodeReq, res: nodeRes });
       request.waitUntil = this.#wait?.waitUntil;
       const res = fetchHandler(request);

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -70,12 +70,7 @@ class NodeServer implements Server {
       // §7.1 asterisk-form (`*`). Bun/Deno reject these at the parser layer;
       // Node leaves it to us. (Hot path is a single char compare.)
       const reqUrl = nodeReq.url;
-      if (
-        reqUrl &&
-        reqUrl[0] !== "/" &&
-        reqUrl !== "*" &&
-        !URL.canParse(reqUrl)
-      ) {
+      if (reqUrl && reqUrl[0] !== "/" && reqUrl !== "*" && !URL.canParse(reqUrl)) {
         nodeRes.statusCode = 400;
         nodeRes.end();
         return;

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -189,51 +189,50 @@ describe("FastURL", () => {
       });
     }
 
-    test.each([
-      "OPTIONS * HTTP/1.1",
-      "GET ** HTTP/1.1",
-      "GET *foo HTTP/1.1",
-    ])("%s over the wire does not crash the server", async (requestLine) => {
-      const server = serve({
-        port: 0,
-        // request.url access is what triggers the original crash
-        fetch: (request) => new Response(request.url),
-      });
-      await server.ready();
-      const addr = server.node?.server?.address();
-      if (!addr || typeof addr !== "object") throw new Error("no address");
-      const port = addr.port;
+    test.each(["OPTIONS * HTTP/1.1", "GET ** HTTP/1.1", "GET *foo HTTP/1.1"])(
+      "%s over the wire does not crash the server",
+      async (requestLine) => {
+        const server = serve({
+          port: 0,
+          // request.url access is what triggers the original crash
+          fetch: (request) => new Response(request.url),
+        });
+        await server.ready();
+        const addr = server.node?.server?.address();
+        if (!addr || typeof addr !== "object") throw new Error("no address");
+        const port = addr.port;
 
-      try {
-        const result = await new Promise<{ statusLine: string; body: string }>(
-          (resolve, reject) => {
-            const socket = new net.Socket();
-            socket.connect(port, "127.0.0.1", () => {
-              socket.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
-            });
-            let data = "";
-            socket.on("data", (chunk) => {
-              data += chunk.toString();
-            });
-            socket.on("end", () => {
-              const statusLine = data.split("\r\n")[0] || "";
-              const body = data.split("\r\n\r\n").slice(1).join("\r\n\r\n");
-              resolve({ statusLine, body });
-            });
-            socket.on("error", reject);
-            socket.setTimeout(2000, () => {
-              socket.destroy();
-              reject(new Error("socket timed out"));
-            });
-          },
-        );
+        try {
+          const result = await new Promise<{ statusLine: string; body: string }>(
+            (resolve, reject) => {
+              const socket = new net.Socket();
+              socket.connect(port, "127.0.0.1", () => {
+                socket.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+              });
+              let data = "";
+              socket.on("data", (chunk) => {
+                data += chunk.toString();
+              });
+              socket.on("end", () => {
+                const statusLine = data.split("\r\n")[0] || "";
+                const body = data.split("\r\n\r\n").slice(1).join("\r\n\r\n");
+                resolve({ statusLine, body });
+              });
+              socket.on("error", reject);
+              socket.setTimeout(2000, () => {
+                socket.destroy();
+                reject(new Error("socket timed out"));
+              });
+            },
+          );
 
-        expect(result.statusLine).toMatch(/^HTTP\/1\.1 \d{3}/);
-        expect(result.statusLine).not.toMatch(/^HTTP\/1\.1 5\d\d/);
-      } finally {
-        await server.close(true);
-      }
-    });
+          expect(result.statusLine).toMatch(/^HTTP\/1\.1 \d{3}/);
+          expect(result.statusLine).not.toMatch(/^HTTP\/1\.1 5\d\d/);
+        } finally {
+          await server.close(true);
+        }
+      },
+    );
   });
 
   describe("pathname normalization", () => {

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -183,28 +183,26 @@ describe("FastURL", () => {
     });
 
     async function sendRaw(port: number, requestLine: string) {
-      return await new Promise<{ statusLine: string; body: string }>(
-        (resolve, reject) => {
-          const socket = new net.Socket();
-          socket.connect(port, "127.0.0.1", () => {
-            socket.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
-          });
-          let data = "";
-          socket.on("data", (chunk) => {
-            data += chunk.toString();
-          });
-          socket.on("end", () => {
-            const statusLine = data.split("\r\n")[0] || "";
-            const body = data.split("\r\n\r\n").slice(1).join("\r\n\r\n");
-            resolve({ statusLine, body });
-          });
-          socket.on("error", reject);
-          socket.setTimeout(2000, () => {
-            socket.destroy();
-            reject(new Error("socket timed out"));
-          });
-        },
-      );
+      return await new Promise<{ statusLine: string; body: string }>((resolve, reject) => {
+        const socket = new net.Socket();
+        socket.connect(port, "127.0.0.1", () => {
+          socket.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+        });
+        let data = "";
+        socket.on("data", (chunk) => {
+          data += chunk.toString();
+        });
+        socket.on("end", () => {
+          const statusLine = data.split("\r\n")[0] || "";
+          const body = data.split("\r\n\r\n").slice(1).join("\r\n\r\n");
+          resolve({ statusLine, body });
+        });
+        socket.on("error", reject);
+        socket.setTimeout(2000, () => {
+          socket.destroy();
+          reject(new Error("socket timed out"));
+        });
+      });
     }
 
     async function withServer<T>(fn: (port: number) => Promise<T>): Promise<T> {

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -1,5 +1,7 @@
+import net from "node:net";
 import { describe, test, expect } from "vitest";
 import { FastURL } from "../src/_url.ts";
+import { serve } from "../src/adapters/node.ts";
 import { NodeRequestURL } from "../src/adapters/_node/url.ts";
 
 const urlTests = await import("./wpt/url_tests.json", {
@@ -152,6 +154,86 @@ describe("FastURL", () => {
         expect(url.pathname).toBe(expected);
       });
     }
+  });
+
+  describe("non-URL request targets (asterisk-form & friends)", () => {
+    // RFC 9110 §7.1: the asterisk-form `*` is used for a server-wide
+    // OPTIONS request. Node's HTTP parser also admits `*`-prefixed
+    // targets like `**` and `*foo`. None of these have a Fetch URL
+    // representation — accessing url props must not crash the process.
+    const cases = [
+      { input: "*", pathname: "/*", search: "" },
+      { input: "**", pathname: "/**", search: "" },
+      { input: "*foo", pathname: "/*foo", search: "" },
+      { input: "*?q=1", pathname: "/*", search: "?q=1" },
+    ] as const;
+
+    for (const { input, pathname, search } of cases) {
+      test(`"${input}" does not throw and synthesizes a stable URL`, () => {
+        const fast = new NodeRequestURL({
+          req: { url: input, headers: { host: "localhost" } } as any,
+        });
+        expect(fast.pathname).toBe(pathname);
+        expect(fast.search).toBe(search);
+        expect(fast.href).toBe(`http://localhost${pathname}${search}`);
+      });
+
+      test(`"${input}" stays consistent after deopt`, () => {
+        const slow = new NodeRequestURL({
+          req: { url: input, headers: { host: "localhost" } } as any,
+        });
+        void slow.hostname; // force deopt to native URL
+        expect(slow.hostname).toBe("localhost");
+        expect(slow.pathname).toBe(pathname);
+        expect(slow.search).toBe(search);
+      });
+    }
+
+    test.each([
+      "OPTIONS * HTTP/1.1",
+      "GET ** HTTP/1.1",
+      "GET *foo HTTP/1.1",
+    ])("%s over the wire does not crash the server", async (requestLine) => {
+      const server = serve({
+        port: 0,
+        // request.url access is what triggers the original crash
+        fetch: (request) => new Response(request.url),
+      });
+      await server.ready();
+      const addr = server.node?.server?.address();
+      if (!addr || typeof addr !== "object") throw new Error("no address");
+      const port = addr.port;
+
+      try {
+        const result = await new Promise<{ statusLine: string; body: string }>(
+          (resolve, reject) => {
+            const socket = new net.Socket();
+            socket.connect(port, "127.0.0.1", () => {
+              socket.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+            });
+            let data = "";
+            socket.on("data", (chunk) => {
+              data += chunk.toString();
+            });
+            socket.on("end", () => {
+              const statusLine = data.split("\r\n")[0] || "";
+              const body = data.split("\r\n\r\n").slice(1).join("\r\n\r\n");
+              resolve({ statusLine, body });
+            });
+            socket.on("error", reject);
+            socket.setTimeout(2000, () => {
+              socket.destroy();
+              reject(new Error("socket timed out"));
+            });
+          },
+        );
+
+        expect(result.statusLine).toMatch(/^HTTP\/1\.1 \d{3}/);
+        expect(result.statusLine).not.toMatch(/^HTTP\/1\.1 5\d\d/);
+      } finally {
+        await server.close(true);
+      }
+    });
   });
 
   describe("pathname normalization", () => {

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -158,79 +158,86 @@ describe("FastURL", () => {
 
   describe("non-URL request targets (asterisk-form & friends)", () => {
     // RFC 9110 §7.1: the asterisk-form `*` is used for a server-wide
-    // OPTIONS request. Node's HTTP parser also admits `*`-prefixed
-    // targets like `**` and `*foo`. None of these have a Fetch URL
-    // representation — accessing url props must not crash the process.
-    const cases = [
-      { input: "*", pathname: "/*", search: "" },
-      { input: "**", pathname: "/**", search: "" },
-      { input: "*foo", pathname: "/*foo", search: "" },
-      { input: "*?q=1", pathname: "/*", search: "?q=1" },
-    ] as const;
+    // OPTIONS request. Surface it as `/*` (matches Deno). Node's HTTP
+    // parser also admits `*`-prefixed targets like `**` and `*foo`;
+    // these are not valid request-targets and are rejected with 400
+    // at the adapter (matches Bun/Deno parser-level rejection).
 
-    for (const { input, pathname, search } of cases) {
-      test(`"${input}" does not throw and synthesizes a stable URL`, () => {
-        const fast = new NodeRequestURL({
-          req: { url: input, headers: { host: "localhost" } } as any,
-        });
-        expect(fast.pathname).toBe(pathname);
-        expect(fast.search).toBe(search);
-        expect(fast.href).toBe(`http://localhost${pathname}${search}`);
+    test(`"*" synthesizes /*`, () => {
+      const fast = new NodeRequestURL({
+        req: { url: "*", headers: { host: "localhost" } } as any,
       });
+      expect(fast.pathname).toBe("/*");
+      expect(fast.search).toBe("");
+      expect(fast.href).toBe("http://localhost/*");
+    });
 
-      test(`"${input}" stays consistent after deopt`, () => {
-        const slow = new NodeRequestURL({
-          req: { url: input, headers: { host: "localhost" } } as any,
-        });
-        void slow.hostname; // force deopt to native URL
-        expect(slow.hostname).toBe("localhost");
-        expect(slow.pathname).toBe(pathname);
-        expect(slow.search).toBe(search);
+    test(`"*" stays consistent after deopt`, () => {
+      const slow = new NodeRequestURL({
+        req: { url: "*", headers: { host: "localhost" } } as any,
       });
+      void slow.hostname; // force deopt to native URL
+      expect(slow.hostname).toBe("localhost");
+      expect(slow.pathname).toBe("/*");
+      expect(slow.search).toBe("");
+    });
+
+    async function sendRaw(port: number, requestLine: string) {
+      return await new Promise<{ statusLine: string; body: string }>(
+        (resolve, reject) => {
+          const socket = new net.Socket();
+          socket.connect(port, "127.0.0.1", () => {
+            socket.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+          });
+          let data = "";
+          socket.on("data", (chunk) => {
+            data += chunk.toString();
+          });
+          socket.on("end", () => {
+            const statusLine = data.split("\r\n")[0] || "";
+            const body = data.split("\r\n\r\n").slice(1).join("\r\n\r\n");
+            resolve({ statusLine, body });
+          });
+          socket.on("error", reject);
+          socket.setTimeout(2000, () => {
+            socket.destroy();
+            reject(new Error("socket timed out"));
+          });
+        },
+      );
     }
 
-    test.each(["OPTIONS * HTTP/1.1", "GET ** HTTP/1.1", "GET *foo HTTP/1.1"])(
-      "%s over the wire does not crash the server",
+    async function withServer<T>(fn: (port: number) => Promise<T>): Promise<T> {
+      const server = serve({
+        port: 0,
+        fetch: (request) => new Response(request.url),
+      });
+      await server.ready();
+      const addr = server.node?.server?.address();
+      if (!addr || typeof addr !== "object") throw new Error("no address");
+      try {
+        return await fn(addr.port);
+      } finally {
+        await server.close(true);
+      }
+    }
+
+    test("OPTIONS * over the wire returns 200 with href http://host/*", async () => {
+      await withServer(async (port) => {
+        const result = await sendRaw(port, "OPTIONS * HTTP/1.1");
+        expect(result.statusLine).toMatch(/^HTTP\/1\.1 200 /);
+        // body may be chunked-encoded
+        expect(result.body).toContain("http://localhost/*");
+      });
+    });
+
+    test.each(["GET ** HTTP/1.1", "GET *foo HTTP/1.1", "GET *?q=1 HTTP/1.1"])(
+      "%s over the wire returns 400",
       async (requestLine) => {
-        const server = serve({
-          port: 0,
-          // request.url access is what triggers the original crash
-          fetch: (request) => new Response(request.url),
+        await withServer(async (port) => {
+          const result = await sendRaw(port, requestLine);
+          expect(result.statusLine).toMatch(/^HTTP\/1\.1 400 /);
         });
-        await server.ready();
-        const addr = server.node?.server?.address();
-        if (!addr || typeof addr !== "object") throw new Error("no address");
-        const port = addr.port;
-
-        try {
-          const result = await new Promise<{ statusLine: string; body: string }>(
-            (resolve, reject) => {
-              const socket = new net.Socket();
-              socket.connect(port, "127.0.0.1", () => {
-                socket.write(`${requestLine}\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
-              });
-              let data = "";
-              socket.on("data", (chunk) => {
-                data += chunk.toString();
-              });
-              socket.on("end", () => {
-                const statusLine = data.split("\r\n")[0] || "";
-                const body = data.split("\r\n\r\n").slice(1).join("\r\n\r\n");
-                resolve({ statusLine, body });
-              });
-              socket.on("error", reject);
-              socket.setTimeout(2000, () => {
-                socket.destroy();
-                reject(new Error("socket timed out"));
-              });
-            },
-          );
-
-          expect(result.statusLine).toMatch(/^HTTP\/1\.1 \d{3}/);
-          expect(result.statusLine).not.toMatch(/^HTTP\/1\.1 5\d\d/);
-        } finally {
-          await server.close(true);
-        }
       },
     );
   });


### PR DESCRIPTION
`OPTIONS *` and similar `*`-prefixed request-targets that Node's `llhttp` admits (`*`, `**`, `*foo`) reach handlers as `req.url`, but the previous code passed them straight to `new URL(...)` which throws. Since `request.url` is a synchronous getter, the throw escaped the user's `fetch` handler and crashed the Node process.

Repro:

```ts
import { serve } from "srvx/node";

serve({ port: 3000, fetch: (request) => new Response(request.url) });
```

```sh
curl -X OPTIONS --request-target "*" http://127.0.0.1:3000/
# server crashes
```

### Behavior

Aligned with what Bun and Deno do natively:

| Request target | Bun 1.3 | Deno 2.8 | srvx (this PR) |
|---|---|---|---|
| `OPTIONS *` (RFC 9110 §7.1) | 400 at parser | **200**, `req.url = http://host/*` | **200**, `req.url = http://host/*` |
| `GET **`, `GET *foo`, `GET *?q=1` | 400 at parser | 400 at parser | **400** at adapter |

- **Bare `*`** (the canonical RFC 9110 asterisk-form) is surfaced as a pathname of `/*`, byte-identical to Deno.
- **Other `*`-prefixed shapes** that llhttp leniently admits are rejected with a 400 at the Node adapter layer before reaching the user's `fetch` handler — mirroring Bun and Deno, whose HTTP parsers reject them at the wire.

### Implementation

- `src/adapters/node.ts`: the handler short-circuits to `400` when `nodeReq.url` is not origin-form, not exactly `*`, and not a parseable absolute URL. Hot path is a single char compare (`reqUrl[0] !== "/"`) and short-circuits on the common case — zero overhead for normal traffic.
- `src/adapters/_node/url.ts`: `NodeRequestURL` now has three explicit branches — origin-form (unchanged fast path), bare `*` (synthesize `/*`), and absolute-form. The previous synthesize-anything fallback is gone; the adapter is the gatekeeper.

### Tests

- `*` synthesizes to `/*` on both the FastURL fast path and after deopt to native URL.
- Raw-TCP integration tests assert `OPTIONS *` returns 200 with `http://localhost/*` as the body, while `GET **`, `GET *foo`, `GET *?q=1` return 400.
- `pnpm vitest run test/url.test.ts` — 532 passed, no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request URL validation to reject malformed targets with HTTP 400 responses.
  * Enhanced host value computation with proper fallback and formatting for IPv6 addresses.
  * Added proper support for asterisk-form HTTP request targets per RFC specifications.

* **Tests**
  * Added comprehensive integration tests for non-standard request targets and validation scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/srvx/pull/206?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->