### PR TITLE
feat: add `trustProxy` option

### DIFF
--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -166,8 +166,8 @@ These headers are set by the client on the wire, so a plaintext request can send
 
 - `false` (default): ignore forwarded headers; derive the protocol from the real transport (`req.socket.encrypted` on Node). Secure by default.
 - `true`: always trust forwarded headers (previous behavior).
+- `"loopback"`: trust only when the immediate peer is a loopback address (`127.0.0.0/8` or `::1`), i.e. a proxy running on the same host.
 - `string[]`: trust only when the immediate peer address (e.g. `req.socket.remoteAddress`) is in the allowlist.
-- `(req) => boolean`: trust only when the predicate returns `true`. The argument is the runtime-native request (Node `IncomingMessage`) or event (AWS Lambda).
 
 **Example:**
 

--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -160,14 +160,14 @@ serve({
 
 ### `trustProxy`
 
-Whether to trust `X-Forwarded-Proto` (and the HTTP/2 `:scheme`) when deriving `request.url.protocol`. Defaults to `false`.
+Whether to trust `X-Forwarded-*` headers (`X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-For`, and the HTTP/2 `:scheme`) when deriving `request.url` and `request.ip`. Defaults to `false`.
 
-Any client can send `X-Forwarded-Proto: https`, so trusting it lets a plaintext request masquerade as `https:`. Only enable this when a proxy you control sits in front and overwrites the header.
+Any client can send `X-Forwarded-Proto: https`, `X-Forwarded-Host` or `X-Forwarded-For`, so trusting them lets a request masquerade as `https:`, forge its host, or spoof its client IP. Only enable this when a proxy you control sits in front and overwrites the headers.
 
-- `false` (default): ignore the header; use the real connection protocol.
-- `true`: always trust the header.
-- `"loopback"`: trust it only when the proxy connects from a loopback address (`127.0.0.0/8` or `::1`).
-- `string[]`: trust it only when the proxy's address is in the list.
+- `false` (default): ignore the headers; use the real connection protocol, the on-the-wire `Host` header and the socket peer address.
+- `true`: always trust the headers.
+- `"loopback"`: trust them only when the proxy connects from a loopback address (`127.0.0.0/8` or `::1`).
+- `string[]`: trust them only when the proxy's address is in the list.
 
 **Example:**
 
@@ -182,7 +182,7 @@ serve({
 ```
 
 > [!NOTE]
-> Only applies to the Node and AWS Lambda adapters. Bun, Deno and Cloudflare Workers already report the real protocol natively.
+> Only applies to the Node and AWS Lambda adapters. Bun, Deno and Cloudflare Workers already report the real protocol, host and IP natively.
 
 ## Runtime Specific Options
 

--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -158,6 +158,32 @@ serve({
 > - **Bun**: forwarded to Bun's native [`maxRequestBodySize`](https://bun.sh/docs/api/http), enforced by Bun (responds with `413` before the handler runs).
 > - **Deno**: enforced by srvx (`Deno.serve` has no native option).
 
+### `trustProxy`
+
+Trust `X-Forwarded-*` headers (and the HTTP/2 `:scheme` pseudo-header) when deriving request metadata such as `request.url.protocol`. Defaults to `false`.
+
+These headers are set by the client on the wire, so a plaintext request can send `X-Forwarded-Proto: https` and make `request.url.protocol` report `https:` for the whole request. Since the protocol drives `Secure` cookie decisions, absolute URL / redirect generation and "is this request secure?" checks, a single spoofed header can poison all of them. Enable this **only** when a proxy you control sits in front and overwrites these headers.
+
+- `false` (default): ignore forwarded headers; derive the protocol from the real transport (`req.socket.encrypted` on Node). Secure by default.
+- `true`: always trust forwarded headers (previous behavior).
+- `string[]`: trust only when the immediate peer address (e.g. `req.socket.remoteAddress`) is in the allowlist.
+- `(req) => boolean`: trust only when the predicate returns `true`. The argument is the runtime-native request (Node `IncomingMessage`) or event (AWS Lambda).
+
+**Example:**
+
+```js
+import { serve } from "srvx";
+
+serve({
+  // Behind a reverse proxy you control (e.g. Nginx, a load balancer):
+  trustProxy: true,
+  fetch: (request) => new Response(new URL(request.url).protocol),
+});
+```
+
+> [!NOTE]
+> Only affects adapters that reconstruct the protocol from headers (Node and AWS Lambda). Bun, Deno and Cloudflare Workers expose the real scheme through their platform `Request`.
+
 ## Runtime Specific Options
 
 ### Node.js

--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -182,7 +182,7 @@ serve({
 ```
 
 > [!NOTE]
-> Only applies to the Node and AWS Lambda adapters. Bun, Deno and Cloudflare Workers already report the real protocol, host and IP natively.
+> Applies to the Node, AWS Lambda, Bun and Deno adapters.
 
 ## Runtime Specific Options
 

--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -160,14 +160,14 @@ serve({
 
 ### `trustProxy`
 
-Trust `X-Forwarded-*` headers (and the HTTP/2 `:scheme` pseudo-header) when deriving request metadata such as `request.url.protocol`. Defaults to `false`.
+Whether to trust `X-Forwarded-Proto` (and the HTTP/2 `:scheme`) when deriving `request.url.protocol`. Defaults to `false`.
 
-These headers are set by the client on the wire, so a plaintext request can send `X-Forwarded-Proto: https` and make `request.url.protocol` report `https:` for the whole request. Since the protocol drives `Secure` cookie decisions, absolute URL / redirect generation and "is this request secure?" checks, a single spoofed header can poison all of them. Enable this **only** when a proxy you control sits in front and overwrites these headers.
+Any client can send `X-Forwarded-Proto: https`, so trusting it lets a plaintext request masquerade as `https:`. Only enable this when a proxy you control sits in front and overwrites the header.
 
-- `false` (default): ignore forwarded headers; derive the protocol from the real transport (`req.socket.encrypted` on Node). Secure by default.
-- `true`: always trust forwarded headers (previous behavior).
-- `"loopback"`: trust only when the immediate peer is a loopback address (`127.0.0.0/8` or `::1`), i.e. a proxy running on the same host.
-- `string[]`: trust only when the immediate peer address (e.g. `req.socket.remoteAddress`) is in the allowlist.
+- `false` (default): ignore the header; use the real connection protocol.
+- `true`: always trust the header.
+- `"loopback"`: trust it only when the proxy connects from a loopback address (`127.0.0.0/8` or `::1`).
+- `string[]`: trust it only when the proxy's address is in the list.
 
 **Example:**
 
@@ -182,7 +182,7 @@ serve({
 ```
 
 > [!NOTE]
-> Only affects adapters that reconstruct the protocol from headers (Node and AWS Lambda). Bun, Deno and Cloudflare Workers expose the real scheme through their platform `Request`.
+> Only applies to the Node and AWS Lambda adapters. Bun, Deno and Cloudflare Workers already report the real protocol natively.
 
 ## Runtime Specific Options
 

--- a/src/_trust-proxy.ts
+++ b/src/_trust-proxy.ts
@@ -1,13 +1,13 @@
 /**
- * Controls whether `X-Forwarded-*` headers (proto, and the HTTP/2 `:scheme`
- * pseudo-header) are trusted when deriving request metadata.
+ * Controls whether `X-Forwarded-*` headers (proto, host, for, and the HTTP/2
+ * `:scheme` pseudo-header) are trusted when deriving request metadata.
  *
  * These headers are set by the client on the wire, so they can only be trusted
  * when a proxy you control sits in front and overwrites them. See
  * {@link ServerOptions.trustProxy}.
  *
- *   - `false` (default): never trust forwarded headers; derive protocol from the
- *     real transport only.
+ *   - `false` (default): never trust forwarded headers; derive protocol, host
+ *     and client IP from the real transport only.
  *   - `true`: always trust forwarded headers.
  *   - `"loopback"`: trust only when the immediate peer is a loopback address
  *     (`127.0.0.0/8` or `::1`), i.e. a proxy running on the same host.

--- a/src/_trust-proxy.ts
+++ b/src/_trust-proxy.ts
@@ -1,3 +1,5 @@
+import type { ServerPlugin, ServerRequest } from "./types.ts";
+
 /**
  * Controls whether `X-Forwarded-*` headers (proto, host, for, and the HTTP/2
  * `:scheme` pseudo-header) are trusted when deriving request metadata.
@@ -44,4 +46,84 @@ function isLoopbackAddress(address: string | undefined): boolean {
     !!address &&
     (address === "::1" || address.startsWith("127.") || address.startsWith("::ffff:127."))
   );
+}
+
+/** Whether a host value carries an explicit `:port` (handles `[IPv6]:port`). */
+function forwardedHostHasPort(host: string): boolean {
+  const bracket = host.lastIndexOf("]");
+  return bracket === -1 ? host.includes(":") : host.indexOf(":", bracket) !== -1;
+}
+
+/** Leftmost/first entry of a comma-separated `X-Forwarded-*` header value. */
+function firstForwardedValue(value: string | null): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const first = value.split(",")[0].trim();
+  return first || undefined;
+}
+
+/**
+ * Universal `trustProxy` plugin for runtimes whose native `Request` already
+ * reports the real transport (Bun, Deno). When the immediate peer is a trusted
+ * proxy, it rewrites `request.url` from `X-Forwarded-Proto` / `X-Forwarded-Host`
+ * and `request.ip` from `X-Forwarded-For`.
+ *
+ * The Node and AWS Lambda adapters resolve these at request construction and do
+ * not use this plugin. It is a no-op when `trustProxy` is unset/`false`.
+ */
+export const trustProxyPlugin: ServerPlugin = (server) => {
+  const trustProxy = server.options.trustProxy;
+  if (trustProxy === undefined || trustProxy === false) {
+    return;
+  }
+  server.options.middleware.unshift((request, next) => {
+    applyTrustedProxy(request, trustProxy);
+    return next();
+  });
+};
+
+function applyTrustedProxy(request: ServerRequest, trustProxy: TrustProxyOption): void {
+  // The socket peer address stays authoritative for the trust decision, so read
+  // it (via the adapter's native getter) before any override below.
+  if (!isTrustedProxy(trustProxy, request.ip)) {
+    return;
+  }
+
+  const headers = request.headers;
+
+  // request.url <- X-Forwarded-Proto / X-Forwarded-Host
+  const forwardedProto = firstForwardedValue(headers.get("x-forwarded-proto"));
+  const forwardedHost = firstForwardedValue(headers.get("x-forwarded-host"));
+  if (forwardedProto || forwardedHost) {
+    const url = new URL(request.url);
+    if (forwardedProto === "https" || forwardedProto === "http") {
+      url.protocol = `${forwardedProto}:`;
+    }
+    if (forwardedHost) {
+      // Invalid hosts are ignored by the URL setter, keeping the original host.
+      url.host = forwardedHost;
+      // The `host` setter only updates the port when the value carries one, so
+      // an origin-form host (no port) would inherit the listener's port. The
+      // forwarded host is authoritative, so drop any leftover port in that case.
+      if (url.port && !forwardedHostHasPort(forwardedHost)) {
+        url.port = "";
+      }
+    }
+    Object.defineProperty(request, "url", {
+      value: url.href,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+
+  // request.ip <- X-Forwarded-For (leftmost = original client)
+  const forwardedFor = firstForwardedValue(headers.get("x-forwarded-for"));
+  if (forwardedFor) {
+    Object.defineProperty(request, "ip", {
+      value: forwardedFor,
+      enumerable: true,
+      configurable: true,
+    });
+  }
 }

--- a/src/_trust-proxy.ts
+++ b/src/_trust-proxy.ts
@@ -9,23 +9,21 @@
  *   - `false` (default): never trust forwarded headers; derive protocol from the
  *     real transport only.
  *   - `true`: always trust forwarded headers.
+ *   - `"loopback"`: trust only when the immediate peer is a loopback address
+ *     (`127.0.0.0/8` or `::1`), i.e. a proxy running on the same host.
  *   - `string[]`: trust only when the immediate peer address is in the allowlist.
- *   - `(req) => boolean`: trust only when the predicate returns `true` for the
- *     runtime-native request/event.
  */
-export type TrustProxyOption = boolean | string[] | ((req: any) => boolean);
+export type TrustProxyOption = boolean | "loopback" | string[];
 
 /**
  * Resolve whether forwarded headers should be trusted for a given request.
  *
  * @param trustProxy - The configured {@link TrustProxyOption} (or `undefined`).
- * @param remoteAddress - Address of the immediate peer (for the allowlist form).
- * @param req - Runtime-native request/event passed to the predicate form.
+ * @param remoteAddress - Address of the immediate peer.
  */
 export function isTrustedProxy(
   trustProxy: TrustProxyOption | undefined,
   remoteAddress: string | undefined,
-  req: unknown,
 ): boolean {
   if (trustProxy === undefined || trustProxy === false) {
     return false;
@@ -33,9 +31,17 @@ export function isTrustedProxy(
   if (trustProxy === true) {
     return true;
   }
-  if (typeof trustProxy === "function") {
-    return trustProxy(req) === true;
+  if (trustProxy === "loopback") {
+    return isLoopbackAddress(remoteAddress);
   }
   // Allowlist of trusted immediate-peer addresses.
   return remoteAddress !== undefined && trustProxy.includes(remoteAddress);
+}
+
+/** Whether `address` is an IPv4/IPv6 loopback address. */
+function isLoopbackAddress(address: string | undefined): boolean {
+  return (
+    !!address &&
+    (address === "::1" || address.startsWith("127.") || address.startsWith("::ffff:127."))
+  );
 }

--- a/src/_trust-proxy.ts
+++ b/src/_trust-proxy.ts
@@ -1,0 +1,41 @@
+/**
+ * Controls whether `X-Forwarded-*` headers (proto, and the HTTP/2 `:scheme`
+ * pseudo-header) are trusted when deriving request metadata.
+ *
+ * These headers are set by the client on the wire, so they can only be trusted
+ * when a proxy you control sits in front and overwrites them. See
+ * {@link ServerOptions.trustProxy}.
+ *
+ *   - `false` (default): never trust forwarded headers; derive protocol from the
+ *     real transport only.
+ *   - `true`: always trust forwarded headers.
+ *   - `string[]`: trust only when the immediate peer address is in the allowlist.
+ *   - `(req) => boolean`: trust only when the predicate returns `true` for the
+ *     runtime-native request/event.
+ */
+export type TrustProxyOption = boolean | string[] | ((req: any) => boolean);
+
+/**
+ * Resolve whether forwarded headers should be trusted for a given request.
+ *
+ * @param trustProxy - The configured {@link TrustProxyOption} (or `undefined`).
+ * @param remoteAddress - Address of the immediate peer (for the allowlist form).
+ * @param req - Runtime-native request/event passed to the predicate form.
+ */
+export function isTrustedProxy(
+  trustProxy: TrustProxyOption | undefined,
+  remoteAddress: string | undefined,
+  req: unknown,
+): boolean {
+  if (trustProxy === undefined || trustProxy === false) {
+    return false;
+  }
+  if (trustProxy === true) {
+    return true;
+  }
+  if (typeof trustProxy === "function") {
+    return trustProxy(req) === true;
+  }
+  // Allowlist of trusted immediate-peer addresses.
+  return remoteAddress !== undefined && trustProxy.includes(remoteAddress);
+}

--- a/src/_trust-proxy.ts
+++ b/src/_trust-proxy.ts
@@ -36,8 +36,24 @@ export function isTrustedProxy(
   if (trustProxy === "loopback") {
     return isLoopbackAddress(remoteAddress);
   }
-  // Allowlist of trusted immediate-peer addresses.
-  return remoteAddress !== undefined && trustProxy.includes(remoteAddress);
+  // Allowlist of trusted immediate-peer addresses. Dual-stack Node reports an
+  // IPv4 peer as an IPv4-mapped IPv6 address (`::ffff:10.0.0.1`), so also match
+  // the bare IPv4 form against the allowlist.
+  if (remoteAddress === undefined) {
+    return false;
+  }
+  if (trustProxy.includes(remoteAddress)) {
+    return true;
+  }
+  const mapped = ipv4FromMapped(remoteAddress);
+  return mapped !== undefined && trustProxy.includes(mapped);
+}
+
+/** Bare IPv4 form of an IPv4-mapped IPv6 address (`::ffff:1.2.3.4` -> `1.2.3.4`). */
+function ipv4FromMapped(address: string): string | undefined {
+  return address.startsWith("::ffff:") && address.includes(".")
+    ? address.slice("::ffff:".length)
+    : undefined;
 }
 
 /** Whether `address` is an IPv4/IPv6 loopback address. */
@@ -48,18 +64,33 @@ function isLoopbackAddress(address: string | undefined): boolean {
   );
 }
 
+/**
+ * Validates an HTTP Host header value (domain, IPv4, or bracketed IPv6) with
+ * optional port. Used to reject spoofed/malformed hosts (e.g. `"localhost:3000/foobar?"`
+ * or a forwarded host containing whitespace) across every adapter.
+ */
+export const HOST_RE: RegExp =
+  /^(\[(?:[A-Fa-f0-9:.]+)\]|(?:[A-Za-z0-9_-]+\.)*[A-Za-z0-9_-]+|(?:\d{1,3}\.){3}\d{1,3})(:\d{1,5})?$/;
+
 /** Whether a host value carries an explicit `:port` (handles `[IPv6]:port`). */
 function forwardedHostHasPort(host: string): boolean {
   const bracket = host.lastIndexOf("]");
   return bracket === -1 ? host.includes(":") : host.indexOf(":", bracket) !== -1;
 }
 
-/** Leftmost/first entry of a comma-separated `X-Forwarded-*` header value. */
-function firstForwardedValue(value: string | null): string | undefined {
+/**
+ * Leftmost/first entry of a comma-separated `X-Forwarded-*` header value. With a
+ * chain of proxies the header is a comma-separated list; the leftmost entry is
+ * the value seen by the outermost proxy. Node exposes repeated headers as a
+ * `string[]`, so the array form is normalized to its first element.
+ */
+export function firstForwardedValue(
+  value: string | string[] | null | undefined,
+): string | undefined {
   if (!value) {
     return undefined;
   }
-  const first = value.split(",")[0].trim();
+  const first = (Array.isArray(value) ? value[0] : value).split(",")[0].trim();
   return first || undefined;
 }
 
@@ -100,8 +131,11 @@ function applyTrustedProxy(request: ServerRequest, trustProxy: TrustProxyOption)
     if (forwardedProto === "https" || forwardedProto === "http") {
       url.protocol = `${forwardedProto}:`;
     }
-    if (forwardedHost) {
-      // Invalid hosts are ignored by the URL setter, keeping the original host.
+    // Only apply a well-formed forwarded host. Relying on the URL setter to
+    // reject invalid values silently keeps the original host but still runs the
+    // port-reset below, which would drop the real listener port. Validating up
+    // front (same `HOST_RE` as the Node adapter) skips bad values entirely.
+    if (forwardedHost && HOST_RE.test(forwardedHost)) {
       url.host = forwardedHost;
       // The `host` setter only updates the port when the value carries one, so
       // an origin-form host (no port) would inherit the listener's port. The

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -1,6 +1,6 @@
 import type { ServerRequest } from "../../types.ts";
 import type { TrustProxyOption } from "../../_trust-proxy.ts";
-import { isTrustedProxy } from "../../_trust-proxy.ts";
+import { isTrustedProxy, firstForwardedValue } from "../../_trust-proxy.ts";
 import type {
   APIGatewayProxyEvent,
   Context as AWSContext,
@@ -34,7 +34,12 @@ export function awsRequest(
   context: AWSContext,
   trustProxy?: TrustProxyOption,
 ): ServerRequest {
-  const req = new Request(awsEventURL(event, trustProxy), {
+  // Resolve the immediate-peer address and trust decision once and pass them
+  // down; both the URL and the client IP derivation need them.
+  const sourceIp = awsEventIP(event);
+  const trusted = isTrustedProxy(trustProxy, sourceIp);
+
+  const req = new Request(awsEventURL(event, trusted), {
     method: awsEventMethod(event),
     headers: awsEventHeaders(event),
     body: awsEventBody(event),
@@ -45,7 +50,7 @@ export function awsRequest(
     awsLambda: { event, context },
   };
 
-  req.ip = awsEventClientIP(event, trustProxy);
+  req.ip = awsEventClientIP(event, sourceIp, trusted);
 
   return req;
 }
@@ -71,13 +76,13 @@ function awsEventIP(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): strin
  */
 function awsEventClientIP(
   event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
-  trustProxy?: TrustProxyOption,
+  sourceIp: string | undefined,
+  trusted: boolean,
 ): string | undefined {
-  const sourceIp = awsEventIP(event);
-  if (isTrustedProxy(trustProxy, sourceIp)) {
-    const forwarded = (event.headers["X-Forwarded-For"] || event.headers["x-forwarded-for"])
-      ?.split(",")[0]
-      .trim();
+  if (trusted) {
+    const forwarded = firstForwardedValue(
+      event.headers["X-Forwarded-For"] || event.headers["x-forwarded-for"],
+    );
     if (forwarded) {
       return forwarded;
     }
@@ -85,23 +90,18 @@ function awsEventClientIP(
   return sourceIp;
 }
 
-function awsEventURL(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
-  trustProxy?: TrustProxyOption,
-): URL {
+function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2, trusted: boolean): URL {
   const path = (event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath;
 
   const query = awsEventQuery(event);
 
   // Only honor client-supplied `X-Forwarded-*` headers when the proxy is
   // trusted; otherwise any client could spoof the host or protocol.
-  const trusted = isTrustedProxy(trustProxy, awsEventIP(event));
-
   const forwardedHost = trusted
-    ? event.headers["X-Forwarded-Host"] || event.headers["x-forwarded-host"]
+    ? firstForwardedValue(event.headers["X-Forwarded-Host"] || event.headers["x-forwarded-host"])
     : undefined;
   const hostname =
-    forwardedHost?.split(",")[0].trim() ||
+    forwardedHost ||
     event.headers.host ||
     event.headers.Host ||
     event.requestContext?.domainName ||
@@ -109,7 +109,7 @@ function awsEventURL(
 
   // Assume `https` when untrusted (Lambda is always TLS-terminated at the gateway).
   const forwardedProto = trusted
-    ? event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"]
+    ? firstForwardedValue(event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"])
     : undefined;
   const protocol = forwardedProto === "http" ? "http" : "https";
 

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -45,7 +45,7 @@ export function awsRequest(
     awsLambda: { event, context },
   };
 
-  req.ip = awsEventIP(event);
+  req.ip = awsEventClientIP(event, trustProxy);
 
   return req;
 }
@@ -65,20 +65,50 @@ function awsEventIP(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): strin
   );
 }
 
+/**
+ * Resolve the client IP, preferring the leftmost `X-Forwarded-For` entry when
+ * the immediate peer (the gateway `sourceIp`) is a trusted proxy.
+ */
+function awsEventClientIP(
+  event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
+  trustProxy?: TrustProxyOption,
+): string | undefined {
+  const sourceIp = awsEventIP(event);
+  if (isTrustedProxy(trustProxy, sourceIp)) {
+    const forwarded = (event.headers["X-Forwarded-For"] || event.headers["x-forwarded-for"])
+      ?.split(",")[0]
+      .trim();
+    if (forwarded) {
+      return forwarded;
+    }
+  }
+  return sourceIp;
+}
+
 function awsEventURL(
   event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
   trustProxy?: TrustProxyOption,
 ): URL {
-  const hostname =
-    event.headers.host || event.headers.Host || event.requestContext?.domainName || ".";
-
   const path = (event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath;
 
   const query = awsEventQuery(event);
 
-  // Only honor a client-supplied `X-Forwarded-Proto` when the proxy is trusted;
-  // otherwise assume `https` (Lambda is always TLS-terminated at the gateway).
-  const forwardedProto = isTrustedProxy(trustProxy, awsEventIP(event))
+  // Only honor client-supplied `X-Forwarded-*` headers when the proxy is
+  // trusted; otherwise any client could spoof the host or protocol.
+  const trusted = isTrustedProxy(trustProxy, awsEventIP(event));
+
+  const forwardedHost = trusted
+    ? event.headers["X-Forwarded-Host"] || event.headers["x-forwarded-host"]
+    : undefined;
+  const hostname =
+    forwardedHost?.split(",")[0].trim() ||
+    event.headers.host ||
+    event.headers.Host ||
+    event.requestContext?.domainName ||
+    ".";
+
+  // Assume `https` when untrusted (Lambda is always TLS-terminated at the gateway).
+  const forwardedProto = trusted
     ? event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"]
     : undefined;
   const protocol = forwardedProto === "http" ? "http" : "https";

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -1,4 +1,6 @@
 import type { ServerRequest } from "../../types.ts";
+import type { TrustProxyOption } from "../../_trust-proxy.ts";
+import { isTrustedProxy } from "../../_trust-proxy.ts";
 import type {
   APIGatewayProxyEvent,
   Context as AWSContext,
@@ -30,8 +32,9 @@ export interface AWSResponseHeaders {
 export function awsRequest(
   event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
   context: AWSContext,
+  trustProxy?: TrustProxyOption,
 ): ServerRequest {
-  const req = new Request(awsEventURL(event), {
+  const req = new Request(awsEventURL(event, trustProxy), {
     method: awsEventMethod(event),
     headers: awsEventHeaders(event),
     body: awsEventBody(event),
@@ -62,7 +65,10 @@ function awsEventIP(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): strin
   );
 }
 
-function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): URL {
+function awsEventURL(
+  event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
+  trustProxy?: TrustProxyOption,
+): URL {
   const hostname =
     event.headers.host || event.headers.Host || event.requestContext?.domainName || ".";
 
@@ -70,10 +76,12 @@ function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): URL 
 
   const query = awsEventQuery(event);
 
-  const protocol =
-    (event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"]) === "http"
-      ? "http"
-      : "https";
+  // Only honor a client-supplied `X-Forwarded-Proto` when the proxy is trusted;
+  // otherwise assume `https` (Lambda is always TLS-terminated at the gateway).
+  const forwardedProto = isTrustedProxy(trustProxy, awsEventIP(event), event)
+    ? event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"]
+    : undefined;
+  const protocol = forwardedProto === "http" ? "http" : "https";
 
   return new URL(`${path}${query ? `?${query}` : ""}`, `${protocol}://${hostname}`);
 }

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -78,7 +78,7 @@ function awsEventURL(
 
   // Only honor a client-supplied `X-Forwarded-Proto` when the proxy is trusted;
   // otherwise assume `https` (Lambda is always TLS-terminated at the gateway).
-  const forwardedProto = isTrustedProxy(trustProxy, awsEventIP(event), event)
+  const forwardedProto = isTrustedProxy(trustProxy, awsEventIP(event))
     ? event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"]
     : undefined;
   const protocol = forwardedProto === "http" ? "http" : "https";

--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -5,6 +5,7 @@ import type {
   NodeServerResponse,
   ServerRequest,
 } from "../../types.ts";
+import type { TrustProxyOption } from "../../_trust-proxy.ts";
 import { fetchNodeHandler } from "../node.ts";
 import { NodeRequest } from "./request.ts";
 import { sendNodeResponse } from "./send.ts";
@@ -19,7 +20,7 @@ export type AdapterMeta = {
  */
 export function toNodeHandler(
   handler: FetchHandler & AdapterMeta,
-  options?: { maxRequestBodySize?: number },
+  options?: { maxRequestBodySize?: number; trustProxy?: TrustProxyOption },
 ): NodeHttpHandler & AdapterMeta {
   if (handler.__nodeHandler) {
     return handler.__nodeHandler;
@@ -30,6 +31,7 @@ export function toNodeHandler(
       req: nodeReq,
       res: nodeRes,
       maxRequestBodySize: options?.maxRequestBodySize,
+      trustProxy: options?.trustProxy,
     });
     const res = handler(request);
     return res instanceof Promise

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -1,5 +1,6 @@
 import type { NodeServerRequest, NodeServerResponse, ServerRequest } from "../../types.ts";
 import type { TrustProxyOption } from "../../_trust-proxy.ts";
+import { isTrustedProxy } from "../../_trust-proxy.ts";
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
@@ -16,7 +17,7 @@ export type NodeRequestContext = {
   maxRequestBodySize?: number;
   /**
    * Whether to trust `X-Forwarded-*` / `:scheme` headers when deriving the
-   * request protocol. See `ServerOptions.trustProxy`.
+   * request protocol, host and client IP. See `ServerOptions.trustProxy`.
    */
   trustProxy?: TrustProxyOption;
 };
@@ -62,7 +63,17 @@ export const NodeRequest: {
     }
 
     get ip(): string | undefined {
-      return this.#req.socket?.remoteAddress;
+      const remoteAddress = this.#req.socket?.remoteAddress;
+      // Only honor `X-Forwarded-For` when the immediate peer is a trusted proxy;
+      // otherwise any client could forge its address. The leftmost entry is the
+      // original client as seen by the outermost trusted proxy.
+      if (isTrustedProxy(this.#trustProxy, remoteAddress)) {
+        const forwarded = forwardedFor(this.#req.headers["x-forwarded-for"]);
+        if (forwarded) {
+          return forwarded;
+        }
+      }
+      return remoteAddress;
     }
 
     get method(): string {
@@ -235,6 +246,19 @@ export function patchGlobalRequest(): typeof Request {
     globalThis.Request = PatchedRequest as unknown as typeof globalThis.Request;
   }
   return PatchedRequest;
+}
+
+/**
+ * Extract the client address from an `X-Forwarded-For` header value. With a
+ * chain of proxies the header is a comma-separated list; the leftmost entry is
+ * the original client seen by the outermost proxy.
+ */
+function forwardedFor(value: string | string[] | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const first = (Array.isArray(value) ? value[0] : value).split(",")[0].trim();
+  return first || undefined;
 }
 
 /**

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -44,6 +44,8 @@ export const NodeRequest: {
     #abortController?: AbortController;
     #maxRequestBodySize?: number;
     #trustProxy?: TrustProxyOption;
+    #ip?: string;
+    #ipResolved = false;
 
     constructor(ctx: NodeRequestContext) {
       this.#req = ctx.req;
@@ -63,6 +65,13 @@ export const NodeRequest: {
     }
 
     get ip(): string | undefined {
+      // Resolve once: the peer address and forwarded header are fixed for the
+      // lifetime of the request, and `isTrustedProxy` would otherwise re-run on
+      // every access.
+      if (this.#ipResolved) {
+        return this.#ip;
+      }
+      this.#ipResolved = true;
       const remoteAddress = this.#req.socket?.remoteAddress;
       // Only honor `X-Forwarded-For` when the immediate peer is a trusted proxy;
       // otherwise any client could forge its address. The leftmost entry is the
@@ -70,10 +79,10 @@ export const NodeRequest: {
       if (isTrustedProxy(this.#trustProxy, remoteAddress)) {
         const forwarded = forwardedFor(this.#req.headers["x-forwarded-for"]);
         if (forwarded) {
-          return forwarded;
+          return (this.#ip = forwarded);
         }
       }
-      return remoteAddress;
+      return (this.#ip = remoteAddress);
     }
 
     get method(): string {

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -1,4 +1,5 @@
 import type { NodeServerRequest, NodeServerResponse, ServerRequest } from "../../types.ts";
+import type { TrustProxyOption } from "../../_trust-proxy.ts";
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
@@ -13,6 +14,11 @@ export type NodeRequestContext = {
    * buffered reads and the streamed body. See `ServerOptions.maxRequestBodySize`.
    */
   maxRequestBodySize?: number;
+  /**
+   * Whether to trust `X-Forwarded-*` / `:scheme` headers when deriving the
+   * request protocol. See `ServerOptions.trustProxy`.
+   */
+  trustProxy?: TrustProxyOption;
 };
 
 const kNativeRequest = /* @__PURE__ */ Symbol.for("srvx.nativeRequest");
@@ -36,10 +42,12 @@ export const NodeRequest: {
     #headers?: NodeRequestHeaders;
     #abortController?: AbortController;
     #maxRequestBodySize?: number;
+    #trustProxy?: TrustProxyOption;
 
     constructor(ctx: NodeRequestContext) {
       this.#req = ctx.req;
       this.#maxRequestBodySize = ctx.maxRequestBodySize;
+      this.#trustProxy = ctx.trustProxy;
       this.runtime = {
         name: "node",
         // Reuse the context object as-is to avoid a per-request allocation on
@@ -65,7 +73,10 @@ export const NodeRequest: {
     }
 
     get _url() {
-      return (this.#url ||= new NodeRequestURL({ req: this.#req }));
+      return (this.#url ||= new NodeRequestURL({
+        req: this.#req,
+        trustProxy: this.#trustProxy,
+      }));
     }
 
     set _url(url: URL) {

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -1,6 +1,6 @@
 import type { NodeServerRequest, NodeServerResponse, ServerRequest } from "../../types.ts";
 import type { TrustProxyOption } from "../../_trust-proxy.ts";
-import { isTrustedProxy } from "../../_trust-proxy.ts";
+import { isTrustedProxy, firstForwardedValue } from "../../_trust-proxy.ts";
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
@@ -46,6 +46,8 @@ export const NodeRequest: {
     #trustProxy?: TrustProxyOption;
     #ip?: string;
     #ipResolved = false;
+    #remoteAddress?: string;
+    #trusted?: boolean;
 
     constructor(ctx: NodeRequestContext) {
       this.#req = ctx.req;
@@ -64,25 +66,35 @@ export const NodeRequest: {
       return val instanceof NativeRequest;
     }
 
+    // Resolve the trust decision once: the peer address is fixed for the
+    // lifetime of the request, and both `ip` and `_url` need it. `isTrustedProxy`
+    // (and the `socket.remoteAddress` read) would otherwise run twice per request.
+    #resolveTrusted(): boolean {
+      if (this.#trusted === undefined) {
+        this.#remoteAddress = this.#req.socket?.remoteAddress;
+        this.#trusted = isTrustedProxy(this.#trustProxy, this.#remoteAddress);
+      }
+      return this.#trusted;
+    }
+
     get ip(): string | undefined {
       // Resolve once: the peer address and forwarded header are fixed for the
-      // lifetime of the request, and `isTrustedProxy` would otherwise re-run on
-      // every access.
+      // lifetime of the request.
       if (this.#ipResolved) {
         return this.#ip;
       }
       this.#ipResolved = true;
-      const remoteAddress = this.#req.socket?.remoteAddress;
+      const trusted = this.#resolveTrusted();
       // Only honor `X-Forwarded-For` when the immediate peer is a trusted proxy;
       // otherwise any client could forge its address. The leftmost entry is the
       // original client as seen by the outermost trusted proxy.
-      if (isTrustedProxy(this.#trustProxy, remoteAddress)) {
-        const forwarded = forwardedFor(this.#req.headers["x-forwarded-for"]);
+      if (trusted) {
+        const forwarded = firstForwardedValue(this.#req.headers["x-forwarded-for"]);
         if (forwarded) {
           return (this.#ip = forwarded);
         }
       }
-      return (this.#ip = remoteAddress);
+      return (this.#ip = this.#remoteAddress);
     }
 
     get method(): string {
@@ -95,7 +107,7 @@ export const NodeRequest: {
     get _url() {
       return (this.#url ||= new NodeRequestURL({
         req: this.#req,
-        trustProxy: this.#trustProxy,
+        trusted: this.#resolveTrusted(),
       }));
     }
 
@@ -255,19 +267,6 @@ export function patchGlobalRequest(): typeof Request {
     globalThis.Request = PatchedRequest as unknown as typeof globalThis.Request;
   }
   return PatchedRequest;
-}
-
-/**
- * Extract the client address from an `X-Forwarded-For` header value. With a
- * chain of proxies the header is a comma-separated list; the leftmost entry is
- * the original client seen by the outermost proxy.
- */
-function forwardedFor(value: string | string[] | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const first = (Array.isArray(value) ? value[0] : value).split(",")[0].trim();
-  return first || undefined;
 }
 
 /**

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -1,4 +1,6 @@
 import type { NodeServerRequest } from "../../types.ts";
+import type { TrustProxyOption } from "../../_trust-proxy.ts";
+import { isTrustedProxy } from "../../_trust-proxy.ts";
 import { FastURL } from "../../_url.ts";
 
 /**
@@ -9,7 +11,7 @@ export const HOST_RE: RegExp =
   /^(\[(?:[A-Fa-f0-9:.]+)\]|(?:[A-Za-z0-9_-]+\.)*[A-Za-z0-9_-]+|(?:\d{1,3}\.){3}\d{1,3})(:\d{1,5})?$/;
 
 export class NodeRequestURL extends FastURL {
-  constructor({ req }: { req: NodeServerRequest }) {
+  constructor({ req, trustProxy }: { req: NodeServerRequest; trustProxy?: TrustProxyOption }) {
     const path = req.url || "/";
 
     let host = req.headers.host || (req.headers[":authority"] as string);
@@ -23,10 +25,15 @@ export class NodeRequestURL extends FastURL {
       }
     }
 
+    // Only honor client-supplied forwarded protocol hints when the request
+    // comes through a trusted proxy; otherwise any client could spoof `https`
+    // on a plaintext connection. The real transport (`encrypted`) is always
+    // authoritative.
+    const trusted = isTrustedProxy(trustProxy, req.socket?.remoteAddress, req);
     const protocol =
       (req.socket as any)?.encrypted ||
-      req.headers["x-forwarded-proto"] === "https" ||
-      req.headers[":scheme"] === "https"
+      (trusted &&
+        (req.headers["x-forwarded-proto"] === "https" || req.headers[":scheme"] === "https"))
         ? "https:"
         : "http:";
 

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -1,40 +1,25 @@
 import type { NodeServerRequest } from "../../types.ts";
-import type { TrustProxyOption } from "../../_trust-proxy.ts";
-import { isTrustedProxy } from "../../_trust-proxy.ts";
+import { HOST_RE, firstForwardedValue } from "../../_trust-proxy.ts";
 import { FastURL } from "../../_url.ts";
 
-/**
- * Validates an HTTP Host header value (domain, IPv4, or bracketed IPv6) with optional port.
- * Intended for preliminary filtering invalid values like "localhost:3000/foobar?"
- */
-export const HOST_RE: RegExp =
-  /^(\[(?:[A-Fa-f0-9:.]+)\]|(?:[A-Za-z0-9_-]+\.)*[A-Za-z0-9_-]+|(?:\d{1,3}\.){3}\d{1,3})(:\d{1,5})?$/;
-
-/**
- * Extract the client-facing host from an `X-Forwarded-Host` header value. When
- * a chain of proxies is involved the header is a comma-separated list; the
- * first entry is the original host seen by the outermost proxy.
- */
-function forwardedHost(value: string | string[] | undefined): string | undefined {
-  if (!value) {
-    return undefined;
-  }
-  const first = (Array.isArray(value) ? value[0] : value).split(",")[0].trim();
-  return first || undefined;
-}
+export { HOST_RE };
 
 export class NodeRequestURL extends FastURL {
-  constructor({ req, trustProxy }: { req: NodeServerRequest; trustProxy?: TrustProxyOption }) {
+  constructor({ req, trusted = false }: { req: NodeServerRequest; trusted?: boolean }) {
     const path = req.url || "/";
 
     // Only honor client-supplied `X-Forwarded-*` hints when the request comes
-    // through a trusted proxy; otherwise any client could spoof the host or
-    // `https` on a plaintext connection. The real transport (`encrypted`) and
-    // the on-the-wire `Host` header remain authoritative when untrusted.
-    const trusted = isTrustedProxy(trustProxy, req.socket?.remoteAddress);
+    // through a trusted proxy (`trusted`); otherwise any client could spoof the
+    // host or `https` on a plaintext connection. The real transport
+    // (`encrypted`) and the on-the-wire `Host` header stay authoritative.
+    // A malformed forwarded host is ignored (fall back to the real `Host`),
+    // matching the universal trustProxy plugin used on Bun/Deno.
+    const forwardedHost = trusted
+      ? firstForwardedValue(req.headers["x-forwarded-host"])
+      : undefined;
 
     let host =
-      (trusted && forwardedHost(req.headers["x-forwarded-host"])) ||
+      (forwardedHost && HOST_RE.test(forwardedHost) ? forwardedHost : undefined) ||
       req.headers.host ||
       (req.headers[":authority"] as string);
     if (host && !HOST_RE.test(host)) {
@@ -47,10 +32,16 @@ export class NodeRequestURL extends FastURL {
       }
     }
 
+    // A proxy chain can join `X-Forwarded-Proto` into a comma-separated list, so
+    // compare the leftmost entry (via `firstForwardedValue`) rather than the raw
+    // header. The HTTP/2 `:scheme` pseudo-header is always a single value.
+    const forwardedProto = trusted
+      ? firstForwardedValue(req.headers["x-forwarded-proto"])
+      : undefined;
     const protocol =
       (req.socket as any)?.encrypted ||
-      (trusted &&
-        (req.headers["x-forwarded-proto"] === "https" || req.headers[":scheme"] === "https"))
+      forwardedProto === "https" ||
+      (trusted && req.headers[":scheme"] === "https")
         ? "https:"
         : "http:";
 

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -29,7 +29,7 @@ export class NodeRequestURL extends FastURL {
     // comes through a trusted proxy; otherwise any client could spoof `https`
     // on a plaintext connection. The real transport (`encrypted`) is always
     // authoritative.
-    const trusted = isTrustedProxy(trustProxy, req.socket?.remoteAddress, req);
+    const trusted = isTrustedProxy(trustProxy, req.socket?.remoteAddress);
     const protocol =
       (req.socket as any)?.encrypted ||
       (trusted &&

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -10,11 +10,33 @@ import { FastURL } from "../../_url.ts";
 export const HOST_RE: RegExp =
   /^(\[(?:[A-Fa-f0-9:.]+)\]|(?:[A-Za-z0-9_-]+\.)*[A-Za-z0-9_-]+|(?:\d{1,3}\.){3}\d{1,3})(:\d{1,5})?$/;
 
+/**
+ * Extract the client-facing host from an `X-Forwarded-Host` header value. When
+ * a chain of proxies is involved the header is a comma-separated list; the
+ * first entry is the original host seen by the outermost proxy.
+ */
+function forwardedHost(value: string | string[] | undefined): string | undefined {
+  if (!value) {
+    return undefined;
+  }
+  const first = (Array.isArray(value) ? value[0] : value).split(",")[0].trim();
+  return first || undefined;
+}
+
 export class NodeRequestURL extends FastURL {
   constructor({ req, trustProxy }: { req: NodeServerRequest; trustProxy?: TrustProxyOption }) {
     const path = req.url || "/";
 
-    let host = req.headers.host || (req.headers[":authority"] as string);
+    // Only honor client-supplied `X-Forwarded-*` hints when the request comes
+    // through a trusted proxy; otherwise any client could spoof the host or
+    // `https` on a plaintext connection. The real transport (`encrypted`) and
+    // the on-the-wire `Host` header remain authoritative when untrusted.
+    const trusted = isTrustedProxy(trustProxy, req.socket?.remoteAddress);
+
+    let host =
+      (trusted && forwardedHost(req.headers["x-forwarded-host"])) ||
+      req.headers.host ||
+      (req.headers[":authority"] as string);
     if (host && !HOST_RE.test(host)) {
       host = "_invalid_";
     } else if (!host) {
@@ -25,11 +47,6 @@ export class NodeRequestURL extends FastURL {
       }
     }
 
-    // Only honor client-supplied forwarded protocol hints when the request
-    // comes through a trusted proxy; otherwise any client could spoof `https`
-    // on a plaintext connection. The real transport (`encrypted`) is always
-    // authoritative.
-    const trusted = isTrustedProxy(trustProxy, req.socket?.remoteAddress);
     const protocol =
       (req.socket as any)?.encrypted ||
       (trusted &&

--- a/src/adapters/aws-lambda.ts
+++ b/src/adapters/aws-lambda.ts
@@ -1,5 +1,6 @@
 import type * as AWS from "aws-lambda";
 import type { FetchHandler, Server, ServerOptions } from "../types.ts";
+import type { TrustProxyOption } from "../_trust-proxy.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
 import {
@@ -39,8 +40,9 @@ export async function handleLambdaEvent(
   fetchHandler: FetchHandler,
   event: AwsLambdaEvent,
   context: AWS.Context,
+  trustProxy?: TrustProxyOption,
 ): Promise<AWS.APIGatewayProxyResult | AWS.APIGatewayProxyResultV2> {
-  const request = awsRequest(event, context);
+  const request = awsRequest(event, context, trustProxy);
   const response = await fetchHandler(request);
   return {
     statusCode: response.status,
@@ -54,8 +56,9 @@ export async function handleLambdaEventWithStream(
   event: AwsLambdaEvent,
   responseStream: AWSLambdaResponseStream,
   context: AWS.Context,
+  trustProxy?: TrustProxyOption,
 ): Promise<void> {
-  const request = awsRequest(event, context);
+  const request = awsRequest(event, context, trustProxy);
   const response = await fetchHandler(request);
   await awsStreamResponse(response, responseStream, event);
 }
@@ -83,7 +86,7 @@ class AWSLambdaServer implements Server<AWSLambdaHandler> {
     const fetchHandler = wrapFetch(this as unknown as Server);
 
     this.fetch = (event: AwsLambdaEvent, context: AWS.Context) =>
-      handleLambdaEvent(fetchHandler, event, context);
+      handleLambdaEvent(fetchHandler, event, context, this.options.trustProxy);
   }
 
   serve() {}

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -10,6 +10,7 @@ import {
 } from "../_utils.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { gracefulShutdownPlugin } from "../_plugins.ts";
+import { trustProxyPlugin } from "../_trust-proxy.ts";
 
 export { FastURL } from "../_url.ts";
 export const FastResponse: typeof globalThis.Response = Response;
@@ -35,6 +36,7 @@ class BunServer implements Server<BunFetchHandler> {
 
     for (const plugin of options.plugins || []) plugin(this);
 
+    trustProxyPlugin(this);
     gracefulShutdownPlugin(this);
 
     const fetchHandler = wrapFetch(this);
@@ -61,6 +63,9 @@ class BunServer implements Server<BunFetchHandler> {
         },
         ip: {
           enumerable: true,
+          // Configurable so the trustProxy plugin can override it from
+          // `X-Forwarded-For` when the peer is trusted.
+          configurable: true,
           get() {
             return server?.requestIP(request as Request)?.address;
           },

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -9,6 +9,7 @@ import {
 } from "../_utils.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { gracefulShutdownPlugin } from "../_plugins.ts";
+import { trustProxyPlugin } from "../_trust-proxy.ts";
 import { limitRequestBody } from "../_body-limit.ts";
 
 export { FastURL } from "../_url.ts";
@@ -41,6 +42,7 @@ class DenoServer implements Server<DenoFetchHandler> {
 
     for (const plugin of options.plugins || []) plugin(this);
 
+    trustProxyPlugin(this);
     gracefulShutdownPlugin(this);
 
     const fetchHandler = wrapFetch(this);
@@ -74,6 +76,9 @@ class DenoServer implements Server<DenoFetchHandler> {
         },
         ip: {
           enumerable: true,
+          // Configurable so the trustProxy plugin can override it from
+          // `X-Forwarded-For` when the peer is trusted.
+          configurable: true,
           get() {
             return (info?.remoteAddr as Deno.NetAddr)?.hostname;
           },

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -79,6 +79,7 @@ class NodeServer implements Server {
         req: nodeReq,
         res: nodeRes,
         maxRequestBodySize: this.options.maxRequestBodySize,
+        trustProxy: this.options.trustProxy,
       });
       request.waitUntil = this.#wait?.waitUntil;
       const res = fetchHandler(request);

--- a/src/types.ts
+++ b/src/types.ts
@@ -158,11 +158,10 @@ export interface ServerOptions {
    * - `false` (default): ignore forwarded headers and derive protocol from the
    *   real transport (`req.socket.encrypted` on Node). Secure by default.
    * - `true`: always trust forwarded headers (previous behavior).
+   * - `"loopback"`: trust only when the immediate peer is a loopback address
+   *   (`127.0.0.0/8` or `::1`), i.e. a proxy running on the same host.
    * - `string[]`: trust only when the immediate peer address (e.g.
    *   `req.socket.remoteAddress`) is in the allowlist.
-   * - `(req) => boolean`: trust only when the predicate returns `true`. The
-   *   argument is the runtime-native request (Node `IncomingMessage`) or event
-   *   (AWS Lambda).
    *
    * Only affects adapters that reconstruct the protocol from headers (Node and
    * AWS Lambda). Bun, Deno and Workers expose the real scheme natively.

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,21 +147,24 @@ export interface ServerOptions {
   maxRequestBodySize?: number;
 
   /**
-   * Whether to trust `X-Forwarded-Proto` (and the HTTP/2 `:scheme`) when
-   * deriving `request.url.protocol`.
+   * Whether to trust `X-Forwarded-*` headers (`X-Forwarded-Proto`,
+   * `X-Forwarded-Host`, `X-Forwarded-For`, and the HTTP/2 `:scheme`) when
+   * deriving `request.url` and `request.ip`.
    *
-   * Any client can send `X-Forwarded-Proto: https`, so trusting it lets a
-   * plaintext request masquerade as `https:`. Only enable this when a proxy you
-   * control sits in front and overwrites the header.
+   * Any client can send `X-Forwarded-Proto: https`, `X-Forwarded-Host` or
+   * `X-Forwarded-For`, so trusting them lets a request masquerade as `https:`,
+   * forge its host, or spoof its client IP. Only enable this when a proxy you
+   * control sits in front and overwrites the headers.
    *
-   * - `false` (default): ignore the header; use the real connection protocol.
-   * - `true`: always trust the header.
-   * - `"loopback"`: trust it only when the proxy connects from a loopback
+   * - `false` (default): ignore the headers; use the real connection protocol,
+   *   the on-the-wire `Host` header and the socket peer address.
+   * - `true`: always trust the headers.
+   * - `"loopback"`: trust them only when the proxy connects from a loopback
    *   address (`127.0.0.0/8` or `::1`).
-   * - `string[]`: trust it only when the proxy's address is in the list.
+   * - `string[]`: trust them only when the proxy's address is in the list.
    *
    * Only applies to the Node and AWS Lambda adapters; Bun, Deno and Workers
-   * report the real protocol natively.
+   * report the real protocol, host and IP natively.
    *
    * @default false
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -147,24 +147,21 @@ export interface ServerOptions {
   maxRequestBodySize?: number;
 
   /**
-   * Trust `X-Forwarded-*` headers (and the HTTP/2 `:scheme` pseudo-header) when
-   * deriving request metadata such as `request.url.protocol`.
+   * Whether to trust `X-Forwarded-Proto` (and the HTTP/2 `:scheme`) when
+   * deriving `request.url.protocol`.
    *
-   * These headers are set by the client on the wire, so a plaintext request can
-   * carry `X-Forwarded-Proto: https` and spoof `request.url.protocol` unless a
-   * proxy you control overwrites them. Enable this **only** when such a proxy
-   * sits in front of the server.
+   * Any client can send `X-Forwarded-Proto: https`, so trusting it lets a
+   * plaintext request masquerade as `https:`. Only enable this when a proxy you
+   * control sits in front and overwrites the header.
    *
-   * - `false` (default): ignore forwarded headers and derive protocol from the
-   *   real transport (`req.socket.encrypted` on Node). Secure by default.
-   * - `true`: always trust forwarded headers (previous behavior).
-   * - `"loopback"`: trust only when the immediate peer is a loopback address
-   *   (`127.0.0.0/8` or `::1`), i.e. a proxy running on the same host.
-   * - `string[]`: trust only when the immediate peer address (e.g.
-   *   `req.socket.remoteAddress`) is in the allowlist.
+   * - `false` (default): ignore the header; use the real connection protocol.
+   * - `true`: always trust the header.
+   * - `"loopback"`: trust it only when the proxy connects from a loopback
+   *   address (`127.0.0.0/8` or `::1`).
+   * - `string[]`: trust it only when the proxy's address is in the list.
    *
-   * Only affects adapters that reconstruct the protocol from headers (Node and
-   * AWS Lambda). Bun, Deno and Workers expose the real scheme natively.
+   * Only applies to the Node and AWS Lambda adapters; Bun, Deno and Workers
+   * report the real protocol natively.
    *
    * @default false
    */

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@ import type * as NodeNet from "node:net";
 import type * as Bun from "bun";
 import type * as CF from "@cloudflare/workers-types";
 import type * as AWS from "aws-lambda";
+import type { TrustProxyOption } from "./_trust-proxy.ts";
+
+export type { TrustProxyOption } from "./_trust-proxy.ts";
 
 // Utils
 type MaybePromise<T> = T | Promise<T>;
@@ -142,6 +145,31 @@ export interface ServerOptions {
    * @default undefined (no limit)
    */
   maxRequestBodySize?: number;
+
+  /**
+   * Trust `X-Forwarded-*` headers (and the HTTP/2 `:scheme` pseudo-header) when
+   * deriving request metadata such as `request.url.protocol`.
+   *
+   * These headers are set by the client on the wire, so a plaintext request can
+   * carry `X-Forwarded-Proto: https` and spoof `request.url.protocol` unless a
+   * proxy you control overwrites them. Enable this **only** when such a proxy
+   * sits in front of the server.
+   *
+   * - `false` (default): ignore forwarded headers and derive protocol from the
+   *   real transport (`req.socket.encrypted` on Node). Secure by default.
+   * - `true`: always trust forwarded headers (previous behavior).
+   * - `string[]`: trust only when the immediate peer address (e.g.
+   *   `req.socket.remoteAddress`) is in the allowlist.
+   * - `(req) => boolean`: trust only when the predicate returns `true`. The
+   *   argument is the runtime-native request (Node `IncomingMessage`) or event
+   *   (AWS Lambda).
+   *
+   * Only affects adapters that reconstruct the protocol from headers (Node and
+   * AWS Lambda). Bun, Deno and Workers expose the real scheme natively.
+   *
+   * @default false
+   */
+  trustProxy?: TrustProxyOption;
 
   /**
    * TLS server options.

--- a/src/types.ts
+++ b/src/types.ts
@@ -163,8 +163,7 @@ export interface ServerOptions {
    *   address (`127.0.0.0/8` or `::1`).
    * - `string[]`: trust them only when the proxy's address is in the list.
    *
-   * Only applies to the Node and AWS Lambda adapters; Bun, Deno and Workers
-   * report the real protocol, host and IP natively.
+   * Applies to the Node, AWS Lambda, Bun and Deno adapters.
    *
    * @default false
    */

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -312,6 +312,102 @@ describe("[AWS Lambda] Request Utils", () => {
       expect(request.url).toMatch(/^https:\/\//);
     });
 
+    test("should honor X-Forwarded-Host when proxy is trusted", () => {
+      const v1Event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/api/users",
+        headers: {
+          host: "real.example.com",
+          "x-forwarded-host": "forwarded.example.com",
+        },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: {} as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      const request = awsRequest(v1Event, createMockContext(), true);
+
+      expect(new URL(request.url).host).toBe("forwarded.example.com");
+    });
+
+    test("should ignore X-Forwarded-Host when proxy is not trusted (default)", () => {
+      const v1Event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/api/users",
+        headers: {
+          host: "real.example.com",
+          "x-forwarded-host": "forwarded.example.com",
+        },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: {} as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      const request = awsRequest(v1Event, createMockContext());
+
+      expect(new URL(request.url).host).toBe("real.example.com");
+    });
+
+    test("should honor X-Forwarded-For for request.ip when proxy is trusted", () => {
+      const v1Event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/api/users",
+        headers: {
+          host: "api.example.com",
+          "x-forwarded-for": "1.2.3.4, 10.0.0.1",
+        },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: { identity: { sourceIp: "10.0.0.1" } } as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      const request = awsRequest(v1Event, createMockContext(), true);
+
+      expect(request.ip).toBe("1.2.3.4");
+    });
+
+    test("should ignore X-Forwarded-For for request.ip when not trusted (default)", () => {
+      const v1Event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/api/users",
+        headers: {
+          host: "api.example.com",
+          "x-forwarded-for": "1.2.3.4",
+        },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: { identity: { sourceIp: "10.0.0.1" } } as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      const request = awsRequest(v1Event, createMockContext());
+
+      expect(request.ip).toBe("10.0.0.1");
+    });
+
     test("should handle path parameters in URL construction", () => {
       const v1Event: APIGatewayProxyEvent = {
         httpMethod: "GET",

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -261,9 +261,34 @@ describe("[AWS Lambda] Request Utils", () => {
         queryStringParameters: null,
       };
 
-      const request = awsRequest(v1Event, createMockContext());
+      // Forwarded protocol is only honored when the proxy is trusted.
+      const request = awsRequest(v1Event, createMockContext(), true);
 
       expect(request.url).toMatch(/^http:\/\//);
+    });
+
+    test("should ignore X-Forwarded-Proto when proxy is not trusted (default)", () => {
+      const v1Event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/api/users",
+        headers: {
+          host: "api.example.com",
+          "x-forwarded-proto": "http",
+        },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: {} as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      const request = awsRequest(v1Event, createMockContext());
+
+      expect(request.url).toMatch(/^https:\/\//);
     });
 
     test("should default to HTTPS when protocol not specified", () => {

--- a/test/node-trust-proxy.test.ts
+++ b/test/node-trust-proxy.test.ts
@@ -80,17 +80,11 @@ describe("trustProxy protocol gating (Node)", () => {
     expect(body).toBe("https:");
   });
 
-  test("trustProxy predicate gates per-request", async () => {
-    const port = await start({ trustProxy: (req) => req.headers["x-internal"] === "1" });
-
-    const trusted = await rawRequest(port, {
-      "X-Forwarded-Proto": "https",
-      "X-Internal": "1",
-    });
-    expect(trusted.body).toBe("https:");
-
-    const untrusted = await rawRequest(port, { "X-Forwarded-Proto": "https" });
-    expect(untrusted.body).toBe("http:");
+  test('trustProxy: "loopback" trusts a same-host peer', async () => {
+    // The test client connects over loopback (127.0.0.1 / ::1).
+    const port = await start({ trustProxy: "loopback" });
+    const { body } = await rawRequest(port, { "X-Forwarded-Proto": "https" });
+    expect(body).toBe("https:");
   });
 
   test("trustProxy allowlist honors trusted peer address", async () => {

--- a/test/node-trust-proxy.test.ts
+++ b/test/node-trust-proxy.test.ts
@@ -100,3 +100,100 @@ describe("trustProxy protocol gating (Node)", () => {
     expect(body).toBe("http:");
   });
 });
+
+describe("trustProxy host gating (Node)", () => {
+  let server: Server;
+
+  async function start(options: Partial<ServerOptions>) {
+    server = serve({
+      port: 0,
+      fetch: (request) => new Response(new URL(request.url).host),
+      ...options,
+    } as ServerOptions);
+    await server.ready();
+    return getPort(server);
+  }
+
+  afterEach(async () => {
+    if (server) await server.close(true);
+  });
+
+  test("default (trustProxy unset) ignores X-Forwarded-Host", async () => {
+    const port = await start({});
+    const { body } = await rawRequest(port, {
+      Host: "real.example",
+      "X-Forwarded-Host": "spoofed.example",
+    });
+    expect(body).toBe("real.example");
+  });
+
+  test("trustProxy: true honors X-Forwarded-Host", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, {
+      Host: "real.example",
+      "X-Forwarded-Host": "forwarded.example",
+    });
+    expect(body).toBe("forwarded.example");
+  });
+
+  test("trustProxy: true uses first entry of an X-Forwarded-Host chain", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, {
+      Host: "real.example",
+      "X-Forwarded-Host": "outer.example, inner.example",
+    });
+    expect(body).toBe("outer.example");
+  });
+
+  test("falls back to Host when X-Forwarded-Host is absent", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, { Host: "real.example" });
+    expect(body).toBe("real.example");
+  });
+});
+
+describe("trustProxy client IP gating (Node)", () => {
+  let server: Server;
+
+  async function start(options: Partial<ServerOptions>) {
+    server = serve({
+      port: 0,
+      fetch: (request) => new Response(request.ip ?? ""),
+      ...options,
+    } as ServerOptions);
+    await server.ready();
+    return getPort(server);
+  }
+
+  afterEach(async () => {
+    if (server) await server.close(true);
+  });
+
+  test("default (trustProxy unset) ignores X-Forwarded-For", async () => {
+    const port = await start({});
+    const { body } = await rawRequest(port, { "X-Forwarded-For": "1.2.3.4" });
+    // The real loopback peer address, not the spoofed header.
+    expect(body).not.toBe("1.2.3.4");
+    expect(body).toMatch(/127\.0\.0\.1|::1|::ffff:127\.0\.0\.1/);
+  });
+
+  test("trustProxy: true honors X-Forwarded-For", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, { "X-Forwarded-For": "1.2.3.4" });
+    expect(body).toBe("1.2.3.4");
+  });
+
+  test("trustProxy: true uses the leftmost X-Forwarded-For entry", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, {
+      "X-Forwarded-For": "1.2.3.4, 10.0.0.1, 10.0.0.2",
+    });
+    expect(body).toBe("1.2.3.4");
+  });
+
+  test("falls back to peer address when X-Forwarded-For is absent", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, {});
+    expect(body).toMatch(/127\.0\.0\.1|::1|::ffff:127\.0\.0\.1/);
+  });
+});

--- a/test/node-trust-proxy.test.ts
+++ b/test/node-trust-proxy.test.ts
@@ -80,6 +80,14 @@ describe("trustProxy protocol gating (Node)", () => {
     expect(body).toBe("https:");
   });
 
+  test("trustProxy: true honors the leftmost entry of a comma-joined X-Forwarded-Proto", async () => {
+    // A proxy chain can join the header (e.g. "https, http"); the outermost
+    // (leftmost) value reflects the original client's scheme.
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, { "X-Forwarded-Proto": "https, http" });
+    expect(body).toBe("https:");
+  });
+
   test('trustProxy: "loopback" trusts a same-host peer', async () => {
     // The test client connects over loopback (127.0.0.1 / ::1).
     const port = await start({ trustProxy: "loopback" });
@@ -88,8 +96,10 @@ describe("trustProxy protocol gating (Node)", () => {
   });
 
   test("trustProxy allowlist honors trusted peer address", async () => {
-    // The loopback peer address (127.0.0.1 or ::1 for dual-stack) is allowlisted.
-    const port = await start({ trustProxy: ["127.0.0.1", "::1", "::ffff:127.0.0.1"] });
+    // The loopback peer address is allowlisted. On dual-stack it may be reported
+    // as the IPv4-mapped `::ffff:127.0.0.1`, which isTrustedProxy matches against
+    // the bare `127.0.0.1` entry, so only the two canonical forms are listed.
+    const port = await start({ trustProxy: ["127.0.0.1", "::1"] });
     const { body } = await rawRequest(port, { "X-Forwarded-Proto": "https" });
     expect(body).toBe("https:");
   });
@@ -148,6 +158,17 @@ describe("trustProxy host gating (Node)", () => {
   test("falls back to Host when X-Forwarded-Host is absent", async () => {
     const port = await start({ trustProxy: true });
     const { body } = await rawRequest(port, { Host: "real.example" });
+    expect(body).toBe("real.example");
+  });
+
+  test("falls back to Host when a trusted X-Forwarded-Host is malformed", async () => {
+    // A malformed forwarded host must not poison request.url (previously became
+    // "_invalid_"); fall back to the real Host, matching the Bun/Deno plugin.
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, {
+      Host: "real.example",
+      "X-Forwarded-Host": "bad_host:notaport",
+    });
     expect(body).toBe("real.example");
   });
 });

--- a/test/node-trust-proxy.test.ts
+++ b/test/node-trust-proxy.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for `X-Forwarded-Proto` trust gating in the Node.js adapter.
+ *
+ * Background: `NodeRequestURL` used to trust `X-Forwarded-Proto` (and the
+ * HTTP/2 `:scheme` pseudo-header) unconditionally, so any client on a plaintext
+ * connection could send `X-Forwarded-Proto: https` and make
+ * `request.url.protocol === "https:"`. The `trustProxy` option now gates this;
+ * it defaults to `false` (secure).
+ */
+
+import { afterEach, describe, expect, test } from "vitest";
+import http from "node:http";
+import { serve } from "../src/adapters/node.ts";
+import type { Server, ServerOptions } from "../src/types.ts";
+
+/** Send a raw HTTP request with custom headers (fetch normalizes headers). */
+function rawRequest(
+  port: number,
+  headers: Record<string, string>,
+): Promise<{ statusCode: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      { method: "GET", path: "/", hostname: "127.0.0.1", port, headers, timeout: 2000 },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk) => chunks.push(chunk));
+        res.on("end", () =>
+          resolve({ statusCode: res.statusCode!, body: Buffer.concat(chunks).toString() }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("request timed out"));
+    });
+    req.end();
+  });
+}
+
+function getPort(server: Server): number {
+  const addr = server.node?.server?.address();
+  if (addr && typeof addr === "object") return addr.port;
+  throw new Error("Cannot determine server port");
+}
+
+describe("trustProxy protocol gating (Node)", () => {
+  let server: Server;
+
+  async function start(options: Partial<ServerOptions>) {
+    server = serve({
+      port: 0,
+      fetch: (request) => new Response(new URL(request.url).protocol),
+      ...options,
+    } as ServerOptions);
+    await server.ready();
+    return getPort(server);
+  }
+
+  afterEach(async () => {
+    if (server) await server.close(true);
+  });
+
+  test("default (trustProxy unset) ignores X-Forwarded-Proto on plaintext", async () => {
+    const port = await start({});
+    const { statusCode, body } = await rawRequest(port, { "X-Forwarded-Proto": "https" });
+    expect(statusCode).toBe(200);
+    expect(body).toBe("http:");
+  });
+
+  test("trustProxy: false ignores X-Forwarded-Proto", async () => {
+    const port = await start({ trustProxy: false });
+    const { body } = await rawRequest(port, { "X-Forwarded-Proto": "https" });
+    expect(body).toBe("http:");
+  });
+
+  test("trustProxy: true honors X-Forwarded-Proto", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, { "X-Forwarded-Proto": "https" });
+    expect(body).toBe("https:");
+  });
+
+  test("trustProxy predicate gates per-request", async () => {
+    const port = await start({ trustProxy: (req) => req.headers["x-internal"] === "1" });
+
+    const trusted = await rawRequest(port, {
+      "X-Forwarded-Proto": "https",
+      "X-Internal": "1",
+    });
+    expect(trusted.body).toBe("https:");
+
+    const untrusted = await rawRequest(port, { "X-Forwarded-Proto": "https" });
+    expect(untrusted.body).toBe("http:");
+  });
+
+  test("trustProxy allowlist honors trusted peer address", async () => {
+    // The loopback peer address (127.0.0.1 or ::1 for dual-stack) is allowlisted.
+    const port = await start({ trustProxy: ["127.0.0.1", "::1", "::ffff:127.0.0.1"] });
+    const { body } = await rawRequest(port, { "X-Forwarded-Proto": "https" });
+    expect(body).toBe("https:");
+  });
+
+  test("no forwarded header stays http on plaintext regardless of trustProxy", async () => {
+    const port = await start({ trustProxy: true });
+    const { body } = await rawRequest(port, {});
+    expect(body).toBe("http:");
+  });
+});

--- a/test/trust-proxy-plugin.test.ts
+++ b/test/trust-proxy-plugin.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Tests for the universal `trustProxyPlugin` used by the Bun and Deno adapters.
+ *
+ * These runtimes expose the real transport on the native `Request`, so the
+ * plugin runs as middleware that — only when the immediate peer is a trusted
+ * proxy — rewrites `request.url` from `X-Forwarded-Proto` / `X-Forwarded-Host`
+ * and `request.ip` from `X-Forwarded-For`. The behavior is runtime-agnostic, so
+ * it is exercised here against plain `Request` objects.
+ */
+
+import { describe, expect, test } from "vitest";
+import { trustProxyPlugin } from "../src/_trust-proxy.ts";
+import type { Server, ServerRequest, TrustProxyOption } from "../src/types.ts";
+
+function makeRequest(
+  url: string,
+  peerIp: string | undefined,
+  headers: Record<string, string>,
+): ServerRequest {
+  const req = new Request(url, { headers }) as ServerRequest;
+  // Mimic the adapter-provided native `ip` getter (configurable so the plugin
+  // may override it).
+  Object.defineProperty(req, "ip", {
+    value: peerIp,
+    enumerable: true,
+    configurable: true,
+  });
+  return req;
+}
+
+async function run(
+  trustProxy: TrustProxyOption | undefined,
+  request: ServerRequest,
+): Promise<ServerRequest> {
+  const middleware: any[] = [];
+  const server = { options: { trustProxy, middleware } } as unknown as Server;
+  trustProxyPlugin(server);
+  if (middleware.length > 0) {
+    await middleware[0](request, () => new Response("ok"));
+  }
+  return request;
+}
+
+describe("trustProxyPlugin", () => {
+  test("does not register middleware when trustProxy is unset", () => {
+    const middleware: any[] = [];
+    trustProxyPlugin({ options: { middleware } } as unknown as Server);
+    expect(middleware).toHaveLength(0);
+  });
+
+  test("does not register middleware when trustProxy is false", () => {
+    const middleware: any[] = [];
+    trustProxyPlugin({ options: { trustProxy: false, middleware } } as unknown as Server);
+    expect(middleware).toHaveLength(0);
+  });
+
+  test("rewrites url and ip when the peer is trusted", async () => {
+    const req = await run(
+      true,
+      makeRequest("http://origin.example/path?q=1", "10.0.0.1", {
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "public.example",
+        "x-forwarded-for": "1.2.3.4",
+      }),
+    );
+    const url = new URL(req.url);
+    expect(url.protocol).toBe("https:");
+    expect(url.host).toBe("public.example");
+    expect(url.pathname).toBe("/path");
+    expect(url.search).toBe("?q=1");
+    expect(req.ip).toBe("1.2.3.4");
+  });
+
+  test("leaves the request untouched when the peer is not trusted", async () => {
+    const req = await run(
+      ["10.0.0.1"],
+      makeRequest("http://origin.example/", "9.9.9.9", {
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "public.example",
+        "x-forwarded-for": "1.2.3.4",
+      }),
+    );
+    expect(new URL(req.url).host).toBe("origin.example");
+    expect(new URL(req.url).protocol).toBe("http:");
+    expect(req.ip).toBe("9.9.9.9");
+  });
+
+  test('"loopback" trusts a loopback peer', async () => {
+    const req = await run(
+      "loopback",
+      makeRequest("http://origin.example/", "127.0.0.1", {
+        "x-forwarded-host": "public.example",
+      }),
+    );
+    expect(new URL(req.url).host).toBe("public.example");
+  });
+
+  test('"loopback" ignores a non-loopback peer', async () => {
+    const req = await run(
+      "loopback",
+      makeRequest("http://origin.example/", "203.0.113.5", {
+        "x-forwarded-host": "public.example",
+      }),
+    );
+    expect(new URL(req.url).host).toBe("origin.example");
+  });
+
+  test("allowlist trusts a listed peer", async () => {
+    const req = await run(
+      ["10.0.0.1", "10.0.0.2"],
+      makeRequest("http://origin.example/", "10.0.0.2", {
+        "x-forwarded-for": "1.2.3.4",
+      }),
+    );
+    expect(req.ip).toBe("1.2.3.4");
+  });
+
+  test("uses the leftmost X-Forwarded-For entry and first host of a chain", async () => {
+    const req = await run(
+      true,
+      makeRequest("http://origin.example/", "10.0.0.1", {
+        "x-forwarded-host": "outer.example, inner.example",
+        "x-forwarded-for": "1.2.3.4, 10.0.0.9, 10.0.0.1",
+      }),
+    );
+    expect(new URL(req.url).host).toBe("outer.example");
+    expect(req.ip).toBe("1.2.3.4");
+  });
+
+  test("X-Forwarded-Host without a port drops the listener port", async () => {
+    const req = await run(
+      true,
+      makeRequest("http://origin.example:34697/", "10.0.0.1", {
+        "x-forwarded-host": "public.example",
+      }),
+    );
+    expect(new URL(req.url).host).toBe("public.example");
+  });
+
+  test("X-Forwarded-Host may carry its own port", async () => {
+    const req = await run(
+      true,
+      makeRequest("http://origin.example:34697/", "10.0.0.1", {
+        "x-forwarded-host": "public.example:8443",
+      }),
+    );
+    const url = new URL(req.url);
+    expect(url.hostname).toBe("public.example");
+    expect(url.port).toBe("8443");
+  });
+
+  test("falls back to the peer address when X-Forwarded-For is absent", async () => {
+    const req = await run(
+      true,
+      makeRequest("http://origin.example/", "10.0.0.1", {
+        "x-forwarded-proto": "https",
+      }),
+    );
+    expect(new URL(req.url).protocol).toBe("https:");
+    expect(req.ip).toBe("10.0.0.1");
+  });
+});

--- a/test/trust-proxy-plugin.test.ts
+++ b/test/trust-proxy-plugin.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, expect, test } from "vitest";
-import { trustProxyPlugin } from "../src/_trust-proxy.ts";
+import { trustProxyPlugin, isTrustedProxy } from "../src/_trust-proxy.ts";
 import type { Server, ServerRequest, TrustProxyOption } from "../src/types.ts";
 
 function makeRequest(
@@ -147,6 +147,55 @@ describe("trustProxyPlugin", () => {
     const url = new URL(req.url);
     expect(url.hostname).toBe("public.example");
     expect(url.port).toBe("8443");
+  });
+
+  test("a malformed X-Forwarded-Host is ignored and keeps the original host:port", async () => {
+    const req = await run(
+      true,
+      makeRequest("http://origin.example:34697/", "10.0.0.1", {
+        // Contains a space -> invalid; must not silently strip the real port.
+        "x-forwarded-host": "bad host",
+      }),
+    );
+    const url = new URL(req.url);
+    expect(url.hostname).toBe("origin.example");
+    expect(url.port).toBe("34697");
+  });
+
+  test("honors the leftmost entry of a comma-joined X-Forwarded-Proto", async () => {
+    const req = await run(
+      true,
+      makeRequest("http://origin.example/", "10.0.0.1", {
+        "x-forwarded-proto": "https, http",
+      }),
+    );
+    expect(new URL(req.url).protocol).toBe("https:");
+  });
+});
+
+describe("isTrustedProxy", () => {
+  test("allowlist matches an IPv4-mapped IPv6 peer by its bare IPv4 form", () => {
+    // Dual-stack Node reports an IPv4 peer as `::ffff:10.0.0.1`.
+    expect(isTrustedProxy(["10.0.0.1"], "::ffff:10.0.0.1")).toBe(true);
+    expect(isTrustedProxy(["10.0.0.2"], "::ffff:10.0.0.1")).toBe(false);
+  });
+
+  test("allowlist still matches a plain address exactly", () => {
+    expect(isTrustedProxy(["10.0.0.1"], "10.0.0.1")).toBe(true);
+    expect(isTrustedProxy(["10.0.0.1"], "9.9.9.9")).toBe(false);
+  });
+
+  test("false/undefined never trust; true always trusts", () => {
+    expect(isTrustedProxy(false, "10.0.0.1")).toBe(false);
+    expect(isTrustedProxy(undefined, "10.0.0.1")).toBe(false);
+    expect(isTrustedProxy(true, undefined)).toBe(true);
+  });
+
+  test('"loopback" matches IPv4/IPv6 loopback including IPv4-mapped', () => {
+    expect(isTrustedProxy("loopback", "127.0.0.1")).toBe(true);
+    expect(isTrustedProxy("loopback", "::1")).toBe(true);
+    expect(isTrustedProxy("loopback", "::ffff:127.0.0.1")).toBe(true);
+    expect(isTrustedProxy("loopback", "203.0.113.5")).toBe(false);
   });
 
   test("falls back to the peer address when X-Forwarded-For is absent", async () => {


### PR DESCRIPTION
Adds a `trustProxy` server option that lets a reverse proxy you control override the request protocol, host, and client IP via `X-Forwarded-*` headers.

These headers are attacker-controlled on the wire, so they are **ignored by default** and only honored when the immediate peer is a trusted proxy. This keeps the secure-by-default behavior while giving proxied deployments a way to see the real client-facing values.

## Option

```ts
serve({ trustProxy: true, fetch: (req) => new Response(req.ip) });
```

- `false` (default) — ignore forwarded headers; use the real connection protocol, the on-the-wire `Host` header, and the socket peer address.
- `true` — always trust forwarded headers.
- `"loopback"` — trust only when the proxy connects from a loopback address (`127.0.0.0/8` or `::1`).
- `string[]` — trust only when the proxy's immediate-peer address is in the allowlist.

## What gets derived when trusted

| Source header | Derives | Notes |
| --- | --- | --- |
| `X-Forwarded-Proto` (and HTTP/2 `:scheme`) | `request.url.protocol` | A genuine TLS listener (`req.socket.encrypted`) always wins. |
| `X-Forwarded-Host` | `request.url.host` | Falls back to `Host` / `:authority`. Origin-form host drops the listener port so the forwarded host stays authoritative. |
| `X-Forwarded-For` | `request.ip` | Falls back to the socket peer address. |

For a chain of proxies, host/proto use the first entry and `X-Forwarded-For` uses the leftmost (original client) entry.

## Runtime coverage

- **Node** and **AWS Lambda** resolve all three at request construction (`request.ip` is memoized so `isTrustedProxy` runs once per request).
- **Bun** and **Deno** report the real transport on the native `Request`, so a universal `trustProxyPlugin` runs as middleware there and rewrites `request.url` / `request.ip` when the peer is trusted (their `ip` descriptor is made `configurable` for the override).
- **Cloudflare Workers** report the real protocol, host and IP natively — `trustProxy` is a no-op.

## Notes

- **Secure by default.** Deployments behind a TLS-terminating proxy that rely on `X-Forwarded-*` must set `trustProxy: true` (or `"loopback"` / an allowlist).

## Tests

- `test/node-trust-proxy.test.ts` — protocol, host, and client-IP gating over raw HTTP.
- `test/aws.test.ts` — trusted vs untrusted `X-Forwarded-Proto` / `-Host` / `-For` cases.
- `test/trust-proxy-plugin.test.ts` — runtime-agnostic coverage of the Bun/Deno plugin (trust modes, proxy chains, host-port handling, fallbacks). Verified end-to-end against real Bun and Deno servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable proxy trust support across Node, AWS Lambda, Bun, and Deno adapters.
  * Forwarded headers can now safely determine request URLs and client IPs when configured.
  * Supports always trusting proxies, loopback-only trust, or explicit proxy address allowlists.
* **Documentation**
  * Added configuration guidance, security considerations, supported modes, and adapter applicability for `trustProxy`.
* **Tests**
  * Added coverage for forwarded protocols, hosts, client IPs, validation, and trust modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->