### PR TITLE
fix: waitUntil Set leak and NaN port bypass in core utils

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -8,8 +8,8 @@ export function resolvePortAndHost(opts: ServerOptions): {
 } {
   const _port = opts.port ?? globalThis.process?.env.PORT ?? 3000;
   const port = typeof _port === "number" ? _port : Number.parseInt(_port, 10);
-  if (port < 0 || port > 65_535) {
-    throw new RangeError(`Port must be between 0 and 65535 (got "${port}").`);
+  if (Number.isNaN(port) || port < 0 || port > 65_535) {
+    throw new RangeError(`Port must be a number between 0 and 65535 (got "${_port}").`);
   }
 
   const hostname = opts.hostname ?? globalThis.process?.env.HOST;
@@ -139,16 +139,19 @@ export function createWaitUntil() {
   return {
     waitUntil: (promise: Promise<any> | PromiseLike<any>): void => {
       if (typeof promise?.then !== "function") return;
-      promises.add(
-        Promise.resolve(promise)
-          .catch(console.error)
-          .finally(() => {
-            promises.delete(promise);
-          }),
-      );
+      const chained = Promise.resolve(promise)
+        .catch(console.error)
+        .finally(() => {
+          promises.delete(chained);
+        });
+      promises.add(chained);
     },
     wait: (): Promise<any> => {
       return Promise.all(promises);
+    },
+    /** @internal Number of pending promises. Exposed for testing only. */
+    get _size(): number {
+      return promises.size;
     },
   };
 }

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,63 @@
+import { describe, test, expect, vi } from "vitest";
+import { resolvePortAndHost, createWaitUntil } from "../src/_utils.ts";
+import type { ServerOptions } from "../src/types.ts";
+
+const withPort = (port: string | number): ServerOptions => ({
+  port,
+  fetch: () => new Response(),
+});
+
+describe("resolvePortAndHost", () => {
+  test("uses numeric port option", () => {
+    expect(resolvePortAndHost(withPort(8080)).port).toBe(8080);
+  });
+
+  test("parses string port option", () => {
+    expect(resolvePortAndHost(withPort("8080")).port).toBe(8080);
+  });
+
+  test.each(["abc", ""])("throws RangeError for non-numeric port %j", (port) => {
+    expect(() => resolvePortAndHost(withPort(port))).toThrow(RangeError);
+    expect(() => resolvePortAndHost(withPort(port))).toThrow(/between 0 and 65535/);
+  });
+
+  test.each([-1, 65_536])("throws RangeError for out-of-range port %i", (port) => {
+    expect(() => resolvePortAndHost(withPort(port))).toThrow(RangeError);
+  });
+});
+
+describe("createWaitUntil", () => {
+  test("does not leak resolved promises", async () => {
+    const w = createWaitUntil();
+
+    for (let i = 0; i < 100; i++) {
+      w.waitUntil(Promise.resolve(i));
+    }
+    expect(w._size).toBe(100);
+
+    await w.wait();
+    expect(w._size).toBe(0);
+  });
+
+  test("does not leak rejected promises", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const w = createWaitUntil();
+
+    for (let i = 0; i < 50; i++) {
+      w.waitUntil(Promise.reject(new Error(`boom ${i}`)));
+    }
+    expect(w._size).toBe(50);
+
+    await w.wait();
+    expect(w._size).toBe(0);
+
+    errorSpy.mockRestore();
+  });
+
+  test("ignores non-thenable values", () => {
+    const w = createWaitUntil();
+    w.waitUntil(undefined as any);
+    w.waitUntil(42 as any);
+    expect(w._size).toBe(0);
+  });
+});


### PR DESCRIPTION
Two small core-utils fixes from the v1 stabilization review.

- **F4 — `waitUntil` leaked memory on every call.** `createWaitUntil` added the chained `.catch().finally()` promise to the Set but the cleanup deleted the *original* promise (which was never added), so the Set grew unbounded on any long-running server. Now the chained promise is captured in a variable and that same promise is deleted on settlement.
- **F36 — `NaN` bypassed the port range check.** `NaN < 0` and `NaN > 65535` are both false, so `PORT=abc` / `PORT=""` slipped past the guard and failed later with an obscure listen error. Added a `Number.isNaN` guard that throws a clear `RangeError`.

Added `test/utils.test.ts` covering both (leak-free after N resolved/rejected `waitUntil` calls, and `RangeError` for non-numeric/out-of-range ports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved port validation to reject invalid, non-numeric, and out-of-range values with clearer errors.
  * Fixed promise tracking so completed or rejected tasks are properly removed.
  * Non-promise values no longer affect pending task tracking.

* **Tests**
  * Added coverage for port parsing, validation, and wait-task cleanup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->