### PR TITLE
fix(service-worker): respondWith synchronously and drop extension bypass

### DIFF
--- a/examples/service-worker/public/sw.mjs
+++ b/examples/service-worker/public/sw.mjs
@@ -2,9 +2,14 @@ import { serve } from "https://esm.sh/srvx";
 
 serve({
   serviceWorker: { url: import.meta.url },
-  fetch(_request) {
-    return new Response(`<h1>👋 Hello there!</h1>`, {
-      headers: { "Content-Type": "text/html; charset=UTF-8" },
-    });
+  fetch(request) {
+    const { pathname } = new URL(request.url);
+    if (pathname === "/") {
+      return new Response(`<h1>👋 Hello there!</h1>`, {
+        headers: { "Content-Type": "text/html; charset=UTF-8" },
+      });
+    }
+    // Fall back to the network for anything else (e.g. the worker script).
+    return new Response("Not Found", { status: 404 });
   },
 });

--- a/src/adapters/service-worker.ts
+++ b/src/adapters/service-worker.ts
@@ -68,29 +68,38 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
           type: "module",
           scope: this.options.serviceWorker?.scope,
         })
-        .then((registration) => {
-          if (registration.active) {
-            location.replace(location.href);
-          } else {
-            registration.addEventListener("updatefound", () => {
-              location.replace(location.href);
-            });
+        .then(() => {
+          // If the page is already controlled by an active service worker,
+          // it can handle requests right away and no reload is needed.
+          if (navigator.serviceWorker.controller) {
+            return;
           }
+          // Otherwise reload once the freshly installed worker takes control
+          // (via `clients.claim()`) so it can handle the current page.
+          navigator.serviceWorker.addEventListener(
+            "controllerchange",
+            () => {
+              location.reload();
+            },
+            { once: true },
+          );
         });
     } else if (isServiceWorker) {
       // Listen for the 'fetch' event to handle requests
-      this.#fetchListener = async (event) => {
-        // skip if event url ends with file with extension
-        if (/\/[^/]*\.[a-zA-Z0-9]+$/.test(new URL(event.request.url).pathname)) {
-          return;
-        }
+      this.#fetchListener = (event) => {
         Object.defineProperty(event.request, "waitUntil", {
           value: event.waitUntil.bind(event),
         });
-        const response = await this.fetch(event.request, event);
-        if (response.status !== 404) {
-          event.respondWith(response);
-        }
+        // `respondWith` must be called synchronously (before the event
+        // dispatch completes), passing a promise that resolves the response.
+        event.respondWith(
+          (async () => {
+            const response = await this.fetch(event.request, event);
+            // Treat a 404 from the handler as "not handled" and fall back
+            // to the network for the original request.
+            return response.status === 404 ? fetch(event.request) : response;
+          })(),
+        );
       };
 
       addEventListener("fetch", this.#fetchListener);

--- a/test/service-worker.test.ts
+++ b/test/service-worker.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { serve as serveType } from "../src/adapters/service-worker.ts";
+
+// Minimal `FetchEvent`-like object for driving the adapter's fetch listener.
+function createFetchEvent(url: string, init?: RequestInit) {
+  const request = new Request(url, init);
+  return {
+    request,
+    respondWith: vi.fn<(r: Response | Promise<Response>) => void>(),
+    waitUntil: vi.fn(),
+  };
+}
+
+describe("service-worker adapter", () => {
+  let serve: typeof serveType;
+  let listeners: Record<string, (event: any) => void>;
+
+  beforeEach(async () => {
+    listeners = {};
+    const addEventListener = (type: string, listener: (event: any) => void) => {
+      listeners[type] = listener;
+    };
+
+    // Emulate a service-worker global scope so `isServiceWorker` is truthy and
+    // the fetch listener is registered on import.
+    vi.stubGlobal("self", {
+      skipWaiting: () => {},
+      clients: { claim: () => {} },
+      registration: { unregister: async () => {} },
+      addEventListener,
+    });
+    vi.stubGlobal("addEventListener", addEventListener);
+    vi.stubGlobal("removeEventListener", () => {});
+    vi.stubGlobal("window", undefined);
+
+    vi.resetModules();
+    ({ serve } = await import("../src/adapters/service-worker.ts"));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+  });
+
+  it("registers a fetch listener", () => {
+    serve({ fetch: () => new Response("ok") });
+    expect(typeof listeners.fetch).toBe("function");
+  });
+
+  it("calls respondWith synchronously with a promise", () => {
+    serve({ fetch: () => new Response("ok") });
+    const event = createFetchEvent("http://localhost/");
+
+    listeners.fetch(event);
+
+    expect(event.respondWith).toHaveBeenCalledTimes(1);
+    expect(event.respondWith.mock.calls[0][0]).toBeInstanceOf(Promise);
+  });
+
+  it("serves non-404 responses from the handler", async () => {
+    serve({ fetch: () => new Response("hello", { status: 200 }) });
+    // A path with a file extension (previously bypassed by the removed regex).
+    const event = createFetchEvent("http://localhost/api/data.json");
+
+    listeners.fetch(event);
+    const response = await event.respondWith.mock.calls[0][0];
+
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("hello");
+  });
+
+  it("falls back to the network for 404 responses", async () => {
+    const fetchMock = vi.fn(
+      async (_request: Request) => new Response("from network", { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    serve({ fetch: () => new Response("nope", { status: 404 }) });
+    const event = createFetchEvent("http://localhost/missing");
+
+    listeners.fetch(event);
+    const response = await event.respondWith.mock.calls[0][0];
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // The original request is passed through to the network.
+    expect(fetchMock.mock.calls[0][0]).toBe(event.request);
+    expect(await response.text()).toBe("from network");
+  });
+});


### PR DESCRIPTION
Fixes two locked-together bugs in the service-worker adapter.

- **F6** — `event.respondWith()` was called after an `await`, past the dispatch flag, throwing `InvalidStateError` on every request so all traffic fell through to the network; the window branch also reloaded whenever an active registration existed, causing an infinite reload loop. Now `respondWith()` is called synchronously with a promise, and the window branch only reloads on first `controllerchange`.
- **F28** — Removed the `/\/[^/]*\.[a-zA-Z0-9]+$/` extension-bypass regex; the handler now sees every same-origin request (e.g. `/api/data.json`), and an unhandled 404 falls back to the network inside the response promise.

Adds in-process tests for the fetch-listener logic and updates `examples/service-worker` so the worker script loads from the network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved service-worker request routing, including explicit handling for root and unknown paths.
  * Added network fallback behavior when a request handler returns a 404.
  * Pages now reload automatically when the service worker takes control.

* **Bug Fixes**
  * Improved request handling for URLs with file extensions.
  * Ensured fetch responses are handled consistently and promptly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->