### PR TITLE
fix: resolve `x-forwarded-*` hop-aware, right-to-left

### DIFF
--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -160,12 +160,23 @@ serve({
 
 Whether to trust `X-Forwarded-*` headers (`X-Forwarded-Proto`, `X-Forwarded-Host`, `X-Forwarded-For`, and the HTTP/2 `:scheme`) when deriving `request.url` and `request.ip`. Defaults to `false`.
 
-Any client can send `X-Forwarded-Proto: https`, `X-Forwarded-Host` or `X-Forwarded-For`, so trusting them lets a request masquerade as `https:`, forge its host, or spoof its client IP. Only enable this when a proxy you control sits in front and overwrites the headers.
+Any client can send `X-Forwarded-Proto: https`, `X-Forwarded-Host` or `X-Forwarded-For`, so trusting them lets a request masquerade as `https:`, forge its host, or spoof its client IP. Only enable this when a proxy you control sits in front.
 
 - `false` (default): ignore the headers; use the real connection protocol, the on-the-wire `Host` header and the socket peer address.
-- `true`: always trust the headers.
-- `"loopback"`: trust them only when the proxy connects from a loopback address (`127.0.0.0/8` or `::1`).
-- `string[]`: trust them only when the proxy's address is in the list.
+- `true`: trust every hop (the leftmost `X-Forwarded-For` entry is the client).
+- `"loopback"`: trust hops on a loopback address (`127.0.0.0/8` or `::1`), i.e. a proxy on the same host.
+- `string[]`: trust hops whose address is in the allowlist.
+
+#### Hop-aware resolution
+
+Real proxies **append** to `X-Forwarded-*`, so the chain grows left-to-right (outermost client first, nearest proxy last). srvx resolves it **hop-aware, right-to-left**, matching Express (`trust proxy`), nginx (`$proxy_add_x_forwarded_for`) and AWS ALB:
+
+- Starting from the immediate peer, each address in the trusted set is treated as a proxy you control.
+- **The client is the rightmost address _not_ in the trusted set.**
+- If every address in the chain is trusted, the leftmost entry is the client.
+- If the immediate peer is not trusted, the headers are ignored entirely.
+
+This is why a spoofed prefix cannot poison `request.ip`: with `trustProxy: "loopback"` and a request carrying `X-Forwarded-For: 9.9.9.9`, the trusted proxy appends the real client address, so the forged `9.9.9.9` is skipped rather than returned. The same model gates the forwarded protocol and host: only the value contributed by the trusted proxy is honored, so an attacker cannot poison `request.url` (e.g. cache keys or password-reset links).
 
 **Example:**
 

--- a/src/_trust-proxy.ts
+++ b/src/_trust-proxy.ts
@@ -4,16 +4,19 @@ import type { ServerPlugin, ServerRequest } from "./types.ts";
  * Controls whether `X-Forwarded-*` headers (proto, host, for, and the HTTP/2
  * `:scheme` pseudo-header) are trusted when deriving request metadata.
  *
- * These headers are set by the client on the wire, so they can only be trusted
- * when a proxy you control sits in front and overwrites them. See
- * {@link ServerOptions.trustProxy}.
+ * These headers are appended by every proxy on the wire, so trusting them is
+ * hop-aware: starting from the immediate peer and walking the forwarded chain
+ * right-to-left, each address in the trusted set is treated as a proxy we
+ * control. The first address *not* in the set is the real client (see
+ * {@link ServerOptions.trustProxy}).
  *
  *   - `false` (default): never trust forwarded headers; derive protocol, host
  *     and client IP from the real transport only.
- *   - `true`: always trust forwarded headers.
- *   - `"loopback"`: trust only when the immediate peer is a loopback address
- *     (`127.0.0.0/8` or `::1`), i.e. a proxy running on the same host.
- *   - `string[]`: trust only when the immediate peer address is in the allowlist.
+ *   - `true`: always trust forwarded headers (every hop is trusted, so the
+ *     leftmost `X-Forwarded-For` entry is the client).
+ *   - `"loopback"`: trust only hops on a loopback address (`127.0.0.0/8` or
+ *     `::1`), i.e. a proxy running on the same host.
+ *   - `string[]`: trust only hops whose address is in the allowlist.
  */
 export type TrustProxyOption = boolean | "loopback" | string[];
 
@@ -79,19 +82,108 @@ function forwardedHostHasPort(host: string): boolean {
 }
 
 /**
- * Leftmost/first entry of a comma-separated `X-Forwarded-*` header value. With a
- * chain of proxies the header is a comma-separated list; the leftmost entry is
- * the value seen by the outermost proxy. Node exposes repeated headers as a
- * `string[]`, so the array form is normalized to its first element.
+ * Split a comma-separated `X-Forwarded-*` header value into trimmed, non-empty
+ * entries in header order (left to right, i.e. outermost/original client first,
+ * nearest proxy last). Node exposes repeated headers as a `string[]`, which is
+ * joined before splitting.
  */
-export function firstForwardedValue(
-  value: string | string[] | null | undefined,
-): string | undefined {
+export function forwardedList(value: string | string[] | null | undefined): string[] {
   if (!value) {
+    return [];
+  }
+  const raw = Array.isArray(value) ? value.join(",") : value;
+  const out: string[] = [];
+  for (const part of raw.split(",")) {
+    const entry = part.trim();
+    if (entry) {
+      out.push(entry);
+    }
+  }
+  return out;
+}
+
+/**
+ * Resolve the real client IP hop-aware, per {@link TrustProxyOption}.
+ *
+ * Conceptually the hop chain (nearest first) is `[peer, ...reversed(forwarded)]`:
+ * the socket peer added no entry of its own, and each proxy appended the address
+ * it saw. Walking right-to-left, every address in the trusted set is a proxy we
+ * control; the first untrusted address is the client. If every hop is trusted
+ * the client is the leftmost forwarded entry (matching Express `trust proxy`),
+ * falling back to the peer when no `X-Forwarded-For` is present. If the peer
+ * itself is untrusted the header is ignored entirely and the peer is the client.
+ */
+export function resolveClientIP(
+  trustProxy: TrustProxyOption | undefined,
+  peer: string | undefined,
+  forwardedFor: string | string[] | null | undefined,
+): string | undefined {
+  if (!isTrustedProxy(trustProxy, peer)) {
+    return peer;
+  }
+  const list = forwardedList(forwardedFor);
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (!isTrustedProxy(trustProxy, list[i])) {
+      return list[i];
+    }
+  }
+  return list.length > 0 ? list[0] : peer;
+}
+
+/**
+ * Number of trusted hops in front of the server, counting the immediate peer and
+ * every trusted `X-Forwarded-For` entry walking right-to-left. `0` means the peer
+ * is untrusted, so no forwarded value may be honored. This count also selects the
+ * trusted entry of the parallel `X-Forwarded-Proto`/`-Host` lists (see
+ * {@link forwardedHopValue}).
+ *
+ * When the whole visible chain is trusted (the peer and every `X-Forwarded-For`
+ * entry — e.g. `trustProxy: true`, or the real client sits upstream of all seen
+ * proxies), the number of trusted hops is effectively unbounded, so `Infinity` is
+ * returned. A proto/host list may then legitimately be longer than the seen
+ * `X-Forwarded-For` chain, and its leftmost (original-client) entry is honored.
+ */
+export function trustedHops(
+  trustProxy: TrustProxyOption | undefined,
+  peer: string | undefined,
+  forwardedFor: string | string[] | null | undefined,
+): number {
+  if (!isTrustedProxy(trustProxy, peer)) {
+    return 0;
+  }
+  const list = forwardedList(forwardedFor);
+  let hops = 1; // the peer
+  for (let i = list.length - 1; i >= 0; i--) {
+    if (!isTrustedProxy(trustProxy, list[i])) {
+      return hops;
+    }
+    hops++;
+  }
+  // No untrusted boundary found in the visible chain: treat as unbounded.
+  return Number.POSITIVE_INFINITY;
+}
+
+/**
+ * Pick the entry of a forwarded `X-Forwarded-Proto`/`-Host` list contributed by
+ * the outermost trusted proxy, given the {@link trustedHops} count. Proxies
+ * append these in lockstep with `X-Forwarded-For`, so with `hops` trusted hops we
+ * may trust the `hops` rightmost entries; the outermost trusted one is at index
+ * `length - hops` (clamped, so it degrades to the leftmost value when every hop
+ * is trusted or the list is shorter than the chain). Returns `undefined` when the
+ * peer is untrusted (`hops <= 0`) or the list is empty.
+ */
+export function forwardedHopValue(
+  value: string | string[] | null | undefined,
+  hops: number,
+): string | undefined {
+  if (hops <= 0) {
     return undefined;
   }
-  const first = (Array.isArray(value) ? value[0] : value).split(",")[0].trim();
-  return first || undefined;
+  const list = forwardedList(value);
+  if (list.length === 0) {
+    return undefined;
+  }
+  return list[Math.max(0, list.length - hops)];
 }
 
 /**
@@ -115,17 +207,20 @@ export const trustProxyPlugin: ServerPlugin = (server) => {
 };
 
 function applyTrustedProxy(request: ServerRequest, trustProxy: TrustProxyOption): void {
-  // The socket peer address stays authoritative for the trust decision, so read
-  // it (via the adapter's native getter) before any override below.
-  if (!isTrustedProxy(trustProxy, request.ip)) {
+  // The socket peer address (via the adapter's native getter) is the nearest hop
+  // and stays authoritative for the trust decision. `trustedHops` walks the
+  // `X-Forwarded-For` chain right-to-left from it; `0` means the peer is
+  // untrusted, so every forwarded header is ignored.
+  const peer = request.ip;
+  const headers = request.headers;
+  const hops = trustedHops(trustProxy, peer, headers.get("x-forwarded-for"));
+  if (hops === 0) {
     return;
   }
 
-  const headers = request.headers;
-
-  // request.url <- X-Forwarded-Proto / X-Forwarded-Host
-  const forwardedProto = firstForwardedValue(headers.get("x-forwarded-proto"));
-  const forwardedHost = firstForwardedValue(headers.get("x-forwarded-host"));
+  // request.url <- X-Forwarded-Proto / X-Forwarded-Host (trusted hop entry)
+  const forwardedProto = forwardedHopValue(headers.get("x-forwarded-proto"), hops);
+  const forwardedHost = forwardedHopValue(headers.get("x-forwarded-host"), hops);
   if (forwardedProto || forwardedHost) {
     const url = new URL(request.url);
     if (forwardedProto === "https" || forwardedProto === "http") {
@@ -151,11 +246,11 @@ function applyTrustedProxy(request: ServerRequest, trustProxy: TrustProxyOption)
     });
   }
 
-  // request.ip <- X-Forwarded-For (leftmost = original client)
-  const forwardedFor = firstForwardedValue(headers.get("x-forwarded-for"));
-  if (forwardedFor) {
+  // request.ip <- X-Forwarded-For (first untrusted address, hop-aware)
+  const client = resolveClientIP(trustProxy, peer, headers.get("x-forwarded-for"));
+  if (client && client !== peer) {
     Object.defineProperty(request, "ip", {
-      value: forwardedFor,
+      value: client,
       enumerable: true,
       configurable: true,
     });

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -1,6 +1,6 @@
 import type { ServerRequest } from "../../types.ts";
 import type { TrustProxyOption } from "../../_trust-proxy.ts";
-import { isTrustedProxy, firstForwardedValue } from "../../_trust-proxy.ts";
+import { resolveClientIP, trustedHops, forwardedHopValue } from "../../_trust-proxy.ts";
 import type {
   APIGatewayProxyEvent,
   Context as AWSContext,
@@ -34,12 +34,14 @@ export function awsRequest(
   context: AWSContext,
   trustProxy?: TrustProxyOption,
 ): ServerRequest {
-  // Resolve the immediate-peer address and trust decision once and pass them
-  // down; both the URL and the client IP derivation need them.
+  // The gateway-verified `sourceIp` is the nearest hop. Resolve the trusted hop
+  // count once (walking `X-Forwarded-For` right-to-left from it) and pass it
+  // down; both the URL and the client IP derivation are hop-aware.
   const sourceIp = awsEventIP(event);
-  const trusted = isTrustedProxy(trustProxy, sourceIp);
+  const forwardedFor = awsForwardedFor(event);
+  const hops = trustedHops(trustProxy, sourceIp, forwardedFor);
 
-  const req = new Request(awsEventURL(event, trusted), {
+  const req = new Request(awsEventURL(event, hops), {
     method: awsEventMethod(event),
     headers: awsEventHeaders(event),
     body: awsEventBody(event),
@@ -50,9 +52,13 @@ export function awsRequest(
     awsLambda: { event, context },
   };
 
-  req.ip = awsEventClientIP(event, sourceIp, trusted);
+  req.ip = resolveClientIP(trustProxy, sourceIp, forwardedFor);
 
   return req;
+}
+
+function awsForwardedFor(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): string | undefined {
+  return event.headers["X-Forwarded-For"] || event.headers["x-forwarded-for"];
 }
 
 function awsEventMethod(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): string {
@@ -70,36 +76,18 @@ function awsEventIP(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): strin
   );
 }
 
-/**
- * Resolve the client IP, preferring the leftmost `X-Forwarded-For` entry when
- * the immediate peer (the gateway `sourceIp`) is a trusted proxy.
- */
-function awsEventClientIP(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
-  sourceIp: string | undefined,
-  trusted: boolean,
-): string | undefined {
-  if (trusted) {
-    const forwarded = firstForwardedValue(
-      event.headers["X-Forwarded-For"] || event.headers["x-forwarded-for"],
-    );
-    if (forwarded) {
-      return forwarded;
-    }
-  }
-  return sourceIp;
-}
-
-function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2, trusted: boolean): URL {
+function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2, hops: number): URL {
   const path = (event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath;
 
   const query = awsEventQuery(event);
 
-  // Only honor client-supplied `X-Forwarded-*` headers when the proxy is
-  // trusted; otherwise any client could spoof the host or protocol.
-  const forwardedHost = trusted
-    ? firstForwardedValue(event.headers["X-Forwarded-Host"] || event.headers["x-forwarded-host"])
-    : undefined;
+  // Only honor client-supplied `X-Forwarded-*` headers when the peer is trusted
+  // (`hops > 0`); otherwise any client could spoof the host or protocol. `hops`
+  // selects the outermost trusted proxy's entry from a comma-joined chain.
+  const forwardedHost = forwardedHopValue(
+    event.headers["X-Forwarded-Host"] || event.headers["x-forwarded-host"],
+    hops,
+  );
   const hostname =
     forwardedHost ||
     event.headers.host ||
@@ -108,9 +96,10 @@ function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2, trust
     ".";
 
   // Assume `https` when untrusted (Lambda is always TLS-terminated at the gateway).
-  const forwardedProto = trusted
-    ? firstForwardedValue(event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"])
-    : undefined;
+  const forwardedProto = forwardedHopValue(
+    event.headers["X-Forwarded-Proto"] || event.headers["x-forwarded-proto"],
+    hops,
+  );
   const protocol = forwardedProto === "http" ? "http" : "https";
 
   return new URL(`${path}${query ? `?${query}` : ""}`, `${protocol}://${hostname}`);

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -1,6 +1,6 @@
 import type { NodeServerRequest, NodeServerResponse, ServerRequest } from "../../types.ts";
 import type { TrustProxyOption } from "../../_trust-proxy.ts";
-import { isTrustedProxy, firstForwardedValue } from "../../_trust-proxy.ts";
+import { resolveClientIP, trustedHops } from "../../_trust-proxy.ts";
 import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
@@ -47,7 +47,8 @@ export const NodeRequest: {
     #ip?: string;
     #ipResolved = false;
     #remoteAddress?: string;
-    #trusted?: boolean;
+    #remoteResolved = false;
+    #hops?: number;
 
     constructor(ctx: NodeRequestContext) {
       this.#req = ctx.req;
@@ -66,15 +67,28 @@ export const NodeRequest: {
       return val instanceof NativeRequest;
     }
 
-    // Resolve the trust decision once: the peer address is fixed for the
-    // lifetime of the request, and both `ip` and `_url` need it. `isTrustedProxy`
-    // (and the `socket.remoteAddress` read) would otherwise run twice per request.
-    #resolveTrusted(): boolean {
-      if (this.#trusted === undefined) {
+    // Read the socket peer address once: it is the nearest hop, fixed for the
+    // lifetime of the request, and both `ip` and `_url` need it (the trust
+    // decision and hop walk key off it).
+    #remoteAddr(): string | undefined {
+      if (!this.#remoteResolved) {
+        this.#remoteResolved = true;
         this.#remoteAddress = this.#req.socket?.remoteAddress;
-        this.#trusted = isTrustedProxy(this.#trustProxy, this.#remoteAddress);
       }
-      return this.#trusted;
+      return this.#remoteAddress;
+    }
+
+    // Resolve the trusted hop count once: it gates `X-Forwarded-Proto`/`-Host`
+    // (in `NodeRequestURL`) and mirrors the client-IP walk here.
+    #resolveHops(): number {
+      if (this.#hops === undefined) {
+        this.#hops = trustedHops(
+          this.#trustProxy,
+          this.#remoteAddr(),
+          this.#req.headers["x-forwarded-for"],
+        );
+      }
+      return this.#hops;
     }
 
     get ip(): string | undefined {
@@ -84,17 +98,14 @@ export const NodeRequest: {
         return this.#ip;
       }
       this.#ipResolved = true;
-      const trusted = this.#resolveTrusted();
-      // Only honor `X-Forwarded-For` when the immediate peer is a trusted proxy;
-      // otherwise any client could forge its address. The leftmost entry is the
-      // original client as seen by the outermost trusted proxy.
-      if (trusted) {
-        const forwarded = firstForwardedValue(this.#req.headers["x-forwarded-for"]);
-        if (forwarded) {
-          return (this.#ip = forwarded);
-        }
-      }
-      return (this.#ip = this.#remoteAddress);
+      // Hop-aware: the client is the first `X-Forwarded-For` address (walking
+      // right-to-left from the peer) that is not a trusted proxy. Untrusted peer
+      // -> the header is ignored and the peer is the client.
+      return (this.#ip = resolveClientIP(
+        this.#trustProxy,
+        this.#remoteAddr(),
+        this.#req.headers["x-forwarded-for"],
+      ));
     }
 
     get method(): string {
@@ -107,7 +118,7 @@ export const NodeRequest: {
     get _url() {
       return (this.#url ||= new NodeRequestURL({
         req: this.#req,
-        trusted: this.#resolveTrusted(),
+        hops: this.#resolveHops(),
       }));
     }
 

--- a/src/adapters/_node/url.ts
+++ b/src/adapters/_node/url.ts
@@ -1,22 +1,23 @@
 import type { NodeServerRequest } from "../../types.ts";
-import { HOST_RE, firstForwardedValue } from "../../_trust-proxy.ts";
+import { HOST_RE, forwardedHopValue } from "../../_trust-proxy.ts";
 import { FastURL } from "../../_url.ts";
 
 export { HOST_RE };
 
 export class NodeRequestURL extends FastURL {
-  constructor({ req, trusted = false }: { req: NodeServerRequest; trusted?: boolean }) {
+  constructor({ req, hops = 0 }: { req: NodeServerRequest; hops?: number }) {
     const path = req.url || "/";
 
     // Only honor client-supplied `X-Forwarded-*` hints when the request comes
-    // through a trusted proxy (`trusted`); otherwise any client could spoof the
+    // through a trusted proxy (`hops > 0`); otherwise any client could spoof the
     // host or `https` on a plaintext connection. The real transport
     // (`encrypted`) and the on-the-wire `Host` header stay authoritative.
+    // `hops` (the trusted hop count) selects the entry contributed by the
+    // outermost trusted proxy from a comma-joined chain, mirroring `request.ip`.
     // A malformed forwarded host is ignored (fall back to the real `Host`),
     // matching the universal trustProxy plugin used on Bun/Deno.
-    const forwardedHost = trusted
-      ? firstForwardedValue(req.headers["x-forwarded-host"])
-      : undefined;
+    const trusted = hops > 0;
+    const forwardedHost = forwardedHopValue(req.headers["x-forwarded-host"], hops);
 
     let host =
       (forwardedHost && HOST_RE.test(forwardedHost) ? forwardedHost : undefined) ||
@@ -33,11 +34,9 @@ export class NodeRequestURL extends FastURL {
     }
 
     // A proxy chain can join `X-Forwarded-Proto` into a comma-separated list, so
-    // compare the leftmost entry (via `firstForwardedValue`) rather than the raw
+    // pick the trusted hop entry (via `forwardedHopValue`) rather than the raw
     // header. The HTTP/2 `:scheme` pseudo-header is always a single value.
-    const forwardedProto = trusted
-      ? firstForwardedValue(req.headers["x-forwarded-proto"])
-      : undefined;
+    const forwardedProto = forwardedHopValue(req.headers["x-forwarded-proto"], hops);
     const protocol =
       (req.socket as any)?.encrypted ||
       forwardedProto === "https" ||

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -408,6 +408,64 @@ describe("[AWS Lambda] Request Utils", () => {
       expect(request.ip).toBe("10.0.0.1");
     });
 
+    test("hop-aware: rightmost untrusted X-Forwarded-For entry is the client", () => {
+      // The gateway `sourceIp` (10.0.0.1) is the nearest hop and is the only
+      // trusted address. An attacker prepends `9.9.9.9`; the gateway appends the
+      // real address `1.2.3.4`. Walking right-to-left, `1.2.3.4` wins — the old
+      // leftmost behavior would have returned the spoofed `9.9.9.9`.
+      const v1Event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/api/users",
+        headers: {
+          host: "api.example.com",
+          "x-forwarded-for": "9.9.9.9, 1.2.3.4",
+        },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: { identity: { sourceIp: "10.0.0.1" } } as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      const request = awsRequest(v1Event, createMockContext(), ["10.0.0.1"]);
+
+      expect(request.ip).toBe("1.2.3.4");
+    });
+
+    test("hop-aware proto/host: only the trusted peer's appended entry is honored", () => {
+      const v1Event: APIGatewayProxyEvent = {
+        httpMethod: "GET",
+        path: "/api/users",
+        headers: {
+          host: "real.example.com",
+          "x-forwarded-for": "9.9.9.9, 1.2.3.4",
+          "x-forwarded-proto": "https, http",
+          "x-forwarded-host": "spoofed.example, forwarded.example",
+        },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: { identity: { sourceIp: "10.0.0.1" } } as any,
+        resource: "",
+        queryStringParameters: null,
+      };
+
+      // Only the gateway (sourceIp) is trusted -> one hop -> the peer-appended
+      // (rightmost) proto/host entries win over the attacker-prepended ones.
+      const request = awsRequest(v1Event, createMockContext(), ["10.0.0.1"]);
+      const url = new URL(request.url);
+
+      expect(url.protocol).toBe("http:");
+      expect(url.host).toBe("forwarded.example");
+    });
+
     test("should handle path parameters in URL construction", () => {
       const v1Event: APIGatewayProxyEvent = {
         httpMethod: "GET",

--- a/test/node-trust-proxy.test.ts
+++ b/test/node-trust-proxy.test.ts
@@ -204,12 +204,37 @@ describe("trustProxy client IP gating (Node)", () => {
     expect(body).toBe("1.2.3.4");
   });
 
-  test("trustProxy: true uses the leftmost X-Forwarded-For entry", async () => {
+  test("all hops trusted (trustProxy: true) -> leftmost X-Forwarded-For entry", async () => {
+    // Every address is trusted, so the outermost (leftmost) entry is the client,
+    // matching Express `trust proxy: true`.
     const port = await start({ trustProxy: true });
     const { body } = await rawRequest(port, {
       "X-Forwarded-For": "1.2.3.4, 10.0.0.1, 10.0.0.2",
     });
     expect(body).toBe("1.2.3.4");
+  });
+
+  test("hop-aware: rightmost untrusted entry is the client, not a spoofed prefix", async () => {
+    // Only the loopback peer is trusted. An attacker prepends `9.9.9.9`; the
+    // trusted proxy appends the attacker's real address `1.2.3.4`. Walking
+    // right-to-left, `1.2.3.4` is the first untrusted hop and wins — the old
+    // leftmost behavior would have returned the spoofed `9.9.9.9`.
+    const port = await start({ trustProxy: ["127.0.0.1", "::1"] });
+    const { body } = await rawRequest(port, {
+      "X-Forwarded-For": "9.9.9.9, 1.2.3.4",
+    });
+    expect(body).toBe("1.2.3.4");
+  });
+
+  test("untrusted peer -> X-Forwarded-For ignored entirely", async () => {
+    // The allowlist does not include the loopback peer, so the whole header is
+    // ignored and the real peer address is used.
+    const port = await start({ trustProxy: ["10.0.0.1"] });
+    const { body } = await rawRequest(port, {
+      "X-Forwarded-For": "1.2.3.4",
+    });
+    expect(body).not.toBe("1.2.3.4");
+    expect(body).toMatch(/127\.0\.0\.1|::1|::ffff:127\.0\.0\.1/);
   });
 
   test("falls back to peer address when X-Forwarded-For is absent", async () => {

--- a/test/trust-proxy-plugin.test.ts
+++ b/test/trust-proxy-plugin.test.ts
@@ -115,7 +115,7 @@ describe("trustProxyPlugin", () => {
     expect(req.ip).toBe("1.2.3.4");
   });
 
-  test("uses the leftmost X-Forwarded-For entry and first host of a chain", async () => {
+  test("all hops trusted (trustProxy: true) -> leftmost X-Forwarded-For is the client", async () => {
     const req = await run(
       true,
       makeRequest("http://origin.example/", "10.0.0.1", {
@@ -123,8 +123,67 @@ describe("trustProxyPlugin", () => {
         "x-forwarded-for": "1.2.3.4, 10.0.0.9, 10.0.0.1",
       }),
     );
+    // Every address is trusted, so the outermost (leftmost) entries are the
+    // original client — matching Express `trust proxy: true`.
     expect(new URL(req.url).host).toBe("outer.example");
     expect(req.ip).toBe("1.2.3.4");
+  });
+
+  test("hop-aware: client is the rightmost address NOT in the trusted set", async () => {
+    // The attacker prepends a fake entry; the trusted peer appends the attacker's
+    // real address. Walking right-to-left, `1.2.3.4` is the first untrusted hop,
+    // so the spoofed `9.9.9.9` is ignored (old leftmost behavior would return it).
+    const req = await run(
+      ["10.0.0.1"],
+      makeRequest("http://origin.example/", "10.0.0.1", {
+        "x-forwarded-for": "9.9.9.9, 1.2.3.4",
+      }),
+    );
+    expect(req.ip).toBe("1.2.3.4");
+    expect(req.ip).not.toBe("9.9.9.9");
+  });
+
+  test("hop-aware: skips a chain of trusted proxies to the first untrusted hop", async () => {
+    const req = await run(
+      ["10.0.0.1", "10.0.0.2"],
+      makeRequest("http://origin.example/", "10.0.0.1", {
+        // peer 10.0.0.1 (trusted) <- 10.0.0.2 (trusted) <- 1.2.3.4 (client)
+        "x-forwarded-for": "1.2.3.4, 10.0.0.2",
+      }),
+    );
+    expect(req.ip).toBe("1.2.3.4");
+  });
+
+  test("hop-aware proto/host: only the trusted peer's appended entry is honored", async () => {
+    // Attacker prepends `https` / `spoofed.example`; the single trusted peer
+    // appended `http` / `real.example`. With one trusted hop the rightmost (the
+    // peer's) entry wins, defeating scheme and host (cache/reset-link) poisoning.
+    const req = await run(
+      ["10.0.0.1"],
+      makeRequest("http://origin.example/", "10.0.0.1", {
+        "x-forwarded-for": "9.9.9.9, 1.2.3.4",
+        "x-forwarded-proto": "https, http",
+        "x-forwarded-host": "spoofed.example, real.example",
+      }),
+    );
+    const url = new URL(req.url);
+    expect(url.protocol).toBe("http:");
+    expect(url.host).toBe("real.example");
+  });
+
+  test("untrusted peer -> X-Forwarded-For (and proto/host) ignored entirely", async () => {
+    const req = await run(
+      ["10.0.0.1"],
+      makeRequest("http://origin.example/", "203.0.113.7", {
+        "x-forwarded-for": "1.2.3.4, 10.0.0.1",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "public.example",
+      }),
+    );
+    // The peer itself is untrusted, so nothing forwarded is honored.
+    expect(req.ip).toBe("203.0.113.7");
+    expect(new URL(req.url).host).toBe("origin.example");
+    expect(new URL(req.url).protocol).toBe("http:");
   });
 
   test("X-Forwarded-Host without a port drops the listener port", async () => {


### PR DESCRIPTION
The `X-Forwarded-*` headers were resolved **leftmost-first**, so under the recommended `trustProxy: "loopback"` an attacker sending `X-Forwarded-For: 9.9.9.9` got `request.ip === "9.9.9.9"`. Because real proxies **append** to the header, the leftmost value is fully client-controlled — this defeats IP rate-limits, allowlists, geo checks and audit logs (F7). The same class of issue let forwarded proto and host be poisoned (cache keys, password-reset links).

## New hop-aware model (D1)

Resolve the forwarded chain **hop-aware, right-to-left** from the immediate peer, skipping addresses in the trusted set — the first untrusted address is the client. This matches Express (`trust proxy`), nginx (`$proxy_add_x_forwarded_for`) and AWS ALB.

- The client is the **rightmost address _not_ in the trusted set**.
- If every hop is trusted, the leftmost entry is the client.
- If the immediate peer is untrusted, the forwarded headers are ignored entirely.
- The same model gates forwarded **proto/host**: only the value contributed by the trusted proxy is honored, so a spoofed prefix cannot poison `request.url`.

## Changes

- Replace `firstForwardedValue` with `forwardedList` / `resolveClientIP` / `trustedHops` / `forwardedHopValue` in `src/_trust-proxy.ts`.
- Apply at all three call sites: universal plugin, Node adapter (`_node/request.ts` + `_node/url.ts`), and AWS adapter (`_aws/utils.ts`, starting from the gateway-verified `sourceIp` as the nearest hop).
- Rewrite the tests that enshrined the old leftmost behavior and add hop-aware cases (spoofed-prefix, all-trusted, untrusted-peer, proto/host poisoning).
- Rewrite the `trustProxy` docs to state the hop model explicitly (Docs-T1).

## Verification

- `pnpm vitest run --exclude '**/{deno,bun}*.test.ts' test/` — 860 passed, 32 skipped
- `pnpm lint` and `pnpm typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
