### PR TITLE
fix(node/web): forward socket drain and handle aborted signals

### DIFF
--- a/src/adapters/_node/web/fetch.ts
+++ b/src/adapters/_node/web/fetch.ts
@@ -39,8 +39,16 @@ export async function fetchNodeHandler(
   try {
     await handler(nodeReq as any, nodeRes as any);
     return await nodeRes.toWebResponse();
-  } catch (error) {
-    console.error(error, { cause: { req, handler } });
+  } catch (error: any) {
+    // Client aborts / premature socket closes are routine (the client is already
+    // gone), so don't log them as errors. See https://github.com/h3js/srvx/issues/208
+    const aborted =
+      req.signal?.aborted ||
+      error?.name === "AbortError" ||
+      error?.code === "ERR_STREAM_PREMATURE_CLOSE";
+    if (!aborted) {
+      console.error(error, { cause: { req, handler } });
+    }
     return new Response(null, {
       status: 500,
       statusText: "Internal Server Error",

--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -1,5 +1,5 @@
 import { ServerResponse } from "node:http";
-import { WebRequestSocket } from "./socket.ts";
+import { WebRequestSocket, prematureCloseError } from "./socket.ts";
 import type { WebIncomingMessage } from "./incoming.ts";
 
 // Node's OutgoingMessage sets an internal `kNeedDrain` symbol to true when a
@@ -14,12 +14,6 @@ function getNeedDrainSymbol(res: ServerResponse): symbol | null {
       Object.getOwnPropertySymbols(res).find((s) => s.description === "kNeedDrain") ?? null;
   }
   return needDrainSymbol;
-}
-
-function prematureCloseError(): Error {
-  return Object.assign(new Error("Connection closed before response was finished"), {
-    code: "ERR_STREAM_PREMATURE_CLOSE",
-  });
 }
 
 export class WebServerResponse extends ServerResponse {
@@ -83,14 +77,26 @@ export class WebServerResponse extends ServerResponse {
       return Promise.resolve();
     }
     return new Promise<void>((resolve, reject) => {
-      this.on("finish", () => resolve());
-      this.on("error", (err) => reject(err));
-      this.#socket.on("error", (err) => reject(err));
-      this.#socket.on("close", () => {
+      const socket = this.#socket;
+      const settle = (err?: Error) => {
+        this.removeListener("finish", onFinish);
+        this.removeListener("error", onError);
+        socket.removeListener("error", onError);
+        socket.removeListener("close", onClose);
+        if (err) reject(err);
+        else resolve();
+      };
+      const onFinish = () => settle();
+      const onError = (err: Error) => settle(err);
+      const onClose = () => {
         if (!this.writableFinished) {
-          reject(this.#socketError ?? prematureCloseError());
+          settle(this.#socketError ?? prematureCloseError());
         }
-      });
+      };
+      this.on("finish", onFinish);
+      this.on("error", onError);
+      socket.on("error", onError);
+      socket.on("close", onClose);
     });
   }
 

--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -2,8 +2,29 @@ import { ServerResponse } from "node:http";
 import { WebRequestSocket } from "./socket.ts";
 import type { WebIncomingMessage } from "./incoming.ts";
 
+// Node's OutgoingMessage sets an internal `kNeedDrain` symbol to true when a
+// write returns false, and clears it (emitting "drain") from the HTTP server's
+// socketOnDrain handler. We don't have access to that symbol publicly, so we
+// resolve it from the instance once and cache it. Resolving may fail across
+// Node versions; in that case we fall back to always re-emitting "drain".
+let needDrainSymbol: symbol | null | undefined;
+function getNeedDrainSymbol(res: ServerResponse): symbol | null {
+  if (needDrainSymbol === undefined) {
+    needDrainSymbol =
+      Object.getOwnPropertySymbols(res).find((s) => s.description === "kNeedDrain") ?? null;
+  }
+  return needDrainSymbol;
+}
+
+function prematureCloseError(): Error {
+  return Object.assign(new Error("Connection closed before response was finished"), {
+    code: "ERR_STREAM_PREMATURE_CLOSE",
+  });
+}
+
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
+  #socketError?: Error;
 
   constructor(req: WebIncomingMessage, socket: WebRequestSocket) {
     super(req);
@@ -15,18 +36,61 @@ export class WebServerResponse extends ServerResponse {
 
     this.#socket = socket;
 
+    // When the client disconnects, the assigned socket is destroyed (e.g. with
+    // an AbortError) and emits "error"/"close" without the ServerResponse ever
+    // emitting "finish" or "error". Attach this listener synchronously so the
+    // socket error is consumed (instead of crashing the process as an unhandled
+    // "error" event) and recorded for waitToFinish() to settle on.
+    socket.once("error", (err) => {
+      this.#socketError ??= err;
+    });
+
+    // Forward socket "drain" events to the response. Node's HTTP server does
+    // this internally (socketOnDrain), but the manual assignSocket() path here
+    // does not, so a handler awaiting res.once("drain") after a backpressured
+    // write() would deadlock. See https://github.com/h3js/srvx/issues/208
+    socket.on("drain", () => {
+      const kNeedDrain = getNeedDrainSymbol(this);
+      if (kNeedDrain && !(this as any)[kNeedDrain]) {
+        return;
+      }
+      if (this.destroyed || this.writableFinished) {
+        return;
+      }
+      if (kNeedDrain) {
+        (this as any)[kNeedDrain] = false;
+      }
+      this.emit("drain");
+    });
+
     // Express can override prototype so we have to bind methods
     this.waitToFinish = this.waitToFinish.bind(this);
     this.toWebResponse = this.toWebResponse.bind(this);
   }
 
   waitToFinish(): Promise<void> {
+    if (this.writableFinished) {
+      return Promise.resolve();
+    }
+    // The socket is destroyed before the response finished flushing (e.g. the
+    // client aborted). `writableEnded` may still be true (end() was called) but
+    // the response will never emit "finish", so resolving here would hand back a
+    // body stream that never closes. Reject instead.
+    if (this.#socketError || this.#socket.destroyed) {
+      return Promise.reject(this.#socketError ?? prematureCloseError());
+    }
     if (this.writableEnded) {
       return Promise.resolve();
     }
     return new Promise<void>((resolve, reject) => {
       this.on("finish", () => resolve());
       this.on("error", (err) => reject(err));
+      this.#socket.on("error", (err) => reject(err));
+      this.#socket.on("close", () => {
+        if (!this.writableFinished) {
+          reject(this.#socketError ?? prematureCloseError());
+        }
+      });
     });
   }
 

--- a/src/adapters/_node/web/socket.ts
+++ b/src/adapters/_node/web/socket.ts
@@ -7,6 +7,12 @@ import { addAbortSignal, Duplex } from "node:stream";
 // https://github.com/nodejs/node/blob/main/lib/internal/streams/duplex.js
 // https://github.com/nodejs/node/blob/main/lib/internal/webstreams/adapters.js
 
+export function prematureCloseError(): Error {
+  return Object.assign(new Error("Connection closed before response was finished"), {
+    code: "ERR_STREAM_PREMATURE_CLOSE",
+  });
+}
+
 /**
  * Events:
  * - Readable (req from client): readable => data => end (push(null)) => error => close
@@ -196,9 +202,7 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
     if (!this.#resBodyClosed) {
       this.#resBodyClosed = true;
       try {
-        this.#resBodyController?.error(
-          err ?? new Error("Connection closed before response was finished"),
-        );
+        this.#resBodyController?.error(err ?? prematureCloseError());
       } catch {
         // controller may already be closed/errored
       }

--- a/src/adapters/_node/web/socket.ts
+++ b/src/adapters/_node/web/socket.ts
@@ -2,7 +2,7 @@ import type { AddressInfo, Socket as NodeSocket } from "node:net";
 import type { SocketReadyState } from "node:net";
 import type { WebServerResponse } from "./response.ts";
 
-import { Duplex } from "node:stream";
+import { addAbortSignal, Duplex } from "node:stream";
 
 // https://github.com/nodejs/node/blob/main/lib/internal/streams/duplex.js
 // https://github.com/nodejs/node/blob/main/lib/internal/webstreams/adapters.js
@@ -35,12 +35,13 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
 
   #headersWritten?: boolean;
   #_writeBody!: (chunk: Uint8Array) => void;
+  #resBodyController?: ReadableStreamDefaultController<Uint8Array>;
+  #resBodyClosed?: boolean;
   _webResBody: ReadableStream;
   #tos: number = 0;
 
   constructor(request: Request) {
     super({
-      signal: request.signal,
       allowHalfOpen: true,
     });
 
@@ -48,13 +49,22 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
 
     this._webResBody = new ReadableStream({
       start: (controller) => {
+        this.#resBodyController = controller;
         this.#_writeBody = controller.enqueue.bind(controller);
         this.once("finish", () => {
           this.readyState = "closed";
+          this.#resBodyClosed = true;
           controller.close();
         });
       },
     });
+
+    // Wire request abort handling *after* `super()` so the subclass private
+    // fields are initialized before any synchronous `destroy()`. Passing the
+    // signal into the `Duplex` constructor instead would destroy the stream
+    // mid-construction for an already-aborted signal, making `_destroy()` throw
+    // while accessing not-yet-initialized private fields.
+    addAbortSignal(request.signal, this);
   }
 
   setTimeout(ms?: number, cb?: () => void): this {
@@ -179,6 +189,19 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
       this.#reqReader.cancel().catch((error) => {
         console.error(error);
       });
+    }
+    // If the socket is torn down before the response finished (e.g. the client
+    // aborted), close the response body stream so consumers reading it don't
+    // hang waiting for chunks that will never arrive.
+    if (!this.#resBodyClosed) {
+      this.#resBodyClosed = true;
+      try {
+        this.#resBodyController?.error(
+          err ?? new Error("Connection closed before response was finished"),
+        );
+      } catch {
+        // controller may already be closed/errored
+      }
     }
     this.readyState = "closed";
     cb(err ?? undefined);

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -147,6 +147,56 @@ describe("adapters", () => {
   test("toNodeHandler(toFetchHandler())", async () => {
     expect(toNodeHandler(toFetchHandler(simpleNodeHandler))).toBe(simpleNodeHandler);
   });
+
+  // https://github.com/h3js/srvx/issues/208
+  test("backpressure-aware handler does not deadlock", async () => {
+    const backpressureHandler: NodeHttp1Handler = (_req, res) => {
+      return (async () => {
+        res.statusCode = 200;
+        res.setHeader("content-type", "text/html");
+        // Write well past the socket highWaterMark so write() returns false and
+        // the handler has to wait for a "drain" event to resume.
+        for (let i = 0; i < 20; i++) {
+          if (!res.write("x".repeat(5000))) {
+            await new Promise<void>((resolve) => res.once("drain", () => resolve()));
+          }
+        }
+        res.end();
+      })();
+    };
+    const webHandler = toFetchHandler(backpressureHandler);
+
+    const body = await Promise.race([
+      Promise.resolve(webHandler(new Request("http://localhost/"))).then((r) => r.text()),
+      new Promise<string>((_, reject) =>
+        setTimeout(() => reject(new Error("deadlocked waiting for response")), 3000),
+      ),
+    ]);
+
+    expect(body.length).toBe(20 * 5000);
+  });
+
+  // https://github.com/h3js/srvx/issues/208
+  test("already-aborted request signal does not crash or hang", async () => {
+    const webHandler = toFetchHandler(simpleNodeHandler);
+
+    const controller = new AbortController();
+    controller.abort();
+
+    // Must not throw an unhandled error / crash the process, must settle, and
+    // reading the body must not hang on a stream that never closes.
+    const settled = await Promise.race([
+      Promise.resolve(webHandler(new Request("http://localhost/", { signal: controller.signal })))
+        .then((res) => res.text())
+        .then(
+          () => "completed",
+          () => "errored",
+        ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("hung"), 3000)),
+    ]);
+
+    expect(settled).not.toBe("hung");
+  });
 });
 
 describe("request signal", () => {

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -197,6 +197,42 @@ describe("adapters", () => {
 
     expect(settled).not.toBe("hung");
   });
+
+  // https://github.com/h3js/srvx/issues/208
+  test("client abort mid-stream does not crash or hang", async () => {
+    const controller = new AbortController();
+
+    // Streams a chunk, then drops the client while the response is still open.
+    // Exercises the asynchronous abort path (addAbortSignal -> socket.destroy
+    // after construction) and the _destroy() teardown erroring an already-open
+    // response body controller that has enqueued data.
+    const abortHandler: NodeHttp1Handler = (_req, res) => {
+      return new Promise<void>((resolve) => {
+        const done = () => resolve();
+        res.on("close", done);
+        res.on("error", done);
+        res.statusCode = 200;
+        res.setHeader("content-type", "text/html");
+        res.write("partial");
+        controller.abort();
+      });
+    };
+    const webHandler = toFetchHandler(abortHandler);
+
+    // Must settle (not hang) and must not crash the process with an unhandled
+    // socket "error" event.
+    const settled = await Promise.race([
+      Promise.resolve(webHandler(new Request("http://localhost/", { signal: controller.signal })))
+        .then((res) => res.text())
+        .then(
+          () => "completed",
+          () => "errored",
+        ),
+      new Promise<string>((resolve) => setTimeout(() => resolve("hung"), 3000)),
+    ]);
+
+    expect(settled).not.toBe("hung");
+  });
 });
 
 describe("request signal", () => {


### PR DESCRIPTION
Fixes #208



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Resolved potential deadlocks in streaming responses under heavy backpressure, including cases requiring proper `drain` handling.
* Improved reliability when clients disconnect early, ensuring socket-level errors are detected and propagated.
* Enhanced `drain` behavior so backpressure events don’t fire after the response is already closed or finished.
* Prevented request/response hangs by improving abort-signal wiring and fetch-side handling for aborted and premature-close scenarios (returning consistent error responses when appropriate).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->