### PR TITLE
fix(node): case-insensitive content-length/content-type dedup in FastResponse

### DIFF
--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -170,9 +170,10 @@ export const NodeResponse: {
           } else {
             headers.push([key, value]);
           }
-          if (key === "content-type") {
+          const lowerKey = typeof key === "string" ? key.toLowerCase() : key;
+          if (lowerKey === "content-type") {
             hasContentTypeHeader = true;
-          } else if (key === "content-length") {
+          } else if (lowerKey === "content-length") {
             hasContentLength = true;
           }
         }

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -3,7 +3,13 @@ import type { AddressInfo } from "node:net";
 import { describe, expect, test } from "vitest";
 
 import type { NodeHttp1Handler, NodeServerRequest, NodeServerResponse } from "../src/types.ts";
-import { fetchNodeHandler, serve, toNodeHandler, toFetchHandler } from "../src/adapters/node.ts";
+import {
+  fetchNodeHandler,
+  FastResponse,
+  serve,
+  toNodeHandler,
+  toFetchHandler,
+} from "../src/adapters/node.ts";
 
 import express from "express";
 import fastify from "fastify";
@@ -385,5 +391,49 @@ describe("node server startup", () => {
       await expect(server.ready()).rejects.toMatchObject({ code: "EADDRINUSE" });
       await server.close();
     });
+  });
+});
+
+describe("FastResponse header dedup", () => {
+  const contentLengthEntries = (headers: [string, string][]) =>
+    headers.filter(([key]) => key.toLowerCase() === "content-length");
+  const contentTypeEntries = (headers: [string, string][]) =>
+    headers.filter(([key]) => key.toLowerCase() === "content-type");
+
+  test("does not duplicate capitalized array-form Content-Length", () => {
+    const { headers } = new FastResponse("hello", {
+      headers: [["Content-Length", "999"]],
+    })._toNodeResponse();
+    const cl = contentLengthEntries(headers);
+    expect(cl).toHaveLength(1);
+    expect(cl[0]).toEqual(["Content-Length", "999"]);
+  });
+
+  test("does not duplicate capitalized array-form Content-Type", () => {
+    const { headers } = new FastResponse("hello", {
+      headers: [["Content-Type", "text/html"]],
+    })._toNodeResponse();
+    const ct = contentTypeEntries(headers);
+    expect(ct).toHaveLength(1);
+    expect(ct[0]).toEqual(["Content-Type", "text/html"]);
+    expect(headers).not.toContainEqual(["content-type", "text/plain; charset=UTF-8"]);
+  });
+
+  test("lowercase array-form Content-Length still dedups", () => {
+    const { headers } = new FastResponse("hello", {
+      headers: [["content-length", "999"]],
+    })._toNodeResponse();
+    const cl = contentLengthEntries(headers);
+    expect(cl).toHaveLength(1);
+    expect(cl[0]).toEqual(["content-length", "999"]);
+  });
+
+  test("auto-computes Content-Length when user provides none", () => {
+    const { headers } = new FastResponse("hello", {
+      headers: [["X-Custom", "1"]],
+    })._toNodeResponse();
+    const cl = contentLengthEntries(headers);
+    expect(cl).toHaveLength(1);
+    expect(cl[0]).toEqual(["content-length", "5"]);
   });
 });


### PR DESCRIPTION
## The bug

`FastResponse._toNodeResponse()` in `src/adapters/_node/response.ts` decides whether to append an auto-computed `content-length`/`content-type` header by checking whether the user already supplied one. The dedup check was **case-sensitive**:

```js
if (key === "content-type") { hasContentTypeHeader = true; }
else if (key === "content-length") { hasContentLength = true; }
```

When `ResponseInit.headers` is passed in **array form** with a capitalized name (e.g. `[["Content-Length","999"]]`), the key is not lowercased (unlike the `Headers`-object and plain-object paths, which do `k.toLowerCase()`). The check never matched, so srvx appended a **second** header.

Reproduction:

```js
new FastResponse("hello", { headers: [["Content-Length","999"]] })._toNodeResponse().headers
// → [["Content-Length","999"],["content-type","text/plain; charset=UTF-8"],["content-length","5"]]  // two content-length
```

## Impact

- Two conflicting `Content-Length` headers on the wire (Node emits both) — a response-desync / request-smuggling primitive.
- Duplicate `Content-Type` headers.

## The fix

Lowercase the header key for the comparison only, preserving the user's original casing in the output `headers` array:

```js
const lowerKey = typeof key === "string" ? key.toLowerCase() : key;
if (lowerKey === "content-type") { hasContentTypeHeader = true; }
else if (lowerKey === "content-length") { hasContentLength = true; }
```

## Tests

Added a focused `FastResponse header dedup` block in `test/node-adapters.test.ts` asserting:
- capitalized array-form `Content-Length` yields exactly one `content-length` (the user's value);
- capitalized array-form `Content-Type` yields exactly one `content-type` (the user's), with no auto-added `text/plain`;
- lowercase array-form still dedups (regression);
- a body with no user content-length still gets the auto-computed one.

All 22 tests in the file pass. Lint, format, and typecheck are clean.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved header handling so `Content-Type` and `Content-Length` are recognized consistently, even when written with different capitalization.
  * Prevented duplicate `Content-Type` and `Content-Length` headers in responses.
  * Responses now automatically include `Content-Length` when it isn’t provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->