### PR TITLE
fix(node): do not mutate raw req.url on pathname change

### DIFF
--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -9,8 +9,6 @@ export const HOST_RE: RegExp =
   /^(\[(?:[A-Fa-f0-9:.]+)\]|(?:[A-Za-z0-9_-]+\.)*[A-Za-z0-9_-]+|(?:\d{1,3}\.){3}\d{1,3})(:\d{1,5})?$/;
 
 export class NodeRequestURL extends FastURL {
-  #req: NodeServerRequest;
-
   constructor({ req }: { req: NodeServerRequest }) {
     const path = req.url || "/";
 
@@ -49,7 +47,6 @@ export class NodeRequestURL extends FastURL {
       // absolute-form (e.g. proxy request)
       super(path);
     }
-    this.#req = req;
   }
 
   override get pathname(): string {
@@ -57,7 +54,9 @@ export class NodeRequestURL extends FastURL {
   }
 
   override set pathname(value: string) {
+    // Update the (web) URL view only. The raw Node `req.url` is intentionally
+    // left untouched so consumers can still access the original, wire-encoded
+    // request target (e.g. for audit logging or proxying). See h3js/h3#1432.
     this._url.pathname = value;
-    this.#req.url = this._url.pathname + this._url.search;
   }
 }

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -48,10 +48,4 @@ export class NodeRequestURL extends FastURL {
       super(path);
     }
   }
-
-  // NOTE: `pathname` is intentionally NOT overridden. The inherited `FastURL`
-  // setter updates the (web) URL view only (`this._url.pathname = value`) and
-  // leaves the raw Node `req.url` untouched, so consumers can still access the
-  // original wire-encoded request target (e.g. for audit logging or proxying).
-  // See h3js/h3#1432.
 }

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -49,14 +49,9 @@ export class NodeRequestURL extends FastURL {
     }
   }
 
-  override get pathname(): string {
-    return super.pathname;
-  }
-
-  override set pathname(value: string) {
-    // Update the (web) URL view only. The raw Node `req.url` is intentionally
-    // left untouched so consumers can still access the original, wire-encoded
-    // request target (e.g. for audit logging or proxying). See h3js/h3#1432.
-    this._url.pathname = value;
-  }
+  // NOTE: `pathname` is intentionally NOT overridden. The inherited `FastURL`
+  // setter updates the (web) URL view only (`this._url.pathname = value`) and
+  // leaves the raw Node `req.url` untouched, so consumers can still access the
+  // original wire-encoded request target (e.g. for audit logging or proxying).
+  // See h3js/h3#1432.
 }

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -410,4 +410,28 @@ describe("FastURL", () => {
       });
     }
   });
+
+  describe("pathname setter", () => {
+    // Setting `pathname` updates the (web) URL view but must NOT mutate the
+    // raw Node `req.url`, so the original wire-encoded target stays available.
+    // See h3js/h3#1432.
+    test("does not mutate raw req.url", () => {
+      const req = { url: "/h%65llo?q=%41", headers: { host: "localhost" } } as any;
+      const url = new NodeRequestURL({ req });
+      url.pathname = "/decoded";
+      expect(url.pathname).toBe("/decoded");
+      expect(url.href).toBe("http://localhost/decoded?q=%41");
+      // raw node request target preserved
+      expect(req.url).toBe("/h%65llo?q=%41");
+    });
+
+    test("does not mutate raw req.url after deopt", () => {
+      const req = { url: "/foo?q=1", headers: { host: "localhost" } } as any;
+      const url = new NodeRequestURL({ req });
+      void url.hostname; // force deopt to native URL
+      url.pathname = "/base/foo";
+      expect(url.pathname).toBe("/base/foo");
+      expect(req.url).toBe("/foo?q=1");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Applies the srvx side of the fix for [h3js/h3#1432](https://github.com/h3js/h3/issues/1432), paired with the h3-side change in [h3js/h3#1433](https://github.com/h3js/h3/pull/1433).

`NodeRequestURL`'s `pathname` setter wrote the updated value back into the raw Node `req.url`. When h3 normalizes a percent-encoded pathname (e.g. `/h%65llo` → `/hello`), this mutated the underlying `IncomingMessage`, diverging from web-platform behavior and losing the original wire-encoded request target that consumers need for audit logging, proxy forwarding, or custom decoding semantics.

## Change

- The `pathname` setter now updates only the (web) URL view (`this._url.pathname = value`) and no longer writes back to the raw Node `req.url`.
- Removed the now-unused `#req` field and its constructor assignment.

The web `Request.url` getter still reflects pathname mutations (it reads `_url.href`), so h3-level rewrites remain visible on the web `Request` — only the raw `IncomingMessage.url` is preserved as the original wire value.

## Why this is safe now (h3js/h3#1433)

The implicit write-back was originally added in #118 so that h3's `withBase`/`mount` rewrites would propagate into the raw `req.url` for legacy Node middleware routed through `fromNodeHandler`.

h3js/h3#1433 makes that propagation **explicit at the adapter boundary**: `fromNodeHandler` now temporarily sets `req.url` to the h3-normalized `event.url.pathname + event.url.search` before invoking the legacy handler, then restores the original raw value in a `finally` block. Because h3 no longer relies on mutating the shared URL object, srvx can drop the implicit write-back entirely and keep `IncomingMessage.url` pristine for every other consumer.

## Tests

Added a `pathname setter` suite asserting that setting `pathname` updates `url.pathname`/`url.href` but does **not** mutate `req.url`, covering both the fast path and the deopt-to-native path.

Full suite: 867 passed, no type errors, lint/format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated URL pathname behavior so changing `pathname` no longer rewrites the raw Node request target; only the internal URL view is updated.
  * Verified consistent behavior across both normal and slower execution paths.

* **Tests**
  * Added new test coverage for `pathname` updates, confirming the displayed URL reflects the new pathname while `req.url` remains unchanged (including after forcing a slower path).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->