### PR TITLE
fix(url): FastURL origin-form string + HTTP/2 char normalization

### DIFF
--- a/src/_url.ts
+++ b/src/_url.ts
@@ -15,19 +15,26 @@ export type URLInit = {
 // - backslashes (rewritten to `/` for special schemes)
 // - fragment delimiter (#) which the fast path does not split on
 // - path percent-encode set chars: ^ " < > ` { }
+// - control chars, space, and DEL (\x00-\x20, \x7f)
 // - non-ASCII characters
-// (Control chars and space are rejected by Node's HTTP parser, so unreachable.)
+// (HTTP/1's parser rejects control chars and space, but the Node adapter also
+// serves HTTP/2, where a raw `:path` reaches the handler verbatim, so they must
+// trigger normalization too \u2014 native percent-encodes/strips them.)
 const _needsNormRE =
-  /(?:(?:^|\/)(?:\.|\.\.|%2e|%2e\.|\.%2e|%2e%2e)(?:\/|$))|[\\^#"<>{}`\x80-\uffff]/i;
+  // oxlint-disable-next-line no-control-regex -- control chars/DEL are intentional (HTTP/2-reachable)
+  /(?:(?:^|\/)(?:\.|\.\.|%2e|%2e\.|\.%2e|%2e%2e)(?:\/|$))|[\\^#"<>{}`\x00-\x20\x7f-\uffff]/i;
 
 // Query percent-encode set chars the WHATWG URL parser rewrites but the verbatim
 // fast path would keep raw. Native percent-encodes `" ' < >` in the query (note
 // this set is narrower than the path set: `` ` `` `{` `}` are NOT encoded in the
 // query); `#` starts a fragment the fast path must not fold into search. When any
 // appears in the query \u2014 or, for a raw origin-form string, anywhere (`" < >` also
-// need encoding in the path) \u2014 we deopt to native parsing.
-// (Control chars and space are rejected by Node's HTTP parser, so unreachable.)
-const _searchNeedsNormRE = /[#"'<>]/;
+// need encoding in the path) \u2014 we deopt to native parsing. Over HTTP/2 (also
+// served by the Node adapter) control chars, space, and DEL reach the handler
+// raw, so the class covers `\x00-\x20` and `\x7f-\uffff` (DEL + all non-ASCII)
+// too \u2014 native percent-encodes/strips these.
+// oxlint-disable-next-line no-control-regex -- control chars/DEL are intentional (HTTP/2-reachable)
+const _searchNeedsNormRE = /[#"'<>\x00-\x20\x7f-\uffff]/;
 
 /**
  * URL wrapper with fast paths to access to the following props:
@@ -61,7 +68,10 @@ export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
         if (typeof url === "string") {
           const isOriginForm = url[0] === "/";
           if (isOriginForm && !_searchNeedsNormRE.test(url)) {
-            this.#href = url;
+            // Store a full absolute href (scheme + host) so `#getPos()` finds
+            // `://` and the getters resolve against `http://localhost` semantics,
+            // matching the `URLInit` and deopt paths below.
+            this.#href = `http://localhost${url}`;
           } else {
             // Absolute-form, or a target with a fragment (#) / query percent-encode
             // set chars (" ' < >) that need full parsing to match native.

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -54,6 +54,79 @@ describe("FastURL", () => {
     expect(url.searchParams).toEqual(new URLSearchParams("?search"));
   });
 
+  describe("origin-form string (bare path)", () => {
+    // Regression (F12): `new FastURL("/foo?x=1")` is a documented fast path.
+    // It must resolve against `http://localhost` semantics (like the adapter's
+    // URLInit path) instead of deopting to `new URL("/foo?x=1")` with no base,
+    // which throws `TypeError: Invalid URL`. Getters must match native both
+    // before and after a mutation-triggered deopt.
+    const cases = ["/foo?x=1", "/", "/a/b/c", "/p?a=1&b=2", "/only-path"] as const;
+
+    for (const input of cases) {
+      test(`FastURL "${input}" matches native`, () => {
+        const std = new URL(`http://localhost${input}`);
+        const url = new FastURL(input);
+        expect(url.pathname, ".pathname").toBe(std.pathname);
+        expect(url.search, ".search").toBe(std.search);
+        expect(url.searchParams.toString(), ".searchParams").toBe(std.searchParams.toString());
+        expect(url.href, ".href").toBe(std.href);
+      });
+
+      test(`FastURL "${input}" stays consistent after deopt`, () => {
+        const std = new URL(`http://localhost${input}`);
+        const url = new FastURL(input);
+        void url.hostname; // force deopt to native URL
+        expect(url.hostname, ".hostname").toBe("localhost");
+        expect(url.pathname, ".pathname").toBe(std.pathname);
+        expect(url.search, ".search").toBe(std.search);
+        expect(url.href, ".href").toBe(std.href);
+      });
+    }
+  });
+
+  describe("HTTP/2-reachable chars (control, space, DEL, non-ASCII)", () => {
+    // Regression (F33): the normalization regexes assumed control chars and
+    // space are rejected by the HTTP parser — true for HTTP/1, FALSE over
+    // HTTP/2 which the Node adapter serves. A raw `:path` like `/p?q=é` reaches
+    // the handler verbatim; native URL percent-encodes/strips these, so the
+    // fast path must deopt to match — both before and after a later deopt.
+    const chars = {
+      "é (non-ASCII)": "é",
+      "DEL (\\x7f)": "\x7f",
+      space: " ",
+    };
+
+    for (const [name, ch] of Object.entries(chars)) {
+      for (const input of [`/a${ch}b`, `/p?x=${ch}y`]) {
+        test(`FastURL string ${name} in "${JSON.stringify(input)}" matches native`, () => {
+          const std = new URL(`http://localhost${input}`);
+          // sanity: native did rewrite the raw char
+          expect(std.href).not.toBe(`http://localhost${input}`);
+
+          const url = new FastURL(input);
+          expect(url.pathname, ".pathname").toBe(std.pathname);
+          expect(url.search, ".search").toBe(std.search);
+          expect(url.href, ".href").toBe(std.href);
+          expect(url.searchParams.toString(), ".searchParams").toBe(std.searchParams.toString());
+        });
+
+        test(`NodeRequestURL ${name} in "${JSON.stringify(input)}" matches native (before & after deopt)`, () => {
+          const std = new URL(`http://localhost${input}`);
+          const url = new NodeRequestURL({
+            req: { url: input, headers: { host: "localhost" } } as any,
+          });
+          expect(url.pathname, ".pathname").toBe(std.pathname);
+          expect(url.search, ".search").toBe(std.search);
+          expect(url.href, ".href").toBe(std.href);
+          void url.hostname; // force deopt to native URL
+          expect(url.pathname, ".pathname (deopt)").toBe(std.pathname);
+          expect(url.search, ".search (deopt)").toBe(std.search);
+          expect(url.href, ".href (deopt)").toBe(std.href);
+        });
+      }
+    }
+  });
+
   describe("WPT tests", () => {
     for (const t of urlTests) {
       if (typeof t === "string") {


### PR DESCRIPTION
Fixes two bugs in `src/_url.ts` (FastURL) from the v1 stabilization review.

- **F12** — `new FastURL("/foo?x=1")` (origin-form string, a documented fast path) stored a bare path, so `#getPos()` found no `://` and deopted to `new URL("/foo?x=1")` with no base, throwing `TypeError: Invalid URL` on every getter. Now stores a full `http://localhost` href, matching the URLInit/deopt paths; getters work before and after deopt.
- **F33** — the normalization regexes assumed control chars and space are unreachable (true for HTTP/1, false over HTTP/2, which the Node adapter serves with the raw path verbatim). `_searchNeedsNormRE` and `_needsNormRE` now trigger on controls, space, DEL, and all non-ASCII, so FastURL getters match native `URL` for inputs like `/p?q=é` both before and after deopt.

Tests in `test/url.test.ts` extended for both; full suite green, lint and typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)