### PR TITLE
fix(node): prevent body-read crashes and wire corruption

### DIFF
--- a/src/adapters/_node/call.ts
+++ b/src/adapters/_node/call.ts
@@ -71,9 +71,9 @@ export function callNodeHandler(
           ),
         ).catch((error) => reject(error));
       } else {
-        Promise.resolve((handler as NodeHttpHandler)(nodeReq as any, nodeRes as any)).then(
-          () => streamPromise || webRes,
-        );
+        Promise.resolve((handler as NodeHttpHandler)(nodeReq as any, nodeRes as any))
+          .then(() => streamPromise || webRes)
+          .catch((error) => reject(error));
       }
     } catch (error: unknown) {
       reject(error);

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -24,6 +24,11 @@ export type NodeRequestContext = {
 
 const kNativeRequest = /* @__PURE__ */ Symbol.for("srvx.nativeRequest");
 
+/** Rejection for a second read of an already-consumed body (matches native fetch). */
+function bodyUnusable(): TypeError {
+  return new TypeError("Body is unusable: Body has already been read");
+}
+
 export const NodeRequest: {
   new (nodeCtx: NodeRequestContext): ServerRequest;
 } = /* @__PURE__ */ (() => {
@@ -39,6 +44,11 @@ export const NodeRequest: {
     #req: NodeServerRequest;
     #url?: URL;
     #bodyStream?: ReadableStream | null;
+    // Tracks body consumption at the srvx level so a second read rejects with
+    // `TypeError: Body is unusable` (like native fetch) instead of hanging on a
+    // re-listened, already-ended IncomingMessage, and so `bodyUsed` can be
+    // served without materializing a native Request over a disturbed stream.
+    #bodyUsed = false;
     #request?: globalThis.Request;
     #headers?: NodeRequestHeaders;
     #abortController?: AbortController;
@@ -159,17 +169,26 @@ export const NodeRequest: {
       return this.#request ? this.#request.signal : this._abortController.signal;
     }
 
+    // Per the fetch spec, GET/HEAD requests always have a null body regardless of
+    // what was on the wire. Raw bytes remain reachable via `runtime.node.req`.
+    #hasBody(): boolean {
+      const method = this.method;
+      return method !== "GET" && method !== "HEAD";
+    }
+
     get body(): ReadableStream | null {
       if (this.#request) {
         return this.#request.body;
       }
       if (this.#bodyStream === undefined) {
-        const method = this.method;
-        const hasBody = !(method === "GET" || method === "HEAD");
-        let stream = hasBody
-          ? // TODO: HTTP2ServerRequest
-            (Readable.toWeb(this.#req as NodeJS.ReadableStream) as unknown as ReadableStream)
-          : null;
+        // No stream for a null-body (GET/HEAD) request, and never re-wrap an
+        // already-consumed IncomingMessage (the fast path leaves it ended, so a
+        // fresh `Readable.toWeb` would produce a stream whose `end` never fires).
+        let stream =
+          this.#hasBody() && !this.#bodyUsed
+            ? // TODO: HTTP2ServerRequest
+              (Readable.toWeb(this.#req as NodeJS.ReadableStream) as unknown as ReadableStream)
+            : null;
         // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
         // through (`request.body`, and therefore the native `Request` methods
         // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
@@ -181,6 +200,16 @@ export const NodeRequest: {
       return this.#bodyStream;
     }
 
+    get bodyUsed(): boolean {
+      // Serve from srvx state: after a fast-path read the native Request is never
+      // materialized (or is materialized with a null body), so it would otherwise
+      // report `false` or throw when the underlying stream is disturbed.
+      if (this.#bodyUsed) {
+        return true;
+      }
+      return this.#request ? this.#request.bodyUsed : false;
+    }
+
     // Buffer the raw request body once; consumers add their own single
     // continuation (`.toString()` / `JSON.parse`) so no extra promise or
     // microtask hop is introduced vs. inlining the read.
@@ -188,22 +217,40 @@ export const NodeRequest: {
       return readBody(this.#req, this.#maxRequestBodySize);
     }
 
-    text() {
+    text(): Promise<string> {
+      // A second read of an already-consumed body must reject like native fetch
+      // rather than re-listen to an ended stream (which would hang).
+      if (this.#bodyUsed) {
+        return Promise.reject(bodyUnusable());
+      }
       if (this.#request) {
         return this.#request.text();
       }
+      // GET/HEAD: null body, so `text()` is repeatable and resolves to "".
+      if (!this.#hasBody()) {
+        return Promise.resolve("");
+      }
+      this.#bodyUsed = true;
       if (this.#bodyStream !== undefined) {
-        return this.#bodyStream ? new Response(this.#bodyStream).text() : Promise.resolve("");
+        return new Response(this.#bodyStream).text();
       }
       return this.#readBuffered().then((buf) => buf.toString());
     }
 
-    json() {
+    json(): Promise<any> {
+      if (this.#bodyUsed) {
+        return Promise.reject(bodyUnusable());
+      }
       if (this.#request) {
         return this.#request.json();
       }
+      // GET/HEAD: null body — match a null-body native Request (`JSON.parse("")`).
+      if (!this.#hasBody()) {
+        return Promise.resolve().then(() => JSON.parse(""));
+      }
+      this.#bodyUsed = true;
       if (this.#bodyStream !== undefined) {
-        return this.text().then((text) => JSON.parse(text));
+        return new Response(this.#bodyStream).json();
       }
       // Parse in a single continuation (readBody -> parse) instead of going
       // through text() — one less promise + microtask hop per body read.
@@ -212,7 +259,13 @@ export const NodeRequest: {
 
     get _request(): globalThis.Request {
       if (!this.#request) {
-        const body = this.body;
+        // If the body was already consumed via the buffered/stream fast path the
+        // underlying IncomingMessage is disturbed; wrapping it in a native
+        // Request throws synchronously ("Response body object should not be
+        // disturbed or locked") and poisons `bodyUsed` / `clone()` / `formData()`
+        // / `blob()` / `mode` / `referrer`. Serve a null-body Request instead and
+        // let `bodyUsed` reflect srvx state.
+        const body = this.#bodyUsed ? null : this.body;
         this.#request = new NativeRequest(this.url, {
           method: this.method,
           headers: this.headers,

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -133,7 +133,11 @@ export const NodeResponse: {
           body = this.#body;
           contentLength = this.#body.byteLength;
         } else if (this.#body instanceof DataView) {
-          body = Buffer.from(this.#body.buffer);
+          // Only the view's window (byteOffset..byteOffset+byteLength) is part of
+          // the body. `Buffer.from(view.buffer)` would send the whole underlying
+          // ArrayBuffer while content-length is the view length — wrong bytes to
+          // the client and stray bytes left in a keep-alive connection.
+          body = Buffer.from(this.#body.buffer, this.#body.byteOffset, this.#body.byteLength);
           contentLength = this.#body.byteLength;
         } else if (this.#body instanceof Blob) {
           body = this.#body.stream();

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -1,5 +1,5 @@
 import { createServer } from "node:http";
-import type { AddressInfo } from "node:net";
+import { connect, type AddressInfo } from "node:net";
 import { describe, expect, test } from "vitest";
 
 import type { NodeHttp1Handler, NodeServerRequest, NodeServerResponse } from "../src/types.ts";
@@ -445,3 +445,230 @@ describe("FastResponse header dedup", () => {
     expect(cl[0]).toEqual(["content-length", "5"]);
   });
 });
+
+// v1 stabilization: Node-adapter crash/corruption regressions.
+describe("node body crash regressions", () => {
+  // F1: the non-middleware branch of callNodeHandler had no `.catch`, so an async
+  // node handler that threw caused an unhandledRejection AND never settled (the
+  // request hung). It must reject like the middleware branch.
+  test("F1: async node handler that throws does not crash or hang", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (err: unknown) => rejections.push(err);
+    process.on("unhandledRejection", onRejection);
+
+    const throwingHandler: NodeHttp1Handler = async () => {
+      throw new Error("boom");
+    };
+
+    const server = serve({
+      port: 0,
+      // Surface the callNodeHandler rejection as a clean 500 so we can assert it
+      // settled instead of hanging.
+      error: () => new Response("caught", { status: 500 }),
+      fetch: (webReq) => fetchNodeHandler(throwingHandler, webReq),
+    });
+    await server.ready();
+
+    try {
+      const res = await Promise.race([
+        fetch(server.url!),
+        new Promise<Response>((_, reject) =>
+          setTimeout(() => reject(new Error("request hung")), 3000),
+        ),
+      ]);
+      expect(res.status).toBe(500);
+      expect(await res.text()).toBe("caught");
+      // Let any (buggy) unhandledRejection flush before asserting the process survived.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(rejections).toHaveLength(0);
+    } finally {
+      process.off("unhandledRejection", onRejection);
+      await server.close(true);
+    }
+  });
+
+  // F2: after the buffered fast path consumes the IncomingMessage, a second
+  // text()/json() re-attached data/end listeners to an ended stream and hung.
+  // It must reject with `TypeError: Body is unusable`.
+  test("F2: second body read rejects with TypeError instead of hanging", async () => {
+    let firstRead: string | undefined;
+    let secondReadOutcome: string | undefined;
+
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        firstRead = await req.text();
+        secondReadOutcome = await Promise.race([
+          req.text().then(
+            () => "resolved",
+            (error) => (error instanceof TypeError ? "TypeError" : "other-error"),
+          ),
+          new Promise<string>((r) => setTimeout(() => r("hung"), 2000)),
+        ]);
+        return new Response("ok");
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(res.status).toBe(200);
+    expect(firstRead).toBe("hello");
+    expect(secondReadOutcome).toBe("TypeError");
+    await server.close(true);
+  });
+
+  // F3: the `_request` getter wrapped the already-consumed stream in a native
+  // Request, throwing "... disturbed or locked" synchronously and poisoning
+  // bodyUsed / clone() / mode. These must all work after consumption.
+  test("F3: bodyUsed / clone() / mode work after body consumption", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const bodyUsedBefore = req.bodyUsed;
+        const text = await req.text();
+        const bodyUsedAfter = req.bodyUsed;
+
+        let cloneOk = true;
+        try {
+          req.clone();
+        } catch {
+          cloneOk = false;
+        }
+
+        let mode: string;
+        try {
+          mode = req.mode;
+        } catch {
+          mode = "THREW";
+        }
+
+        return Response.json({ text, bodyUsedBefore, bodyUsedAfter, cloneOk, mode });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      text: "hello",
+      bodyUsedBefore: false,
+      bodyUsedAfter: true,
+      cloneOk: true,
+      mode: "cors",
+    });
+    await server.close(true);
+  });
+
+  // GET/HEAD are always null-body per the fetch spec, regardless of what was on
+  // the wire and regardless of property-access order.
+  for (const order of ["text-first", "body-first"] as const) {
+    test(`GET with a body on the wire is null-body (${order})`, async () => {
+      const server = serve({
+        port: 0,
+        hostname: "127.0.0.1",
+        async fetch(req) {
+          const result: Record<string, unknown> = {};
+          if (order === "body-first") {
+            result.bodyNull = req.body === null;
+            result.text = await req.text();
+          } else {
+            result.text = await req.text();
+            result.bodyNull = req.body === null;
+          }
+          // FastResponse with a string body is content-length framed, which the
+          // raw parser below relies on.
+          return new FastResponse(JSON.stringify(result));
+        },
+      });
+      await server.ready();
+
+      // Send a GET with a body on the wire via a raw socket (fetch forbids it).
+      const u = new URL(server.url!);
+      const raw = await rawExchange(
+        Number(u.port),
+        u.hostname,
+        "GET / HTTP/1.1\r\n" +
+          `Host: ${u.hostname}\r\n` +
+          "Content-Length: 5\r\n" +
+          "Connection: close\r\n" +
+          "\r\n" +
+          "hello",
+      );
+      const responses = parseHttpResponses(raw);
+      expect(responses).toHaveLength(1);
+      expect(JSON.parse(responses[0].body.toString())).toEqual({ bodyNull: true, text: "" });
+      await server.close(true);
+    });
+  }
+
+  // F5: a TypedArray/DataView view of a larger buffer must send only the view's
+  // window. `Buffer.from(view.buffer)` sent the whole ArrayBuffer while
+  // content-length was the view length — wrong bytes out, stray bytes left in the
+  // keep-alive connection (corrupting the next pipelined response).
+  test("F5: DataView view body sends exact bytes and keeps the connection clean", async () => {
+    const server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch(req) {
+        const url = new URL(req.url);
+        if (url.pathname === "/view") {
+          // 4-byte view (values 3,4,5,6) of a 10-byte buffer.
+          const buffer = new Uint8Array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]).buffer;
+          const view = new DataView(buffer, 3, 4);
+          return new FastResponse(view);
+        }
+        return new FastResponse("second");
+      },
+    });
+    await server.ready();
+
+    const u = new URL(server.url!);
+    // Two pipelined keep-alive requests on one socket; the second closes it.
+    const raw = await rawExchange(
+      Number(u.port),
+      u.hostname,
+      `GET /view HTTP/1.1\r\nHost: ${u.hostname}\r\n\r\n` +
+        `GET /second HTTP/1.1\r\nHost: ${u.hostname}\r\nConnection: close\r\n\r\n`,
+    );
+
+    const responses = parseHttpResponses(raw);
+    expect(responses).toHaveLength(2);
+    expect([...responses[0].body]).toEqual([3, 4, 5, 6]);
+    expect(responses[1].body.toString()).toBe("second");
+    await server.close(true);
+  });
+});
+
+// Raw HTTP/1.1 helpers: write `payload`, collect every byte until the server
+// closes the connection (driven by a `Connection: close` on the last request).
+function rawExchange(port: number, host: string, payload: string): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const socket = connect(port, host);
+    const chunks: Buffer[] = [];
+    socket.on("data", (d: Buffer) => chunks.push(d));
+    socket.on("error", reject);
+    socket.on("close", () => resolve(Buffer.concat(chunks)));
+    socket.on("connect", () => socket.write(payload));
+    setTimeout(() => {
+      socket.destroy();
+      reject(new Error("rawExchange timed out"));
+    }, 3000).unref?.();
+  });
+}
+
+// Minimal content-length-framed response parser (sufficient for these fixtures).
+function parseHttpResponses(buf: Buffer): { headers: string; body: Buffer }[] {
+  const responses: { headers: string; body: Buffer }[] = [];
+  let offset = 0;
+  while (offset < buf.length) {
+    const headerEnd = buf.indexOf("\r\n\r\n", offset);
+    if (headerEnd === -1) break;
+    const headers = buf.toString("latin1", offset, headerEnd);
+    const clMatch = /content-length:\s*(\d+)/i.exec(headers);
+    const bodyStart = headerEnd + 4;
+    const len = clMatch ? Number(clMatch[1]) : 0;
+    responses.push({ headers, body: buf.subarray(bodyStart, bodyStart + len) });
+    offset = bodyStart + len;
+  }
+  return responses;
+}


### PR DESCRIPTION
Batch of Node-adapter crash/corruption fixes from the v1 stabilization review.

- **F1** — `callNodeHandler`'s non-middleware branch had no `.catch`; an async handler that threw caused an unhandledRejection and the request hung forever. Now mirrors the middleware branch's `.catch(reject)`.
- **F2** — a second `text()`/`json()` after the buffered fast path re-listened to an ended `IncomingMessage` and hung. Body consumption is now tracked at the srvx level and a second read rejects with `TypeError: Body is unusable`.
- **F3** — the `_request` getter wrapped the consumed stream in a native `Request`, throwing "… disturbed or locked" and poisoning `bodyUsed` / `clone()` / `formData()` / `blob()` / `mode` / `referrer`. `bodyUsed` is now served from srvx state and no native `Request` is materialized over a disturbed stream.
- **F5** — `DataView` view bodies sent the whole underlying `ArrayBuffer` while `content-length` was the view length, corrupting the response and leaving stray bytes in keep-alive connections. Now sliced to the view's window (`Buffer.from(b.buffer, b.byteOffset, b.byteLength)`).
- **GET/HEAD null-body** — GET/HEAD are now always null-body per the fetch spec, regardless of what was on the wire and regardless of property-access order (raw bytes remain reachable via `request.runtime.node.req`).

Tests added in `test/node-adapters.test.ts` cover each finding (verified to fail on the unpatched source). Full suite: 858 passed, 32 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)