### PR TITLE
perf(node): fast header lookups and fewer per-request allocations

### DIFF
--- a/src/adapters/_node/headers.ts
+++ b/src/adapters/_node/headers.ts
@@ -3,6 +3,51 @@ import { lazyInherit } from "../../_inherit.ts";
 
 // https://github.com/nodejs/node/blob/main/lib/_http_incoming.js
 
+/**
+ * Header names Node.js treats as single-value: repeats keep only the FIRST
+ * occurrence in `req.headers`, diverging from WHATWG Headers ", " join
+ * semantics. (https://nodejs.org/api/http.html#messageheaders — `set-cookie`
+ * stays an array and `cookie` repeats join with "; " in both Node and the
+ * Fetch spec, so neither needs a fallback.)
+ */
+const _nonJoinedHeaders = /* @__PURE__ */ new Set([
+  "age",
+  "authorization",
+  "content-length",
+  "content-type",
+  "etag",
+  "expires",
+  "from",
+  "host",
+  "if-modified-since",
+  "if-unmodified-since",
+  "last-modified",
+  "location",
+  "max-forwards",
+  "proxy-authorization",
+  "referer",
+  "retry-after",
+  "server",
+  "user-agent",
+]);
+
+// WHATWG header name token (RFC 9110 field-name)
+const _validHeaderNameRE = /^[!#$%&'*+\-.^_`|~\dA-Za-z]+$/;
+
+function _isRepeated(rawHeaders: string[], lowerName: string): boolean {
+  let seen = false;
+  for (let i = 0; i < rawHeaders.length; i += 2) {
+    const key = rawHeaders[i];
+    if (key.length === lowerName.length && key.toLowerCase() === lowerName) {
+      if (seen) {
+        return true;
+      }
+      seen = true;
+    }
+  }
+  return false;
+}
+
 export type NodeRequestHeaders = InstanceType<typeof NodeRequestHeaders>;
 
 export const NodeRequestHeaders: {
@@ -41,18 +86,66 @@ export const NodeRequestHeaders: {
     }
 
     get(name: string): string | null {
-      // Always read from the rawHeaders-materialized Headers: Node collapses
-      // headers it treats as single-value (authorization, content-type, …) to
-      // their first occurrence in `req.headers`, which diverges from WHATWG.
-      return this._headers.get(name);
+      if (this.#headers) {
+        return this.#headers.get(name);
+      }
+      const lower = name.toLowerCase();
+      if (lower.charCodeAt(0) === 58 /* : */) {
+        // HTTP/2 pseudo-header: invalid WHATWG name → native TypeError
+        return this._headers.get(name);
+      }
+      const value = this.#req.headers[lower];
+      if (typeof value === "string") {
+        // Node collapses repeated single-value headers (authorization,
+        // content-type, …) to their first occurrence in `req.headers`,
+        // diverging from WHATWG ", " join semantics. Deopt to the
+        // rawHeaders-materialized Headers only when such a header actually
+        // repeats.
+        return _nonJoinedHeaders.has(lower) && _isRepeated(this.#req.rawHeaders, lower)
+          ? this._headers.get(name)
+          : value;
+      }
+      if (Array.isArray(value)) {
+        // Only set-cookie is array-valued in `req.headers`
+        return value.join(", ");
+      }
+      // Absent, or a non-string artifact from `req.headers`'s prototype
+      // (`toString`, …). A real `__proto__` header never lands as an own key
+      // (the prototype accessor swallows Node's assignment) and invalid names
+      // need native error semantics — both read from the materialized Headers.
+      return lower !== "__proto__" && _validHeaderNameRE.test(name)
+        ? null
+        : this._headers.get(name);
     }
 
     has(name: string): boolean {
-      return this._headers.has(name);
+      if (this.#headers) {
+        return this.#headers.has(name);
+      }
+      const lower = name.toLowerCase();
+      if (lower.charCodeAt(0) === 58 /* : */) {
+        // HTTP/2 pseudo-header: invalid WHATWG name → native TypeError
+        return this._headers.has(name);
+      }
+      // Presence is unaffected by Node's duplicate collapsing/joining.
+      // `hasOwn` guards against `req.headers` prototype hits (`toString`, …).
+      if (Object.hasOwn(this.#req.headers, lower)) {
+        return true;
+      }
+      // `__proto__` never lands as an own key (see get()); invalid names need
+      // native error semantics.
+      return lower !== "__proto__" && _validHeaderNameRE.test(name)
+        ? false
+        : this._headers.has(name);
     }
 
     getSetCookie(): string[] {
-      return this._headers.getSetCookie();
+      if (this.#headers) {
+        return this.#headers.getSetCookie();
+      }
+      // Node always materializes set-cookie as an array of every occurrence.
+      const value = this.#req.headers["set-cookie"];
+      return Array.isArray(value) ? value.slice() : value ? [value] : [];
     }
 
     entries(): HeadersIterator<[string, string]> {

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -257,7 +257,8 @@ function readBody(req: NodeServerRequest, maxRequestBodySize?: number): Promise<
     };
     const onEnd = () => {
       cleanup();
-      resolve(Buffer.concat(chunks));
+      // Single-chunk bodies (the common case) skip Buffer.concat's alloc+copy
+      resolve(chunks.length === 1 ? chunks[0] : Buffer.concat(chunks));
     };
     req.on("data", onData).once("end", onEnd).once("error", onError);
   });

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -8,7 +8,8 @@ export type PreparedNodeResponseBody = string | Buffer | Uint8Array | DataView |
 export interface PreparedNodeResponse {
   status: number;
   statusText: string;
-  headers: [string, string][];
+  /** Flat rawHeaders-style list: `[name1, value1, name2, value2, …]` */
+  headers: string[];
   body: PreparedNodeResponseBody;
 }
 
@@ -145,8 +146,8 @@ export const NodeResponse: {
         }
       }
 
-      // Headers
-      const headers: [string, string][] = [];
+      // Headers (flat rawHeaders-style list — avoids a per-response flatten in writeHead)
+      const headers: string[] = [];
       const initHeaders = this.#init?.headers;
       const headerEntries =
         this.#response?.headers ||
@@ -156,21 +157,22 @@ export const NodeResponse: {
             ? initHeaders
             : initHeaders?.entries
               ? (initHeaders as Headers).entries()
-              : // prettier-ignore
-                Object.entries(initHeaders).map(([k, v]) => [k.toLowerCase(), v])
+              : Object.entries(initHeaders)
           : undefined);
       let hasContentTypeHeader: boolean | undefined;
       let hasContentLength: boolean | undefined;
       if (headerEntries) {
         for (const [key, value] of headerEntries) {
+          // Normalize names once: enables case-insensitive content-type /
+          // content-length dedup and matches native Response header casing.
+          const lowerKey = typeof key === "string" ? key.toLowerCase() : String(key);
           if (Array.isArray(value)) {
             for (const v of value) {
-              headers.push([key, v]);
+              headers.push(lowerKey, v);
             }
           } else {
-            headers.push([key, value]);
+            headers.push(lowerKey, value);
           }
-          const lowerKey = typeof key === "string" ? key.toLowerCase() : key;
           if (lowerKey === "content-type") {
             hasContentTypeHeader = true;
           } else if (lowerKey === "content-length") {
@@ -179,10 +181,10 @@ export const NodeResponse: {
         }
       }
       if (contentType && !hasContentTypeHeader) {
-        headers.push(["content-type", contentType]);
+        headers.push("content-type", contentType);
       }
       if (contentLength && !hasContentLength) {
-        headers.push(["content-length", String(contentLength)]);
+        headers.push("content-length", String(contentLength));
       }
 
       // Free up memory

--- a/src/adapters/_node/send.ts
+++ b/src/adapters/_node/send.ts
@@ -34,7 +34,10 @@ export async function sendNodeResponse(
     return endNodeResponse(nodeRes);
   }
 
-  const rawHeaders = [...webRes.headers];
+  const rawHeaders: string[] = [];
+  for (const [key, value] of webRes.headers) {
+    rawHeaders.push(key, value);
+  }
   writeHead(nodeRes, webRes.status, webRes.statusText, rawHeaders);
 
   return webRes.body ? streamBody(webRes.body, nodeRes) : endNodeResponse(nodeRes);
@@ -44,21 +47,21 @@ function writeHead(
   nodeRes: NodeServerResponse,
   status: number,
   statusText: string,
-  rawHeaders: [string, string][],
-): void {
   // Node.js writeHead accepts a raw array of [key, value, key, value] or [[key, value], [key, value]]
   // https://github.com/nodejs/node/blob/v22.14.0/lib/_http_server.js#L376
   // https://github.com/nodejs/node/blob/v24.10.0/lib/_http_outgoing.js#L417
   // But it has an inconsistency in slow-path that does not unflattens!!
   // https://github.com/h3js/srvx/pull/40
-  const writeHeaders = rawHeaders.flat();
+  // We always pass the (safe) flat form, pre-built to avoid a per-response flatten.
+  rawHeaders: string[],
+): void {
   if (!nodeRes.headersSent) {
     if (nodeRes.req?.httpVersion === "2.0") {
       // @ts-expect-error
-      nodeRes.writeHead(status, writeHeaders);
+      nodeRes.writeHead(status, rawHeaders);
     } else {
       // @ts-expect-error
-      nodeRes.writeHead(status, statusText, writeHeaders);
+      nodeRes.writeHead(status, statusText, rawHeaders);
     }
   }
 }
@@ -72,7 +75,7 @@ function pipeBody(
   nodeRes: NodeServerResponse,
   status: number,
   statusText: string,
-  headers: [string, string][],
+  headers: string[],
 ): Promise<void> | void {
   if (nodeRes.destroyed) {
     stream.destroy?.();

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -395,10 +395,19 @@ describe("node server startup", () => {
 });
 
 describe("FastResponse header dedup", () => {
-  const contentLengthEntries = (headers: [string, string][]) =>
-    headers.filter(([key]) => key.toLowerCase() === "content-length");
-  const contentTypeEntries = (headers: [string, string][]) =>
-    headers.filter(([key]) => key.toLowerCase() === "content-type");
+  // `_toNodeResponse().headers` is a flat rawHeaders-style list; header names
+  // are normalized to lowercase (matching native Response semantics).
+  const headerPairs = (headers: string[]) => {
+    const pairs: [string, string][] = [];
+    for (let i = 0; i < headers.length; i += 2) {
+      pairs.push([headers[i], headers[i + 1]]);
+    }
+    return pairs;
+  };
+  const contentLengthEntries = (headers: string[]) =>
+    headerPairs(headers).filter(([key]) => key === "content-length");
+  const contentTypeEntries = (headers: string[]) =>
+    headerPairs(headers).filter(([key]) => key === "content-type");
 
   test("does not duplicate capitalized array-form Content-Length", () => {
     const { headers } = new FastResponse("hello", {
@@ -406,7 +415,7 @@ describe("FastResponse header dedup", () => {
     })._toNodeResponse();
     const cl = contentLengthEntries(headers);
     expect(cl).toHaveLength(1);
-    expect(cl[0]).toEqual(["Content-Length", "999"]);
+    expect(cl[0]).toEqual(["content-length", "999"]);
   });
 
   test("does not duplicate capitalized array-form Content-Type", () => {
@@ -415,8 +424,7 @@ describe("FastResponse header dedup", () => {
     })._toNodeResponse();
     const ct = contentTypeEntries(headers);
     expect(ct).toHaveLength(1);
-    expect(ct[0]).toEqual(["Content-Type", "text/html"]);
-    expect(headers).not.toContainEqual(["content-type", "text/plain; charset=UTF-8"]);
+    expect(ct[0]).toEqual(["content-type", "text/html"]);
   });
 
   test("lowercase array-form Content-Length still dedups", () => {

--- a/test/node-headers.test.ts
+++ b/test/node-headers.test.ts
@@ -79,4 +79,44 @@ describe("NodeRequestHeaders", () => {
     expect(after.get("authorization")).toBe("Bearer AAA, Bearer BBB");
     expect(after.get("content-type")).toBe("text/plain, application/json");
   });
+
+  test("get()/has() see a literal `__proto__` header", () => {
+    // Node's `req.headers` can never carry an own `__proto__` key (the
+    // prototype accessor swallows the assignment), so the fast path must
+    // fall back to rawHeaders for this name.
+    const withProto = new NodeRequestHeaders(
+      mockReq(["__proto__", "evil", "x-a", "1"], { "x-a": "1" }),
+    );
+    expect(withProto.get("__proto__")).toBe("evil");
+    expect(withProto.has("__proto__")).toBe(true);
+
+    const withoutProto = new NodeRequestHeaders(mockReq(["x-a", "1"], { "x-a": "1" }));
+    expect(withoutProto.get("__proto__")).toBe(null);
+    expect(withoutProto.has("__proto__")).toBe(false);
+  });
+
+  test("get()/has() ignore `req.headers` prototype artifacts and reject invalid names", () => {
+    const headers = new NodeRequestHeaders(mockReq(["x-a", "1"], { "x-a": "1" }));
+    // Plain (non null-prototype) `req.headers` exposes Object.prototype members
+    expect(headers.get("toString")).toBe(null);
+    expect(headers.has("toString")).toBe(false);
+    // Invalid names throw like native Headers
+    expect(() => headers.get("foo bar")).toThrow(TypeError);
+    expect(() => headers.has("foo bar")).toThrow(TypeError);
+    expect(() => headers.get(":path")).toThrow(TypeError);
+  });
+
+  test("repeated cookie joins with '; ' like native Headers", () => {
+    // Node joins repeated cookie headers with "; " in `req.headers`, matching
+    // the Fetch spec's cookie special case — the fast path returns it as-is.
+    const headers = new NodeRequestHeaders(
+      mockReq(["cookie", "a=1", "cookie", "b=2"], { cookie: "a=1; b=2" }),
+    );
+    expect(headers.get("cookie")).toBe("a=1; b=2");
+    // Reference: materialized native Headers behave identically
+    const ref = new Headers();
+    ref.append("cookie", "a=1");
+    ref.append("cookie", "b=2");
+    expect(ref.get("cookie")).toBe("a=1; b=2");
+  });
 });


### PR DESCRIPTION
Fixes a Node adapter performance regression introduced by the recent security hardenings (#217) and further reduces per-request work to keep srvx fast.

### Changes

- **Request headers**: `get()`/`has()`/`getSetCookie()` read `req.headers` directly again instead of always materializing a native `Headers` from `rawHeaders` per call. The #217 correctness is kept: repeated single-value headers (`authorization`, `content-type`, …) and a literal `__proto__` header still fall back to the materialized `Headers`, prototype artifacts (`toString`, …) are rejected, and invalid names / HTTP/2 pseudo-headers throw `TypeError` like native `Headers`. Repeated `cookie` headers need no fallback (Node and the Fetch spec both join with `"; "`). Verified with a differential test against the rawHeaders-materialized reference through Node's real parser.
- **Response path**: `FastResponse._toNodeResponse()` emits a flat rawHeaders-style list, removing the per-response `.flat()`, an intermediate `Object.entries().map()` array, and a double `toLowerCase` per header. Header names are now always lowercased on the wire (matching native `Response`).
- **Body read**: single-chunk bodies skip the `Buffer.concat` alloc+copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Node-style header handling to better match native `Headers` behavior, including repeated headers, special header names, and `__proto__` edge cases.
  * Fixed request body handling to avoid unnecessary buffering when the body arrives in a single chunk.
  * Standardized response header formatting so headers are sent in a consistent, lowercased flat representation.

* **Tests**
  * Added and updated coverage for header lookup, validation, cookie joining, and response header deduplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->