### PR TITLE
fix(node): read duplicate single-value headers from rawHeaders in get/has

### DIFF
--- a/src/adapters/_node/headers.ts
+++ b/src/adapters/_node/headers.ts
@@ -41,26 +41,18 @@ export const NodeRequestHeaders: {
     }
 
     get(name: string): string | null {
-      if (this.#headers) {
-        return this.#headers.get(name);
-      }
-      const value = this.#req.headers[name.toLowerCase()];
-      return Array.isArray(value) ? value.join(", ") : value || null;
+      // Always read from the rawHeaders-materialized Headers: Node collapses
+      // headers it treats as single-value (authorization, content-type, …) to
+      // their first occurrence in `req.headers`, which diverges from WHATWG.
+      return this._headers.get(name);
     }
 
     has(name: string): boolean {
-      if (this.#headers) {
-        return this.#headers.has(name);
-      }
-      return name.toLowerCase() in this.#req.headers;
+      return this._headers.has(name);
     }
 
     getSetCookie(): string[] {
-      if (this.#headers) {
-        return this.#headers.getSetCookie();
-      }
-      const value = this.#req.headers["set-cookie"];
-      return Array.isArray(value) ? value : value ? [value] : [];
+      return this._headers.getSetCookie();
     }
 
     entries(): HeadersIterator<[string, string]> {

--- a/test/node-headers.test.ts
+++ b/test/node-headers.test.ts
@@ -49,4 +49,34 @@ describe("NodeRequestHeaders", () => {
     expect(cookie).toContain("a=1");
     expect(cookie).toContain("b=2");
   });
+
+  test("get()/has() combine duplicate single-value headers regardless of iteration order", () => {
+    // Node collapses headers it treats as single-value (authorization,
+    // content-type, …) to the FIRST occurrence in `req.headers`, while
+    // `rawHeaders` keeps every occurrence. The result must not depend on
+    // whether the Headers object was iterated first.
+    const rawHeaders = [
+      "authorization",
+      "Bearer AAA",
+      "authorization",
+      "Bearer BBB",
+      "content-type",
+      "text/plain",
+      "content-type",
+      "application/json",
+    ];
+    const collapsed = { authorization: "Bearer AAA", "content-type": "text/plain" };
+
+    // Fresh instance: get() before any iteration.
+    const before = new NodeRequestHeaders(mockReq(rawHeaders, collapsed));
+    expect(before.get("authorization")).toBe("Bearer AAA, Bearer BBB");
+    expect(before.get("content-type")).toBe("text/plain, application/json");
+    expect(before.has("authorization")).toBe(true);
+
+    // Separate instance, iterated first, then get(): must match.
+    const after = new NodeRequestHeaders(mockReq(rawHeaders, collapsed));
+    void [...after.entries()];
+    expect(after.get("authorization")).toBe("Bearer AAA, Bearer BBB");
+    expect(after.get("content-type")).toBe("text/plain, application/json");
+  });
 });


### PR DESCRIPTION
## Problem

On the Node adapter, `NodeRequestHeaders.get()` / `has()` / `getSetCookie()` had a fast path that read Node's *collapsed* `req.headers` object before `_headers` was materialized. For headers Node treats as single-value (`authorization`, `content-type`, …), Node keeps only the **first** occurrence, whereas the `rawHeaders`-materialized `_headers` appends **all** occurrences, matching WHATWG `Headers`.

As a result, `get('authorization')` returned a different value depending on whether the Headers object had been iterated first:

```
get('authorization') BEFORE iteration = "Bearer AAA"              <- fast path, first only
get('authorization') AFTER  iteration = "Bearer AAA, Bearer BBB"  <- via rebuilt _headers
native Headers.get()                  = "Bearer AAA, Bearer BBB"  <- WHATWG (correct)
```

This is a spec divergence and a header-confusion primitive: two layers reading the same header can disagree if one reads before iteration and the other after. Reproduced end-to-end against a live Node server over a raw socket (duplicate `Authorization` / `Content-Type` lines — a normal fetch client can't send these).

## Fix

Route `get()` / `has()` / `getSetCookie()` through the `rawHeaders`-materialized `_headers` consistently, dropping the `if (this.#headers)` fast branches. The result no longer depends on prior iteration order and matches native `Headers`.

Node adapter only — other adapters (Deno/Bun/Cloudflare/Bunny/generic/AWS-Lambda) use native `Request`/`Headers` and are unaffected.

## Tests

- Added a regression test in `test/node-headers.test.ts` sending duplicate `authorization` / `content-type` headers and asserting the joined value both before and after iteration.
- Full node suite passes (144 passed, 6 skipped); typecheck and lint clean.
- Post-fix raw-socket repro confirms `before` and `after` both return the joined value and match native `Headers`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)