### PR TITLE
fix(url): deopt FastURL for query percent-encode-set chars (" ' < >)

### DIFF
--- a/src/_url.ts
+++ b/src/_url.ts
@@ -20,6 +20,15 @@ export type URLInit = {
 const _needsNormRE =
   /(?:(?:^|\/)(?:\.|\.\.|%2e|%2e\.|\.%2e|%2e%2e)(?:\/|$))|[\\^#"<>{}`\x80-\uffff]/i;
 
+// Query percent-encode set chars the WHATWG URL parser rewrites but the verbatim
+// fast path would keep raw. Native percent-encodes `" ' < >` in the query (note
+// this set is narrower than the path set: `` ` `` `{` `}` are NOT encoded in the
+// query); `#` starts a fragment the fast path must not fold into search. When any
+// appears in the query \u2014 or, for a raw origin-form string, anywhere (`" < >` also
+// need encoding in the path) \u2014 we deopt to native parsing.
+// (Control chars and space are rejected by Node's HTTP parser, so unreachable.)
+const _searchNeedsNormRE = /[#"'<>]/;
+
 /**
  * URL wrapper with fast paths to access to the following props:
  *
@@ -51,13 +60,17 @@ export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
       constructor(url: string | URLInit) {
         if (typeof url === "string") {
           const isOriginForm = url[0] === "/";
-          if (isOriginForm && !url.includes("#")) {
+          if (isOriginForm && !_searchNeedsNormRE.test(url)) {
             this.#href = url;
           } else {
-            // Absolute-form or a target with a fragment (#) needs full parsing
+            // Absolute-form, or a target with a fragment (#) / query percent-encode
+            // set chars (" ' < >) that need full parsing to match native.
             this.#url = new NativeURL(isOriginForm ? `http://localhost${url}` : url);
           }
-        } else if (_needsNormRE.test(url.pathname) || url.search?.includes("#")) {
+        } else if (
+          _needsNormRE.test(url.pathname) ||
+          (url.search && _searchNeedsNormRE.test(url.search))
+        ) {
           this.#url = new NativeURL(
             `${url.protocol || "http:"}//${url.host || "localhost"}${url.pathname}${url.search || ""}`,
           );

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -312,6 +312,48 @@ describe("FastURL", () => {
     }
   });
 
+  describe("query percent-encode set in request target", () => {
+    // Characters Node's HTTP parser delivers verbatim but the WHATWG URL parser
+    // percent-encodes in the query (" ' < >). This set is narrower than the path
+    // set (` { } are NOT encoded in the query). The fast path must match native so
+    // `url.search` / `url.href` stay consistent with `new URL(url.href)` — apps that
+    // reflect the raw query into HTML are XSS-safe on Deno/Bun/CF but would leak raw
+    // `< > " '` under Node's fast path otherwise. Same interpretation-conflict class
+    // (CWE-436) as the path/fragment cases; `searchParams` decodes identically.
+    // (Control chars and space are rejected by Node with 400, so excluded.)
+    const chars = ['"', "'", "<", ">"];
+
+    for (const ch of chars) {
+      const input = `/p?x=${ch}a${ch}`;
+      test(`FastURL "${input}" matches native search & href`, () => {
+        const std = new URL(`http://localhost${input}`);
+        expect(std.search).not.toBe(`?x=${ch}a${ch}`); // sanity: native encoded it
+
+        const url = new NodeRequestURL({
+          req: { url: input, headers: { host: "localhost" } } as any,
+        });
+        expect(url.search, ".search").toBe(std.search);
+        expect(url.href, ".href").toBe(std.href);
+        // searchParams still decodes to the raw value
+        expect(url.searchParams.get("x"), ".searchParams x").toBe(`${ch}a${ch}`);
+        expect(url.searchParams.get("x")).toBe(std.searchParams.get("x"));
+      });
+    }
+
+    test("path + query combined matches native", () => {
+      const input = `/a<b?y=>c&z="d'`;
+      const std = new URL(`http://localhost${input}`);
+      const url = new NodeRequestURL({
+        req: { url: input, headers: { host: "localhost" } } as any,
+      });
+      expect(url.pathname, ".pathname").toBe(std.pathname);
+      expect(url.search, ".search").toBe(std.search);
+      expect(url.href, ".href").toBe(std.href);
+      expect(url.searchParams.get("y"), ".searchParams y").toBe(">c");
+      expect(url.searchParams.get("z"), ".searchParams z").toBe("\"d'");
+    });
+  });
+
   describe("pathname normalization", () => {
     const cases = [
       // Literal dot segments


### PR DESCRIPTION
## The divergence

`FastURL` (`src/_url.ts`) has a verbatim fast path that avoids full `new URL()` parsing. It kept the query percent-encode-set characters `"`, `'`, `<`, `>` **verbatim** in the query string, whereas the WHATWG URL parser (and every other runtime — Deno / Bun / Cloudflare) percent-encodes them:

```
new URL("http://h/p?x=<a>").search      → "?x=%3Ca%3E"   (native / other runtimes)
FastURL fast path for "/p?x=<a>"        → "?x=<a>"        (before this fix)
```

`url.searchParams` decodes identically, so the divergence was confined to the raw `.search` / `.href` strings — but those are exactly what apps reflect into HTML. An app that is XSS-safe on Deno/Bun/CF (because the runtime encoded `< > " '` for it) could have reflected XSS **only** under Node's fast path.

This is the same CWE-436 interpretation-conflict class already hardened for the pathname (see the `path percent-encode set in request target` tests and the `_needsNormRE` char class). The query set is intentionally **narrower** than the path set: `` ` ``, `{`, `}` are NOT percent-encoded in the query (only in the path), and `#` is already handled by the existing fragment guard. Space / control chars are rejected by Node's HTTP parser with 400, so they are unreachable.

## The fix

Added a dedicated `_searchNeedsNormRE = /[#"'<>]/` and made the fast path deopt to native `new URL()` parsing when it matches:

- **URLInit branch** (feeds `NodeRequestURL`): the search guard `url.search?.includes("#")` is extended to `url.search && _searchNeedsNormRE.test(url.search)`.
- **String origin-form branch**: the guard `!url.includes("#")` becomes `!_searchNeedsNormRE.test(url)`, so `" ' < >` in path or query also force native parsing (the branch previously stored the target href verbatim without running any normalization).

End state: for a request target with `"`, `'`, `<`, or `>` anywhere in path or query, `FastURL.search`, `.pathname`, and `.href` now equal `new URL("http://host" + target)`, while `.searchParams` still decodes correctly.

## Tests

Added a `describe("query percent-encode set in request target", ...)` block in `test/url.test.ts`, analogous to the existing path block: for each of `"` `'` `<` `>` in the query it asserts `NodeRequestURL`'s `.search` and `.href` match native `new URL`, that native actually encoded (sanity), and that `.searchParams` still decodes. A combined path+query case (`/a<b?y=>c&z="d'`) is also covered.

`pnpm lint`, `pnpm typecheck`, and `pnpm vitest run test/url.test.ts` (556 passed / 26 skipped) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling so query strings with special characters now match standard browser/Node parsing more reliably.
  * Fixed cases where certain path and query combinations could produce inconsistent `href`, `search`, or `pathname` values.
  * Preserved expected decoding behavior in query parameters while aligning serialized URLs with native URL behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->