### PR TITLE
feat: `maxRequestBodySize` server option

### DIFF
--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -123,6 +123,41 @@ serve({
 });
 ```
 
+### `maxRequestBodySize`
+
+Maximum allowed size **in bytes** for the request body. Defaults to `undefined` (no limit).
+
+As the body is read, its accumulated length is tracked and, once it exceeds the limit, reading is aborted and rejects with a `413`-style error. The error carries `statusCode: 413`, `status: 413` and `code: "ERR_BODY_TOO_LARGE"`, so a handler (or [`onError`](#onerror)) can map it to an HTTP `413 Payload Too Large` response.
+
+The limit covers both buffered reads (`request.text()` / `request.json()`) and the streamed body (`request.body`, and therefore `request.arrayBuffer()` / `.blob()` / `.bytes()` / `.formData()`).
+
+**Example:**
+
+```js
+import { serve } from "srvx";
+
+serve({
+  maxRequestBodySize: 1024 * 1024, // 1 MiB
+  fetch: async (request) => {
+    try {
+      return Response.json(await request.json());
+    } catch (error) {
+      if (error.code === "ERR_BODY_TOO_LARGE") {
+        return new Response("Payload Too Large", { status: 413 });
+      }
+      throw error;
+    }
+  },
+});
+```
+
+> [!NOTE]
+> Runtime support:
+>
+> - **Node**: enforced by srvx (the request body stream is size-limited).
+> - **Bun**: forwarded to Bun's native [`maxRequestBodySize`](https://bun.sh/docs/api/http), enforced by Bun (responds with `413` before the handler runs).
+> - **Deno**: enforced by srvx (`Deno.serve` has no native option).
+
 ## Runtime Specific Options
 
 ### Node.js

--- a/src/_body-limit.ts
+++ b/src/_body-limit.ts
@@ -4,24 +4,27 @@
 
 /**
  * Creates a `413 Payload Too Large` style error for when a request body exceeds
- * the configured `maxBodySize`. The `statusCode` / `status` properties let a
+ * the configured `maxRequestBodySize`. The `statusCode` / `status` properties let a
  * handler map it to an HTTP 413 response.
  */
-export function createBodyTooLargeError(maxBodySize: number): Error {
+export function createBodyTooLargeError(maxRequestBodySize: number): Error {
   return Object.assign(
-    new Error(`Request body exceeds the maximum allowed size of ${maxBodySize} bytes.`),
+    new Error(`Request body exceeds the maximum allowed size of ${maxRequestBodySize} bytes.`),
     { code: "ERR_BODY_TOO_LARGE", statusCode: 413, status: 413 },
   );
 }
 
 /**
  * Wraps a body `ReadableStream` so the total number of bytes read cannot exceed
- * `maxBodySize`. Once the limit is passed the wrapped stream errors with a
+ * `maxRequestBodySize`. Once the limit is passed the wrapped stream errors with a
  * `413`-style error and the upstream stream is cancelled. This is pull-based, so
  * it preserves backpressure and stops reading as soon as the limit is hit rather
  * than buffering the whole body first.
  */
-export function limitBodyStream(stream: ReadableStream, maxBodySize: number): ReadableStream {
+export function limitBodyStream(
+  stream: ReadableStream,
+  maxRequestBodySize: number,
+): ReadableStream {
   const reader = stream.getReader();
   let size = 0;
   return new ReadableStream({
@@ -32,8 +35,8 @@ export function limitBodyStream(stream: ReadableStream, maxBodySize: number): Re
         return;
       }
       size += (value as Uint8Array).byteLength;
-      if (size > maxBodySize) {
-        const error = createBodyTooLargeError(maxBodySize);
+      if (size > maxRequestBodySize) {
+        const error = createBodyTooLargeError(maxRequestBodySize);
         reader.cancel(error).catch(() => {});
         controller.error(error);
         return;
@@ -47,17 +50,17 @@ export function limitBodyStream(stream: ReadableStream, maxBodySize: number): Re
 }
 
 /**
- * Returns a `Request` whose body is size-limited to `maxBodySize`. If the request
+ * Returns a `Request` whose body is size-limited to `maxRequestBodySize`. If the request
  * has no body it is returned unchanged; otherwise it is rebuilt with a limited
  * body stream (method, url, headers and signal are preserved). Used for runtimes
  * that expose a native `Request` but no body-size option (e.g. Deno).
  */
-export function limitRequestBody(request: Request, maxBodySize: number): Request {
+export function limitRequestBody(request: Request, maxRequestBodySize: number): Request {
   if (!request.body) {
     return request;
   }
   return new Request(request, {
-    body: limitBodyStream(request.body, maxBodySize),
+    body: limitBodyStream(request.body, maxRequestBodySize),
     // @ts-expect-error `duplex` is required for a streaming request body.
     duplex: "half",
   });

--- a/src/_body-limit.ts
+++ b/src/_body-limit.ts
@@ -1,0 +1,64 @@
+// Runtime-agnostic request body size limiting (web streams only, no Node APIs).
+// Used by adapters that don't have a native body-size option (Node, Deno).
+// Bun enforces natively via `maxRequestBodySize`.
+
+/**
+ * Creates a `413 Payload Too Large` style error for when a request body exceeds
+ * the configured `maxBodySize`. The `statusCode` / `status` properties let a
+ * handler map it to an HTTP 413 response.
+ */
+export function createBodyTooLargeError(maxBodySize: number): Error {
+  return Object.assign(
+    new Error(`Request body exceeds the maximum allowed size of ${maxBodySize} bytes.`),
+    { code: "ERR_BODY_TOO_LARGE", statusCode: 413, status: 413 },
+  );
+}
+
+/**
+ * Wraps a body `ReadableStream` so the total number of bytes read cannot exceed
+ * `maxBodySize`. Once the limit is passed the wrapped stream errors with a
+ * `413`-style error and the upstream stream is cancelled. This is pull-based, so
+ * it preserves backpressure and stops reading as soon as the limit is hit rather
+ * than buffering the whole body first.
+ */
+export function limitBodyStream(stream: ReadableStream, maxBodySize: number): ReadableStream {
+  const reader = stream.getReader();
+  let size = 0;
+  return new ReadableStream({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      size += (value as Uint8Array).byteLength;
+      if (size > maxBodySize) {
+        const error = createBodyTooLargeError(maxBodySize);
+        reader.cancel(error).catch(() => {});
+        controller.error(error);
+        return;
+      }
+      controller.enqueue(value);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/**
+ * Returns a `Request` whose body is size-limited to `maxBodySize`. If the request
+ * has no body it is returned unchanged; otherwise it is rebuilt with a limited
+ * body stream (method, url, headers and signal are preserved). Used for runtimes
+ * that expose a native `Request` but no body-size option (e.g. Deno).
+ */
+export function limitRequestBody(request: Request, maxBodySize: number): Request {
+  if (!request.body) {
+    return request;
+  }
+  return new Request(request, {
+    body: limitBodyStream(request.body, maxBodySize),
+    // @ts-expect-error `duplex` is required for a streaming request body.
+    duplex: "half",
+  });
+}

--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -17,13 +17,20 @@ export type AdapterMeta = {
 /**
  * Converts a Fetch API handler to a Node.js HTTP handler.
  */
-export function toNodeHandler(handler: FetchHandler & AdapterMeta): NodeHttpHandler & AdapterMeta {
+export function toNodeHandler(
+  handler: FetchHandler & AdapterMeta,
+  options?: { maxBodySize?: number },
+): NodeHttpHandler & AdapterMeta {
   if (handler.__nodeHandler) {
     return handler.__nodeHandler;
   }
 
   function convertedNodeHandler(nodeReq: NodeServerRequest, nodeRes: NodeServerResponse) {
-    const request = new NodeRequest({ req: nodeReq, res: nodeRes });
+    const request = new NodeRequest({
+      req: nodeReq,
+      res: nodeRes,
+      maxBodySize: options?.maxBodySize,
+    });
     const res = handler(request);
     return res instanceof Promise
       ? res.then((resolvedRes) => sendNodeResponse(nodeRes, resolvedRes))

--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -19,7 +19,7 @@ export type AdapterMeta = {
  */
 export function toNodeHandler(
   handler: FetchHandler & AdapterMeta,
-  options?: { maxBodySize?: number },
+  options?: { maxRequestBodySize?: number },
 ): NodeHttpHandler & AdapterMeta {
   if (handler.__nodeHandler) {
     return handler.__nodeHandler;
@@ -29,7 +29,7 @@ export function toNodeHandler(
     const request = new NodeRequest({
       req: nodeReq,
       res: nodeRes,
-      maxBodySize: options?.maxBodySize,
+      maxRequestBodySize: options?.maxRequestBodySize,
     });
     const res = handler(request);
     return res instanceof Promise

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -2,6 +2,7 @@ import type { NodeServerRequest, NodeServerResponse, ServerRequest } from "../..
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
+import { createBodyTooLargeError, limitBodyStream } from "../../_body-limit.ts";
 import { Readable } from "node:stream";
 
 export type NodeRequestContext = {
@@ -260,50 +261,6 @@ function readBody(req: NodeServerRequest, maxBodySize?: number): Promise<any> {
     };
     req.on("data", onData).once("end", onEnd).once("error", onError);
   });
-}
-
-/**
- * Wraps a body `ReadableStream` so the total number of bytes read cannot exceed
- * `maxBodySize`. Once the limit is passed the wrapped stream errors with a
- * `413`-style error and the upstream (Node request) stream is cancelled. This
- * is pull-based, so it preserves backpressure and stops reading as soon as the
- * limit is hit rather than buffering the whole body first.
- */
-function limitBodyStream(stream: ReadableStream, maxBodySize: number): ReadableStream {
-  const reader = stream.getReader();
-  let size = 0;
-  return new ReadableStream({
-    async pull(controller) {
-      const { done, value } = await reader.read();
-      if (done) {
-        controller.close();
-        return;
-      }
-      size += (value as Uint8Array).byteLength;
-      if (size > maxBodySize) {
-        const error = createBodyTooLargeError(maxBodySize);
-        reader.cancel(error).catch(() => {});
-        controller.error(error);
-        return;
-      }
-      controller.enqueue(value);
-    },
-    cancel(reason) {
-      return reader.cancel(reason);
-    },
-  });
-}
-
-/**
- * Creates a `413 Payload Too Large` style error for when a request body exceeds
- * the configured `maxBodySize`. The `statusCode` / `status` properties let a
- * handler map it to an HTTP 413 response.
- */
-function createBodyTooLargeError(maxBodySize: number): Error {
-  return Object.assign(
-    new Error(`Request body exceeds the maximum allowed size of ${maxBodySize} bytes.`),
-    { code: "ERR_BODY_TOO_LARGE", statusCode: 413, status: 413 },
-  );
 }
 
 /**

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -7,6 +7,11 @@ import { Readable } from "node:stream";
 export type NodeRequestContext = {
   req: NodeServerRequest;
   res?: NodeServerResponse;
+  /**
+   * Maximum allowed size (in bytes) for a body buffered in memory via the
+   * {@link readBody} fallback. See `ServerOptions.maxBodySize`.
+   */
+  maxBodySize?: number;
 };
 
 const kNativeRequest = /* @__PURE__ */ Symbol.for("srvx.nativeRequest");
@@ -25,12 +30,14 @@ export const NodeRequest: {
     #request?: globalThis.Request;
     #headers?: NodeRequestHeaders;
     #abortController?: AbortController;
+    #maxBodySize?: number;
 
     constructor(ctx: NodeRequestContext) {
       this.#req = ctx.req;
+      this.#maxBodySize = ctx.maxBodySize;
       this.runtime = {
         name: "node",
-        node: ctx,
+        node: { req: ctx.req, res: ctx.res },
       };
     }
 
@@ -123,7 +130,7 @@ export const NodeRequest: {
       if (this.#bodyStream !== undefined) {
         return this.#bodyStream ? new Response(this.#bodyStream).text() : Promise.resolve("");
       }
-      return readBody(this.#req).then((buf) => buf.toString());
+      return readBody(this.#req, this.#maxBodySize).then((buf) => buf.toString());
     }
 
     json() {
@@ -192,27 +199,69 @@ export function patchGlobalRequest(): typeof Request {
   return PatchedRequest;
 }
 
-function readBody(req: NodeServerRequest): Promise<any> {
+/**
+ * Buffers the whole request body into a single `Buffer`.
+ *
+ * This is the fallback used by `NodeRequest.text()` / `.json()` when the body was
+ * not consumed as a stream. When `maxBodySize` (bytes) is provided, the accumulated
+ * length is tracked as chunks arrive and, once it is exceeded, reading is aborted
+ * (the stream is paused so a handler can still send a response) and the promise
+ * rejects with a `413`-style error. When `maxBodySize` is `undefined` (the default)
+ * no limit is enforced.
+ */
+function readBody(req: NodeServerRequest, maxBodySize?: number): Promise<any> {
   // https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/5ce5e513d739fdb8388fb0e8b6fd5f52d59604f2/src/server.ts#L62
   if ("rawBody" in req && Buffer.isBuffer(req.rawBody)) {
+    if (maxBodySize !== undefined && req.rawBody.length > maxBodySize) {
+      return Promise.reject(createBodyTooLargeError(maxBodySize));
+    }
     return Promise.resolve(req.rawBody);
   }
 
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
+    let size = 0;
+    const cleanup = () => {
+      req.off("data", onData);
+      req.off("end", onEnd);
+      req.off("error", onError);
+    };
     const onData = (chunk: any) => {
+      if (maxBodySize !== undefined) {
+        size += chunk.length;
+        if (size > maxBodySize) {
+          cleanup();
+          // Stop consuming the body but keep the socket alive so a handler can
+          // still respond (e.g. with an HTTP 413).
+          req.pause?.();
+          reject(createBodyTooLargeError(maxBodySize));
+          return;
+        }
+      }
       chunks.push(chunk);
     };
     const onError = (err: any) => {
+      cleanup();
       reject(err);
     };
     const onEnd = () => {
-      req.off("error", onError);
-      req.off("data", onData);
+      cleanup();
       resolve(Buffer.concat(chunks));
     };
     req.on("data", onData).once("end", onEnd).once("error", onError);
   });
+}
+
+/**
+ * Creates a `413 Payload Too Large` style error for when a buffered request body
+ * exceeds the configured `maxBodySize`. The `statusCode` / `status` properties let
+ * a handler map it to an HTTP 413 response.
+ */
+function createBodyTooLargeError(maxBodySize: number): Error {
+  return Object.assign(
+    new Error(`Request body exceeds the maximum allowed size of ${maxBodySize} bytes.`),
+    { code: "ERR_BODY_TOO_LARGE", statusCode: 413, status: 413 },
+  );
 }
 
 /**

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -8,8 +8,8 @@ export type NodeRequestContext = {
   req: NodeServerRequest;
   res?: NodeServerResponse;
   /**
-   * Maximum allowed size (in bytes) for a body buffered in memory via the
-   * {@link readBody} fallback. See `ServerOptions.maxBodySize`.
+   * Maximum allowed size (in bytes) for the request body, enforced for both the
+   * buffered reads and the streamed body. See `ServerOptions.maxBodySize`.
    */
   maxBodySize?: number;
 };
@@ -118,10 +118,17 @@ export const NodeRequest: {
       if (this.#bodyStream === undefined) {
         const method = this.method;
         const hasBody = !(method === "GET" || method === "HEAD");
-        this.#bodyStream = hasBody
+        let stream = hasBody
           ? // TODO: HTTP2ServerRequest
             (Readable.toWeb(this.#req as NodeJS.ReadableStream) as unknown as ReadableStream)
           : null;
+        // Enforce `maxBodySize` at the single choke point every consumer funnels
+        // through (`request.body`, and therefore the native `Request` methods
+        // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
+        if (stream && this.#maxBodySize !== undefined) {
+          stream = limitBodyStream(stream, this.#maxBodySize);
+        }
+        this.#bodyStream = stream;
       }
       return this.#bodyStream;
     }
@@ -256,9 +263,41 @@ function readBody(req: NodeServerRequest, maxBodySize?: number): Promise<any> {
 }
 
 /**
- * Creates a `413 Payload Too Large` style error for when a buffered request body
- * exceeds the configured `maxBodySize`. The `statusCode` / `status` properties let
- * a handler map it to an HTTP 413 response.
+ * Wraps a body `ReadableStream` so the total number of bytes read cannot exceed
+ * `maxBodySize`. Once the limit is passed the wrapped stream errors with a
+ * `413`-style error and the upstream (Node request) stream is cancelled. This
+ * is pull-based, so it preserves backpressure and stops reading as soon as the
+ * limit is hit rather than buffering the whole body first.
+ */
+function limitBodyStream(stream: ReadableStream, maxBodySize: number): ReadableStream {
+  const reader = stream.getReader();
+  let size = 0;
+  return new ReadableStream({
+    async pull(controller) {
+      const { done, value } = await reader.read();
+      if (done) {
+        controller.close();
+        return;
+      }
+      size += (value as Uint8Array).byteLength;
+      if (size > maxBodySize) {
+        const error = createBodyTooLargeError(maxBodySize);
+        reader.cancel(error).catch(() => {});
+        controller.error(error);
+        return;
+      }
+      controller.enqueue(value);
+    },
+    cancel(reason) {
+      return reader.cancel(reason);
+    },
+  });
+}
+
+/**
+ * Creates a `413 Payload Too Large` style error for when a request body exceeds
+ * the configured `maxBodySize`. The `statusCode` / `status` properties let a
+ * handler map it to an HTTP 413 response.
  */
 function createBodyTooLargeError(maxBodySize: number): Error {
   return Object.assign(

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -37,7 +37,10 @@ export const NodeRequest: {
       this.#maxBodySize = ctx.maxBodySize;
       this.runtime = {
         name: "node",
-        node: { req: ctx.req, res: ctx.res },
+        // Reuse the context object as-is to avoid a per-request allocation on
+        // the hot path. `maxBodySize` may ride along but is intentionally not
+        // part of the public `runtime.node` type; consumers only read req/res.
+        node: ctx,
       };
     }
 

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -10,9 +10,9 @@ export type NodeRequestContext = {
   res?: NodeServerResponse;
   /**
    * Maximum allowed size (in bytes) for the request body, enforced for both the
-   * buffered reads and the streamed body. See `ServerOptions.maxBodySize`.
+   * buffered reads and the streamed body. See `ServerOptions.maxRequestBodySize`.
    */
-  maxBodySize?: number;
+  maxRequestBodySize?: number;
 };
 
 const kNativeRequest = /* @__PURE__ */ Symbol.for("srvx.nativeRequest");
@@ -31,15 +31,15 @@ export const NodeRequest: {
     #request?: globalThis.Request;
     #headers?: NodeRequestHeaders;
     #abortController?: AbortController;
-    #maxBodySize?: number;
+    #maxRequestBodySize?: number;
 
     constructor(ctx: NodeRequestContext) {
       this.#req = ctx.req;
-      this.#maxBodySize = ctx.maxBodySize;
+      this.#maxRequestBodySize = ctx.maxRequestBodySize;
       this.runtime = {
         name: "node",
         // Reuse the context object as-is to avoid a per-request allocation on
-        // the hot path. `maxBodySize` may ride along but is intentionally not
+        // the hot path. `maxRequestBodySize` may ride along but is intentionally not
         // part of the public `runtime.node` type; consumers only read req/res.
         node: ctx,
       };
@@ -123,11 +123,11 @@ export const NodeRequest: {
           ? // TODO: HTTP2ServerRequest
             (Readable.toWeb(this.#req as NodeJS.ReadableStream) as unknown as ReadableStream)
           : null;
-        // Enforce `maxBodySize` at the single choke point every consumer funnels
+        // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
         // through (`request.body`, and therefore the native `Request` methods
         // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
-        if (stream && this.#maxBodySize !== undefined) {
-          stream = limitBodyStream(stream, this.#maxBodySize);
+        if (stream && this.#maxRequestBodySize !== undefined) {
+          stream = limitBodyStream(stream, this.#maxRequestBodySize);
         }
         this.#bodyStream = stream;
       }
@@ -141,7 +141,7 @@ export const NodeRequest: {
       if (this.#bodyStream !== undefined) {
         return this.#bodyStream ? new Response(this.#bodyStream).text() : Promise.resolve("");
       }
-      return readBody(this.#req, this.#maxBodySize).then((buf) => buf.toString());
+      return readBody(this.#req, this.#maxRequestBodySize).then((buf) => buf.toString());
     }
 
     json() {
@@ -214,17 +214,17 @@ export function patchGlobalRequest(): typeof Request {
  * Buffers the whole request body into a single `Buffer`.
  *
  * This is the fallback used by `NodeRequest.text()` / `.json()` when the body was
- * not consumed as a stream. When `maxBodySize` (bytes) is provided, the accumulated
+ * not consumed as a stream. When `maxRequestBodySize` (bytes) is provided, the accumulated
  * length is tracked as chunks arrive and, once it is exceeded, reading is aborted
  * (the stream is paused so a handler can still send a response) and the promise
- * rejects with a `413`-style error. When `maxBodySize` is `undefined` (the default)
+ * rejects with a `413`-style error. When `maxRequestBodySize` is `undefined` (the default)
  * no limit is enforced.
  */
-function readBody(req: NodeServerRequest, maxBodySize?: number): Promise<any> {
+function readBody(req: NodeServerRequest, maxRequestBodySize?: number): Promise<any> {
   // https://github.com/GoogleCloudPlatform/functions-framework-nodejs/blob/5ce5e513d739fdb8388fb0e8b6fd5f52d59604f2/src/server.ts#L62
   if ("rawBody" in req && Buffer.isBuffer(req.rawBody)) {
-    if (maxBodySize !== undefined && req.rawBody.length > maxBodySize) {
-      return Promise.reject(createBodyTooLargeError(maxBodySize));
+    if (maxRequestBodySize !== undefined && req.rawBody.length > maxRequestBodySize) {
+      return Promise.reject(createBodyTooLargeError(maxRequestBodySize));
     }
     return Promise.resolve(req.rawBody);
   }
@@ -238,14 +238,14 @@ function readBody(req: NodeServerRequest, maxBodySize?: number): Promise<any> {
       req.off("error", onError);
     };
     const onData = (chunk: any) => {
-      if (maxBodySize !== undefined) {
+      if (maxRequestBodySize !== undefined) {
         size += chunk.length;
-        if (size > maxBodySize) {
+        if (size > maxRequestBodySize) {
           cleanup();
           // Stop consuming the body but keep the socket alive so a handler can
           // still respond (e.g. with an HTTP 413).
           req.pause?.();
-          reject(createBodyTooLargeError(maxBodySize));
+          reject(createBodyTooLargeError(maxRequestBodySize));
           return;
         }
       }

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -76,6 +76,12 @@ class BunServer implements Server<BunFetchHandler> {
       ...resolvePortAndHost(this.options),
       reusePort: this.options.reusePort,
       error: this.options.error,
+      // Map the generic `maxBodySize` to Bun's native option (enforced by Bun,
+      // returning 413 before the handler runs). An explicit `bun.maxRequestBodySize`
+      // below still wins.
+      ...(this.options.maxBodySize !== undefined
+        ? { maxRequestBodySize: this.options.maxBodySize }
+        : {}),
       ...(this.options.bun as any),
       tls: {
         cert: tls?.cert,

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -76,11 +76,11 @@ class BunServer implements Server<BunFetchHandler> {
       ...resolvePortAndHost(this.options),
       reusePort: this.options.reusePort,
       error: this.options.error,
-      // Map the generic `maxBodySize` to Bun's native option (enforced by Bun,
+      // Forward `maxRequestBodySize` to Bun's native serve option (Bun enforces it,
       // returning 413 before the handler runs). An explicit `bun.maxRequestBodySize`
       // below still wins.
-      ...(this.options.maxBodySize !== undefined
-        ? { maxRequestBodySize: this.options.maxBodySize }
+      ...(this.options.maxRequestBodySize !== undefined
+        ? { maxRequestBodySize: this.options.maxRequestBodySize }
         : {}),
       ...(this.options.bun as any),
       tls: {

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -9,6 +9,7 @@ import {
 } from "../_utils.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { gracefulShutdownPlugin } from "../_plugins.ts";
+import { limitRequestBody } from "../_body-limit.ts";
 
 export { FastURL } from "../_url.ts";
 export const FastResponse: typeof globalThis.Response = Response;
@@ -57,7 +58,14 @@ class DenoServer implements Server<DenoFetchHandler> {
     this.#wait = createWaitUntil();
     this.waitUntil = this.#wait.waitUntil;
 
+    const maxBodySize = this.options.maxBodySize;
     this.fetch = (request, info) => {
+      // Deno.serve has no native body-size option, so enforce it here by
+      // rebuilding the request with a size-limited body stream (no-op when unset
+      // or bodyless, keeping the default hot path allocation-free).
+      if (maxBodySize !== undefined) {
+        request = limitRequestBody(request, maxBodySize);
+      }
       Object.defineProperties(request, {
         waitUntil: { value: this.#wait?.waitUntil },
         runtime: {

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -58,13 +58,13 @@ class DenoServer implements Server<DenoFetchHandler> {
     this.#wait = createWaitUntil();
     this.waitUntil = this.#wait.waitUntil;
 
-    const maxBodySize = this.options.maxBodySize;
+    const maxRequestBodySize = this.options.maxRequestBodySize;
     this.fetch = (request, info) => {
       // Deno.serve has no native body-size option, so enforce it here by
       // rebuilding the request with a size-limited body stream (no-op when unset
       // or bodyless, keeping the default hot path allocation-free).
-      if (maxBodySize !== undefined) {
-        request = limitRequestBody(request, maxBodySize);
+      if (maxRequestBodySize !== undefined) {
+        request = limitRequestBody(request, maxRequestBodySize);
       }
       Object.defineProperties(request, {
         waitUntil: { value: this.#wait?.waitUntil },

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -75,7 +75,11 @@ class NodeServer implements Server {
         nodeRes.end();
         return;
       }
-      const request = new NodeRequest({ req: nodeReq, res: nodeRes });
+      const request = new NodeRequest({
+        req: nodeReq,
+        res: nodeRes,
+        maxBodySize: this.options.maxBodySize,
+      });
       request.waitUntil = this.#wait?.waitUntil;
       const res = fetchHandler(request);
       return res instanceof Promise

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -78,7 +78,7 @@ class NodeServer implements Server {
       const request = new NodeRequest({
         req: nodeReq,
         res: nodeRes,
-        maxBodySize: this.options.maxBodySize,
+        maxRequestBodySize: this.options.maxRequestBodySize,
       });
       request.waitUntil = this.#wait?.waitUntil;
       const res = fetchHandler(request);

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,7 +141,7 @@ export interface ServerOptions {
    *
    * @default undefined (no limit)
    */
-  maxBodySize?: number;
+  maxRequestBodySize?: number;
 
   /**
    * TLS server options.

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,6 +123,23 @@ export interface ServerOptions {
   gracefulShutdown?: boolean | { gracefulTimeout?: number; forceTimeout?: number };
 
   /**
+   * Maximum allowed size (in bytes) for a request body that is buffered in memory.
+   *
+   * This guards the Node.js fallback path used by `request.text()` / `request.json()`
+   * when the body is consumed as a whole instead of being streamed. As chunks arrive,
+   * their accumulated length is tracked and, once it exceeds this limit, reading is
+   * aborted and rejects with a `413`-style error (the error has `statusCode: 413`,
+   * `status: 413` and `code: "ERR_BODY_TOO_LARGE"`) so a handler can map it to an
+   * HTTP 413 (Payload Too Large) response.
+   *
+   * **Note:** Currently only enforced for the Node.js runtime buffered body fallback.
+   * Streaming consumers (`request.body`) are not affected.
+   *
+   * @default undefined (no limit)
+   */
+  maxBodySize?: number;
+
+  /**
    * TLS server options.
    */
   tls?: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -123,17 +123,18 @@ export interface ServerOptions {
   gracefulShutdown?: boolean | { gracefulTimeout?: number; forceTimeout?: number };
 
   /**
-   * Maximum allowed size (in bytes) for a request body that is buffered in memory.
+   * Maximum allowed size (in bytes) for the request body.
    *
-   * This guards the Node.js fallback path used by `request.text()` / `request.json()`
-   * when the body is consumed as a whole instead of being streamed. As chunks arrive,
-   * their accumulated length is tracked and, once it exceeds this limit, reading is
-   * aborted and rejects with a `413`-style error (the error has `statusCode: 413`,
-   * `status: 413` and `code: "ERR_BODY_TOO_LARGE"`) so a handler can map it to an
-   * HTTP 413 (Payload Too Large) response.
+   * As the body is read, its accumulated length is tracked and, once it exceeds
+   * this limit, reading is aborted and rejects with a `413`-style error (the error
+   * has `statusCode: 413`, `status: 413` and `code: "ERR_BODY_TOO_LARGE"`) so a
+   * handler can map it to an HTTP 413 (Payload Too Large) response.
    *
-   * **Note:** Currently only enforced for the Node.js runtime buffered body fallback.
-   * Streaming consumers (`request.body`) are not affected.
+   * This is enforced for the buffered reads (`request.text()` / `request.json()`)
+   * as well as the streamed body (`request.body`, and therefore the native `Request`
+   * methods `arrayBuffer()` / `blob()` / `bytes()` / `formData()`).
+   *
+   * **Note:** Currently only enforced for the Node.js runtime.
    *
    * @default undefined (no limit)
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -130,11 +130,14 @@ export interface ServerOptions {
    * has `statusCode: 413`, `status: 413` and `code: "ERR_BODY_TOO_LARGE"`) so a
    * handler can map it to an HTTP 413 (Payload Too Large) response.
    *
-   * This is enforced for the buffered reads (`request.text()` / `request.json()`)
-   * as well as the streamed body (`request.body`, and therefore the native `Request`
-   * methods `arrayBuffer()` / `blob()` / `bytes()` / `formData()`).
+   * The limit covers the buffered reads (`request.text()` / `request.json()`) as
+   * well as the streamed body (`request.body`, and therefore `arrayBuffer()` /
+   * `blob()` / `bytes()` / `formData()`).
    *
-   * **Note:** Currently only enforced for the Node.js runtime.
+   * Runtime support:
+   * - **Node**: enforced by srvx (body stream is size-limited).
+   * - **Bun**: mapped to Bun's native `maxRequestBodySize` (413 before the handler).
+   * - **Deno**: enforced by srvx (request body stream is size-limited).
    *
    * @default undefined (no limit)
    */

--- a/test/_max-body-size.ts
+++ b/test/_max-body-size.ts
@@ -1,0 +1,42 @@
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import { execa, type ResultPromise as ExecaRes } from "execa";
+import { getRandomPort, waitForPort } from "get-port-please";
+
+const testDir = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * Spawns `fixtures/max-body-server.ts` (maxBodySize: 8) under the given runtime
+ * command and asserts the limit is enforced end-to-end.
+ */
+export function maxBodySizeTests(cmd: string): void {
+  let childProc: ExecaRes;
+  let baseURL: string;
+
+  beforeAll(async () => {
+    const port = await getRandomPort("localhost");
+    baseURL = `http://localhost:${port}/`;
+    const [bin, ...args] = cmd.replace("./", testDir).split(" ");
+    childProc = execa(bin, args, { env: { PORT: port.toString() } });
+    childProc.catch((error) => {
+      if (error.signal !== "SIGTERM") console.error(error);
+    });
+    await waitForPort(port, { host: "localhost", delay: 50, retries: 100 });
+  });
+
+  afterAll(async () => {
+    await childProc?.kill();
+  });
+
+  test("rejects a body larger than maxBodySize with 413", async () => {
+    const res = await fetch(baseURL, { method: "POST", body: "0123456789" });
+    expect(res.status).toBe(413);
+    await res.body?.cancel();
+  });
+
+  test("accepts a body within maxBodySize", async () => {
+    const res = await fetch(baseURL, { method: "POST", body: "hi" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("OK:2");
+  });
+}

--- a/test/_max-body-size.ts
+++ b/test/_max-body-size.ts
@@ -6,10 +6,10 @@ import { getRandomPort, waitForPort } from "get-port-please";
 const testDir = fileURLToPath(new URL(".", import.meta.url));
 
 /**
- * Spawns `fixtures/max-body-server.ts` (maxBodySize: 8) under the given runtime
+ * Spawns `fixtures/max-body-server.ts` (maxRequestBodySize: 8) under the given runtime
  * command and asserts the limit is enforced end-to-end.
  */
-export function maxBodySizeTests(cmd: string): void {
+export function maxRequestBodySizeTests(cmd: string): void {
   let childProc: ExecaRes;
   let baseURL: string;
 
@@ -28,13 +28,13 @@ export function maxBodySizeTests(cmd: string): void {
     await childProc?.kill();
   });
 
-  test("rejects a body larger than maxBodySize with 413", async () => {
+  test("rejects a body larger than maxRequestBodySize with 413", async () => {
     const res = await fetch(baseURL, { method: "POST", body: "0123456789" });
     expect(res.status).toBe(413);
     await res.body?.cancel();
   });
 
-  test("accepts a body within maxBodySize", async () => {
+  test("accepts a body within maxRequestBodySize", async () => {
     const res = await fetch(baseURL, { method: "POST", body: "hi" });
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("OK:2");

--- a/test/bench-node/_run.mjs
+++ b/test/bench-node/_run.mjs
@@ -25,6 +25,7 @@ const names = [
   "node",
   "srvx",
   "srvx-fast",
+  "srvx-fast-maxbody",
   release && "srvx-release",
   release && "srvx-fast-release",
   all && "whatwg-node",

--- a/test/bench-node/srvx-fast-maxbody.mjs
+++ b/test/bench-node/srvx-fast-maxbody.mjs
@@ -1,0 +1,13 @@
+import { serve, FastResponse } from "srvx";
+import { fetchHandler } from "./_handler.mjs";
+
+globalThis.Response = FastResponse;
+
+serve({
+  port: 3000,
+  silent: true,
+  // Large enough to never trigger, so this measures the per-request/per-chunk
+  // enforcement overhead on the fast path, not the rejection path.
+  maxRequestBodySize: 100 * 1024 * 1024,
+  fetch: fetchHandler,
+});

--- a/test/bun-max-body-size.test.ts
+++ b/test/bun-max-body-size.test.ts
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
-import { maxBodySizeTests } from "./_max-body-size.ts";
+import { maxRequestBodySizeTests } from "./_max-body-size.ts";
 
-describe("bun maxBodySize", () => {
-  maxBodySizeTests("bun run ./fixtures/max-body-server.ts");
+describe("bun maxRequestBodySize", () => {
+  maxRequestBodySizeTests("bun run ./fixtures/max-body-server.ts");
 });

--- a/test/bun-max-body-size.test.ts
+++ b/test/bun-max-body-size.test.ts
@@ -1,0 +1,6 @@
+import { describe } from "vitest";
+import { maxBodySizeTests } from "./_max-body-size.ts";
+
+describe("bun maxBodySize", () => {
+  maxBodySizeTests("bun run ./fixtures/max-body-server.ts");
+});

--- a/test/deno-max-body-size.test.ts
+++ b/test/deno-max-body-size.test.ts
@@ -1,6 +1,6 @@
 import { describe } from "vitest";
-import { maxBodySizeTests } from "./_max-body-size.ts";
+import { maxRequestBodySizeTests } from "./_max-body-size.ts";
 
-describe("deno maxBodySize", () => {
-  maxBodySizeTests("deno run -A ./fixtures/max-body-server.ts");
+describe("deno maxRequestBodySize", () => {
+  maxRequestBodySizeTests("deno run -A ./fixtures/max-body-server.ts");
 });

--- a/test/deno-max-body-size.test.ts
+++ b/test/deno-max-body-size.test.ts
@@ -1,0 +1,6 @@
+import { describe } from "vitest";
+import { maxBodySizeTests } from "./_max-body-size.ts";
+
+describe("deno maxBodySize", () => {
+  maxBodySizeTests("deno run -A ./fixtures/max-body-server.ts");
+});

--- a/test/fixtures/max-body-server.ts
+++ b/test/fixtures/max-body-server.ts
@@ -1,4 +1,4 @@
-// Minimal server used by the cross-runtime maxBodySize tests. Spawned under the
+// Minimal server used by the cross-runtime maxRequestBodySize tests. Spawned under the
 // target runtime (bun/deno); reads PORT from the env like the main fixture.
 const runtime = (globalThis as any).Deno ? "deno" : (globalThis as any).Bun ? "bun" : "node";
 const { serve } = (await import(
@@ -7,7 +7,7 @@ const { serve } = (await import(
 
 serve({
   hostname: "localhost",
-  maxBodySize: 8,
+  maxRequestBodySize: 8,
   fetch: async (req) => {
     try {
       // Read via the whole native body path so streaming/native reads are exercised.

--- a/test/fixtures/max-body-server.ts
+++ b/test/fixtures/max-body-server.ts
@@ -1,0 +1,20 @@
+// Minimal server used by the cross-runtime maxBodySize tests. Spawned under the
+// target runtime (bun/deno); reads PORT from the env like the main fixture.
+const runtime = (globalThis as any).Deno ? "deno" : (globalThis as any).Bun ? "bun" : "node";
+const { serve } = (await import(
+  `../../src/adapters/${runtime}.ts`
+)) as typeof import("../../src/types.ts");
+
+serve({
+  hostname: "localhost",
+  maxBodySize: 8,
+  fetch: async (req) => {
+    try {
+      // Read via the whole native body path so streaming/native reads are exercised.
+      const body = await req.arrayBuffer();
+      return new Response(`OK:${body.byteLength}`);
+    } catch (error: any) {
+      return new Response(error.code ?? "ERR", { status: error.statusCode ?? 500 });
+    }
+  },
+});

--- a/test/node-max-body-size.test.ts
+++ b/test/node-max-body-size.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { fetch } from "undici";
+import { fetch, FormData } from "undici";
 import { serve } from "../src/adapters/node.ts";
 
 describe("node maxBodySize", () => {
@@ -32,6 +32,75 @@ describe("node maxBodySize", () => {
     const res = await fetch(server.url!, { method: "POST", body: "hello" });
     expect(res.status).toBe(200);
     expect(await res.text()).toBe("hello");
+    await server.close(true);
+  });
+
+  // The limit must also cover the native `Request` read methods that bypass the
+  // buffered `readBody` fallback by routing through `request.body`.
+  const bodyReaders = {
+    "arrayBuffer()": (req: Request) => req.arrayBuffer().then((b) => b.byteLength),
+    "bytes()": (req: Request) => req.bytes().then((b) => b.byteLength),
+    "blob()": (req: Request) => req.blob().then((b) => b.size),
+    stream: async (req: Request) => {
+      let n = 0;
+      for await (const chunk of req.body!) n += chunk.length;
+      return n;
+    },
+  } as const;
+
+  for (const [name, read] of Object.entries(bodyReaders)) {
+    test(`rejects an oversized body read via ${name}`, async () => {
+      const server = serve({
+        port: 0,
+        maxBodySize: 8,
+        fetch: async (req) => {
+          try {
+            return new Response(String(await read(req)));
+          } catch (error: any) {
+            return new Response(error.code, { status: error.statusCode ?? 500 });
+          }
+        },
+      });
+      await server.ready();
+      const res = await fetch(server.url!, { method: "POST", body: "0123456789" });
+      expect(res.status).toBe(413);
+      expect(await res.text()).toBe("ERR_BODY_TOO_LARGE");
+      await server.close(true);
+    });
+  }
+
+  test("rejects an oversized multipart body via formData()", async () => {
+    const server = serve({
+      port: 0,
+      maxBodySize: 16,
+      fetch: async (req) => {
+        try {
+          const form = await req.formData();
+          return new Response(String([...form].length));
+        } catch (error: any) {
+          return new Response(error.code, { status: error.statusCode ?? 500 });
+        }
+      },
+    });
+    await server.ready();
+    const form = new FormData();
+    form.set("field", "a value long enough to exceed the limit");
+    const res = await fetch(server.url!, { method: "POST", body: form });
+    expect(res.status).toBe(413);
+    expect(await res.text()).toBe("ERR_BODY_TOO_LARGE");
+    await server.close(true);
+  });
+
+  test("accepts a body within the limit read via arrayBuffer()", async () => {
+    const server = serve({
+      port: 0,
+      maxBodySize: 1024,
+      fetch: async (req) => new Response(String((await req.arrayBuffer()).byteLength)),
+    });
+    await server.ready();
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("5");
     await server.close(true);
   });
 

--- a/test/node-max-body-size.test.ts
+++ b/test/node-max-body-size.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+import { fetch } from "undici";
+import { serve } from "../src/adapters/node.ts";
+
+describe("node maxBodySize", () => {
+  test("rejects a buffered body larger than the limit with a 413-style error", async () => {
+    const server = serve({
+      port: 0,
+      maxBodySize: 8,
+      fetch: async (req) => {
+        try {
+          return new Response(await req.text());
+        } catch (error: any) {
+          return new Response(error.message, { status: error.statusCode ?? 500 });
+        }
+      },
+    });
+    await server.ready();
+    const res = await fetch(server.url!, { method: "POST", body: "0123456789" });
+    expect(res.status).toBe(413);
+    expect(await res.text()).toContain("maximum allowed size");
+    await server.close(true);
+  });
+
+  test("accepts a buffered body within the limit", async () => {
+    const server = serve({
+      port: 0,
+      maxBodySize: 1024,
+      fetch: async (req) => new Response(await req.text()),
+    });
+    await server.ready();
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello");
+    await server.close(true);
+  });
+
+  test("has no limit by default (backward compatible)", async () => {
+    const server = serve({
+      port: 0,
+      fetch: async (req) => new Response(await req.text()),
+    });
+    await server.ready();
+    const body = "x".repeat(100_000);
+    const res = await fetch(server.url!, { method: "POST", body });
+    expect(res.status).toBe(200);
+    expect((await res.text()).length).toBe(100_000);
+    await server.close(true);
+  });
+});

--- a/test/node-max-body-size.test.ts
+++ b/test/node-max-body-size.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, test } from "vitest";
 import { fetch, FormData } from "undici";
 import { serve } from "../src/adapters/node.ts";
 
-describe("node maxBodySize", () => {
+describe("node maxRequestBodySize", () => {
   test("rejects a buffered body larger than the limit with a 413-style error", async () => {
     const server = serve({
       port: 0,
-      maxBodySize: 8,
+      maxRequestBodySize: 8,
       fetch: async (req) => {
         try {
           return new Response(await req.text());
@@ -25,7 +25,7 @@ describe("node maxBodySize", () => {
   test("accepts a buffered body within the limit", async () => {
     const server = serve({
       port: 0,
-      maxBodySize: 1024,
+      maxRequestBodySize: 1024,
       fetch: async (req) => new Response(await req.text()),
     });
     await server.ready();
@@ -52,7 +52,7 @@ describe("node maxBodySize", () => {
     test(`rejects an oversized body read via ${name}`, async () => {
       const server = serve({
         port: 0,
-        maxBodySize: 8,
+        maxRequestBodySize: 8,
         fetch: async (req) => {
           try {
             return new Response(String(await read(req)));
@@ -72,7 +72,7 @@ describe("node maxBodySize", () => {
   test("rejects an oversized multipart body via formData()", async () => {
     const server = serve({
       port: 0,
-      maxBodySize: 16,
+      maxRequestBodySize: 16,
       fetch: async (req) => {
         try {
           const form = await req.formData();
@@ -94,7 +94,7 @@ describe("node maxBodySize", () => {
   test("accepts a body within the limit read via arrayBuffer()", async () => {
     const server = serve({
       port: 0,
-      maxBodySize: 1024,
+      maxRequestBodySize: 1024,
       fetch: async (req) => new Response(String((await req.arrayBuffer()).byteLength)),
     });
     await server.ready();


### PR DESCRIPTION
Adds an opt-in `maxRequestBodySize` server option that caps the size of an incoming request body, enforced across Node, Bun, and Deno.

## Motivation

srvx had no way to bound request-body memory. The buffered read path (`request.text()` / `request.json()`) accumulated every chunk with no limit, and the streamed/native paths (`arrayBuffer()`, `blob()`, `bytes()`, `formData()`, `request.body`) had none either — so a large or malicious upload (multipart `formData()` being the most common heavy case) could grow process memory unbounded. Bun ships a native `maxRequestBodySize` (default 128 MiB); Node and Deno have no default limit.

## What this does

New generic `ServerOptions.maxRequestBodySize` (bytes, default `undefined` = no limit). When a body exceeds it, reading aborts and rejects with a `413`-style error (`statusCode: 413`, `status: 413`, `code: "ERR_BODY_TOO_LARGE"`) that a handler or `onError` can map to `413 Payload Too Large`.

The limit covers **all** read paths — buffered (`text()`/`json()`) and streamed (`request.body`, and therefore `arrayBuffer()` / `blob()` / `bytes()` / `formData()`).

### Per-runtime enforcement

| Runtime | How |
|---|---|
| **Node** | srvx wraps `request.body`'s `ReadableStream` with a pull-based byte-limiter (preserves backpressure, cancels upstream on overflow); the buffered `readBody()` fast path keeps its own cheap check. |
| **Bun** | forwarded to Bun's native `maxRequestBodySize` — Bun responds `413` before the handler runs. An explicit `bun.maxRequestBodySize` still wins. |
| **Deno** | `Deno.serve` has no native option, so srvx rebuilds the request with a size-limited body stream (method/url/headers/**signal** preserved). |

The shared limiter primitives live in a runtime-agnostic `src/_body-limit.ts`. Also threaded through `toNodeHandler(handler, { maxRequestBodySize })` for handlers embedded in an existing Node server.

## Hot path / backward compat

Default `undefined` → **no limit**, identical to today. When unset, no body-stream wrapping and no per-request allocation occurs on any runtime (a separate commit also reverted an incidental per-request object allocation so the Node default path matches `main` exactly, ~25 ns/ctor).

## Tests

- `test/node-max-body-size.test.ts` — 9 cases: per-method (`text`/`json`/`arrayBuffer`/`bytes`/`blob`/`formData`/streaming) over-limit → 413, within-limit → 200, and no-limit-by-default backward-compat.
- `test/bun-max-body-size.test.ts` + `test/deno-max-body-size.test.ts` — spawn the target runtime against `test/fixtures/max-body-server.ts` and assert 413 over / 200 within.

All suites green (node/bun/deno adapter suites + body-size tests: 191 passed, 8 skipped). `pnpm lint` and `pnpm typecheck` clean. Docs updated in `docs/1.guide/5.options.md`.

## Notes for review

- **Bun semantics differ slightly**: Bun rejects at the protocol level (413, empty body, handler never runs), whereas Node/Deno surface `ERR_BODY_TOO_LARGE` as a catchable rejection. Inherent to using Bun's native option.
- **Deno rebuilds the `Request`** per bodied request when a limit is set (opt-in only) — a small allocation on that path; happy to gate it further if preferred.
- Option name matches Bun's `maxRequestBodySize` for consistency; unreleased, so no alias kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional request body size limit for Node.js servers.
  * Large buffered request bodies can now be rejected with a clear 413-style error when they exceed the configured limit.

* **Bug Fixes**
  * Improved handling of request body buffering so oversized payloads stop reading sooner.
  * Existing behavior remains unchanged when no limit is set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
