### PR TITLE
docs(cli): document static file serving

### DIFF
--- a/docs/1.guide/9.cli.md
+++ b/docs/1.guide/9.cli.md
@@ -42,6 +42,7 @@ $ srvx serve --entry ./server.ts    # Start development server
 $ srvx serve --prod                 # Start production  server
 $ srvx serve --port=8080            # Listen on port 8080
 $ srvx serve --host=localhost       # Bind to localhost only
+$ srvx serve --static=./dist        # Serve static files (no entry needed)
 $ srvx serve --import=jiti/register # Enable [jiti](https://github.com/unjs/jiti) loader
 $ srvx serve --tls --cert=cert.pem --key=key.pem  # Enable TLS (HTTPS/HTTP2)
 
@@ -90,3 +91,27 @@ ENVIRONMENT
 ```
 
 <!-- /automd -->
+
+## Serving static files
+
+The CLI can serve a directory of static files, similar to [`serve`](https://github.com/vercel/serve). No server entry is required &mdash; point `--static` at any folder:
+
+```bash
+npx srvx --static ./dist
+```
+
+If `--static` is omitted, srvx serves files from a `public/` directory when one exists. When both a server entry and a static directory are present, static files take priority and unmatched requests fall through to your handler.
+
+Static serving includes automatic `index.html` resolution, `.html` extension fallback (e.g. `/about` → `about.html`), common MIME types, gzip/Brotli compression, and path-traversal protection.
+
+For programmatic usage, import the [`serveStatic`](https://github.com/h3js/srvx/blob/main/src/static.ts) middleware:
+
+```js
+import { serve } from "srvx";
+import { serveStatic } from "srvx/static";
+
+serve({
+  middleware: [serveStatic({ dir: "public" })],
+  fetch: () => new Response("Not found", { status: 404 }),
+});
+```

--- a/docs/1.guide/9.cli.md
+++ b/docs/1.guide/9.cli.md
@@ -106,7 +106,7 @@ Static serving includes automatic `index.html` resolution, `.html` extension fal
 
 For programmatic usage, import the [`serveStatic`](https://github.com/h3js/srvx/blob/main/src/static.ts) middleware:
 
-```js
+```ts [server.ts]
 import { serve } from "srvx";
 import { serveStatic } from "srvx/static";
 

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -19,6 +19,7 @@ ${c.gray("$")} ${c.cyan(command)} serve --entry ${c.gray("./server.ts")}    ${c.
 ${c.gray("$")} ${c.cyan(command)} serve --prod                 ${c.gray("# Start production  server")}
 ${c.gray("$")} ${c.cyan(command)} serve --port=8080            ${c.gray("# Listen on port 8080")}
 ${c.gray("$")} ${c.cyan(command)} serve --host=localhost       ${c.gray("# Bind to localhost only")}
+${c.gray("$")} ${c.cyan(command)} serve --static=./dist        ${c.gray("# Serve static files (no entry needed)")}
 ${c.gray("$")} ${c.cyan(command)} serve --import=jiti/register ${c.gray(`# Enable ${c.url("jiti", "https://github.com/unjs/jiti")} loader`)}
 ${c.gray("$")} ${c.cyan(command)} serve --tls --cert=cert.pem --key=key.pem  ${c.gray("# Enable TLS (HTTPS/HTTP2)")}
 


### PR DESCRIPTION
Documents static file serving in the CLI, which was already supported but undocumented.

- Add a `--static` example to the CLI usage/help block
- Add a "Serving static files" section to the CLI guide covering the `serve`-equivalent `npx srvx --static ./dist`, default `public/` behavior, fall-through to the handler, and programmatic `serveStatic` usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for serving static files using the `--static` flag with practical examples.
  * Documented features: index resolution, HTML fallback, MIME types, compression, and path-traversal protection.
  * Included programmatic usage examples for developers integrating static file serving.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->