### PR TITLE
doc: add missing aws stream docs, tests and example

### DIFF
--- a/docs/1.guide/8.aws-lambda.md
+++ b/docs/1.guide/8.aws-lambda.md
@@ -105,4 +105,6 @@ export const handler: AWSLambdaStreamingHandler = awslambda.streamifyResponse(
 ```
 
 > [!NOTE]
-> Response streaming requires a Lambda Function URL with `--invoke-mode RESPONSE_STREAM` or the `InvokeWithResponseStream` API. It does not work with API Gateway or Application Load Balancer for progressive streaming.
+> Response streaming requires a Lambda Function URL with `--invoke-mode RESPONSE_STREAM`, or an API Gateway **REST API (v1)** integration configured with `responseTransferMode: STREAM` (both use the `InvokeWithResponseStream` API under the hood, and srvx's request/response handling is identical for both). HTTP API (v2) and Application Load Balancer do not support progressive streaming yet.
+>
+> See the [`examples/aws-lambda`](https://github.com/h3js/srvx/tree/main/examples/aws-lambda) directory for a REST API streaming example wired up with the Serverless Framework, and its README for how to verify streaming is actually progressive (not buffered) against a real deployment.

--- a/examples/aws-lambda/README.md
+++ b/examples/aws-lambda/README.md
@@ -1,0 +1,26 @@
+# AWS Lambda example
+
+Deploys an srvx app behind an API Gateway REST API (v1), using the [Serverless Framework](https://www.serverless.com/).
+
+## Deploy
+
+```sh
+npx serverless deploy
+```
+
+This requires valid AWS credentials (`aws configure` or the usual `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` env vars).
+
+## Verifying REST API v1 response streaming
+
+The `stream` function (`stream.ts`) is wired up in `serverless.yml` with `response.transferMode: STREAM`, so API Gateway invokes it via [`InvokeWithResponseStream`](https://docs.aws.amazon.com/lambda/latest/api/API_InvokeWithResponseStream.html) and forwards bytes to the client as soon as srvx writes them, instead of buffering the full response first.
+
+> [!NOTE]
+> `serverless offline` does **not** support Lambda response streaming ([serverless-offline#1681](https://github.com/dherault/serverless-offline/issues/1681)), so this can only be verified against a real deployment, not `npm run dev`.
+
+After deploying, hit the `/stream` endpoint with `curl` (not a browser — some browsers still buffer chunked responses from API Gateway, see [serverless#13177](https://github.com/serverless/serverless/issues/13177)) and watch chunks arrive roughly every 500ms instead of all at once at the end:
+
+```sh
+curl -N --no-buffer https://<your-api-id>.execute-api.<region>.amazonaws.com/stream
+```
+
+Each printed line embeds its own server-side timestamp, so if streaming is actually working you'll see `curl` print lines one by one, ~500ms apart, rather than all five lines appearing together after ~2.5s.

--- a/examples/aws-lambda/serverless.yml
+++ b/examples/aws-lambda/serverless.yml
@@ -27,6 +27,16 @@ functions:
           path: /{proxy+}
           method: ANY
           cors: true
+  stream:
+    handler: stream.streamHandler
+    events:
+      - http:
+          path: /stream
+          method: get
+          # Requires API Gateway REST API response streaming (Nov 2025+):
+          # https://docs.aws.amazon.com/apigateway/latest/developerguide/response-transfer-mode.html
+          response:
+            transferMode: STREAM
 
 custom:
   serverless-offline:

--- a/examples/aws-lambda/stream.ts
+++ b/examples/aws-lambda/stream.ts
@@ -1,0 +1,40 @@
+import { handleLambdaEventWithStream, type AWSLambdaStreamingHandler } from "srvx/aws-lambda";
+
+// The `awslambda` global is injected by the Lambda Node.js runtime and is
+// only present when the function is invoked via `InvokeWithResponseStream`
+// (Function URLs with `--invoke-mode RESPONSE_STREAM`, or an API Gateway
+// REST API integration configured with `response.transferMode: STREAM`).
+declare const awslambda: {
+  streamifyResponse: <T extends (...args: any[]) => any>(handler: T) => T;
+};
+
+const fetchHandler = async (request: Request) => {
+  const encoder = new TextEncoder();
+  let counter = 0;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      const interval = setInterval(() => {
+        counter++;
+        controller.enqueue(encoder.encode(`chunk ${counter} at ${new Date().toISOString()}\n`));
+        if (counter >= 5) {
+          clearInterval(interval);
+          controller.close();
+        }
+      }, 500);
+    },
+  });
+
+  return new Response(stream, {
+    headers: { "content-type": "text/plain; charset=utf-8" },
+  });
+};
+
+// Exported and wired up in `serverless.yml` behind a REST API (v1) `http`
+// event with `response.transferMode: STREAM`, to prove that srvx's AWS
+// Lambda streaming adapter also works through API Gateway REST APIs and
+// not just Lambda Function URLs. See https://github.com/h3js/srvx/issues/184
+export const streamHandler: AWSLambdaStreamingHandler = awslambda.streamifyResponse(
+  (event, responseStream, context) =>
+    handleLambdaEventWithStream(fetchHandler, event, responseStream, context),
+);

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -1241,5 +1241,99 @@ describe("[AWS Lambda] Request Utils", () => {
       // writer.end should NOT be called since error happened before streaming
       expect(mockWriter.end).not.toHaveBeenCalled();
     });
+
+    // API Gateway REST APIs (v1) now support response streaming via
+    // `responseTransferMode: STREAM` + the `InvokeWithResponseStream` API,
+    // using the same `APIGatewayProxyEvent` input shape as buffered proxy
+    // integrations. See: https://github.com/h3js/srvx/issues/184 and
+    // https://docs.aws.amazon.com/apigateway/latest/developerguide/response-transfer-mode-lambda.html
+    describe("API Gateway REST API (v1) streaming", () => {
+      test("delivers chunks to the writer progressively instead of buffering the full body", async () => {
+        const { mockStream, mockWriter, getChunks } = createMockResponseStream();
+
+        const fetchHandler = vi.fn().mockImplementation(async () => {
+          const encoder = new TextEncoder();
+          const stream = new ReadableStream({
+            async start(controller) {
+              controller.enqueue(encoder.encode("chunk-1"));
+              await Promise.resolve();
+              controller.enqueue(encoder.encode("chunk-2"));
+              await Promise.resolve();
+              controller.enqueue(encoder.encode("chunk-3"));
+              controller.close();
+            },
+          });
+          return new Response(stream, { headers: { "content-type": "text/plain" } });
+        });
+
+        const v1Event: APIGatewayProxyEvent = {
+          httpMethod: "GET",
+          path: "/stream",
+          headers: { host: "api.example.com" },
+          body: null,
+          isBase64Encoded: false,
+          multiValueHeaders: {},
+          multiValueQueryStringParameters: {},
+          pathParameters: null,
+          stageVariables: null,
+          requestContext: {} as any,
+          resource: "",
+          queryStringParameters: null,
+        };
+
+        await handleLambdaEventWithStream(fetchHandler, v1Event, mockStream, createMockContext());
+
+        // Each chunk must reach the writer as a separate write, otherwise
+        // API Gateway can't start forwarding bytes before the body is complete.
+        const decoder = new TextDecoder();
+        expect(getChunks().map((chunk) => decoder.decode(chunk as Uint8Array))).toEqual([
+          "chunk-1",
+          "chunk-2",
+          "chunk-3",
+        ]);
+        expect(mockWriter.end).toHaveBeenCalled();
+      });
+
+      test("emits a metadata prelude matching the API Gateway stream-response format", async () => {
+        const { mockStream, getMetadata } = createMockResponseStream();
+
+        const fetchHandler = vi.fn().mockResolvedValue(
+          new Response("ok", {
+            status: 201,
+            headers: { "content-type": "text/plain" },
+          }),
+        );
+
+        const v1Event: APIGatewayProxyEvent = {
+          httpMethod: "GET",
+          path: "/stream",
+          headers: { host: "api.example.com" },
+          body: null,
+          isBase64Encoded: false,
+          multiValueHeaders: {},
+          multiValueQueryStringParameters: {},
+          pathParameters: null,
+          stageVariables: null,
+          requestContext: {} as any,
+          resource: "",
+          queryStringParameters: null,
+        };
+
+        await handleLambdaEventWithStream(fetchHandler, v1Event, mockStream, createMockContext());
+
+        const metadata = getMetadata() as any;
+
+        // AWS only accepts `headers`, `multiValueHeaders`, `cookies` and
+        // `statusCode` in the JSON prelude - no v2-only fields should leak in.
+        expect(Object.keys(metadata).sort()).toEqual(["headers", "statusCode"]);
+        expect(metadata.statusCode).toBe(201);
+
+        // API Gateway requires either `Transfer-Encoding: chunked` or a
+        // `Content-Length` header on the prelude, or it rejects the stream.
+        expect(
+          metadata.headers["transfer-encoding"] || metadata.headers["content-length"],
+        ).toBeTruthy();
+      });
+    });
   });
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Resolves #184 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AWS Lambda streaming example for API Gateway REST API (v1).
  * Added a `/stream` endpoint that delivers five progressive plaintext chunks.
  * Added deployment and verification guidance, including expected streaming behavior.

* **Documentation**
  * Clarified AWS compatibility requirements for progressive response streaming.
  * Documented that HTTP API (v2), Application Load Balancer, and offline emulation do not currently support it.

* **Tests**
  * Added coverage verifying progressive chunk delivery and streaming response metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->