### PR TITLE
fix: `file://` loader entry and node-level TLS detection in mtls

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,5 +1,5 @@
 import type { NodeHttpHandler, Server, ServerHandler, ServerRequest } from "srvx";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import * as nodeHTTP from "node:http";
 import { resolve } from "node:path";
 import { EventEmitter } from "node:events";
@@ -104,9 +104,17 @@ export async function loadServerEntry(opts: LoadOptions): Promise<LoadedServerEn
   // Guess entry if not provided
   let entry: string | undefined = opts.entry;
   if (entry) {
-    entry = resolve(opts.dir || ".", entry);
-    if (!existsSync(entry)) {
-      return { notFound: true };
+    // `file://` URLs are already absolute — resolving them as plain paths would
+    // mangle them into `$cwd/file:/...`. Only resolve plain filesystem paths.
+    if (entry.startsWith("file://")) {
+      if (!existsSync(fileURLToPath(entry))) {
+        return { notFound: true };
+      }
+    } else {
+      entry = resolve(opts.dir || ".", entry);
+      if (!existsSync(entry)) {
+        return { notFound: true };
+      }
     }
   } else {
     for (const defEntry of defaultEntries) {

--- a/src/mtls.ts
+++ b/src/mtls.ts
@@ -141,12 +141,13 @@ export function mtls(options: MTLSOptions = {}): ServerPlugin {
         "[srvx] mtls() is not available on Bun: Bun does not expose the peer certificate to node:http(s) request handlers. See https://github.com/oven-sh/bun/issues/16254",
       );
     }
-    // Mutual TLS is meaningless without TLS.
-    if (
-      server.options.protocol === "http" ||
-      !server.options.tls?.cert ||
-      !server.options.tls?.key
-    ) {
+    // Mutual TLS is meaningless without TLS. The node adapter accepts cert/key
+    // either via `tls.cert/key` or directly through node server options
+    // (`node.cert/key`), so mirror that when deciding HTTP vs HTTPS.
+    const nodeOptions = server.options.node as { cert?: unknown; key?: unknown } | undefined;
+    const cert = server.options.tls?.cert ?? nodeOptions?.cert;
+    const key = server.options.tls?.key ?? nodeOptions?.key;
+    if (server.options.protocol === "http" || !cert || !key) {
       throw new Error(
         "[srvx] mtls() requires an HTTPS server: set `tls.cert` and `tls.key`. Mutual TLS cannot run over plain HTTP.",
       );

--- a/test/loader.test.ts
+++ b/test/loader.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
 import { loadServerEntry } from "../src/loader.ts";
 
 const fixturesDir = resolve(import.meta.dirname, "fixtures");
@@ -71,6 +72,18 @@ describe("loadServerEntry", () => {
 
       const response = await result.fetch!(new Request("http://test/"));
       expect(await response.text()).toBe("explicit-url");
+    });
+
+    it("loads from an explicit file:// URL entry", async () => {
+      const entry = pathToFileURL(resolve(fixturesDir, "fetch-export/server.ts")).href;
+      const result = await loadServerEntry({ entry });
+
+      expect(result.notFound).toBeUndefined();
+      expect(result.fetch).toBeDefined();
+      expect(result.url).toBe(entry);
+
+      const response = await result.fetch!(new Request("http://test/"));
+      expect(await response.text()).toBe("fetch-export");
     });
 
     it("returns notFound when explicit url does not exist", async () => {

--- a/test/tls-peer-cert.test.ts
+++ b/test/tls-peer-cert.test.ts
@@ -105,6 +105,21 @@ test("mtls() throws when TLS is not configured", () => {
   ).toThrow(expected);
 });
 
+test("mtls() accepts TLS configured via node server options", () => {
+  // The node adapter also reads cert/key straight from `options.node`, so the
+  // plugin must recognize that path as a valid HTTPS server (not throw).
+  expect(() =>
+    nodeServe(
+      fixture({
+        manual: true,
+        port: 0,
+        node: { cert: tls.cert, key: tls.key },
+        plugins: [mtls({ ca: tls.ca })],
+      }),
+    ),
+  ).not.toThrow();
+});
+
 test("mtls() throws on the native Deno adapter and points to srvx/node", () => {
   // The native `Deno.serve` cannot expose client certificates, so the plugin must
   // fail loudly instead of silently leaving `request.tls` empty.


### PR DESCRIPTION
Two small Node-scope fixes:

- **F35** (`src/loader.ts`): a `file://` URL entry was passed through `resolve()` as a plain path, mangling it into `$cwd/file:/...` and returning `notFound`. Now the `file://` scheme is checked first and only plain filesystem paths are `resolve()`d.
- **F37** (`src/mtls.ts`): the plugin only accepted TLS via `tls.cert`/`tls.key` and threw a false "requires an HTTPS server" error when cert/key were supplied through node server options. Detection now mirrors the node adapter and accepts cert/key from either path.

Tests extended for both cases; `build`, `vitest`, `lint`, and `typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)