### PR TITLE
fix(node/web): correct body handling in toFetchHandler compat layer

### DIFF
--- a/src/adapters/_node/web/incoming.ts
+++ b/src/adapters/_node/web/incoming.ts
@@ -4,8 +4,12 @@ import { WebRequestSocket } from "./socket.ts";
 import { FastURL } from "../../../_url.ts";
 
 export class WebIncomingMessage extends IncomingMessage {
+  #socket: WebRequestSocket;
+
   constructor(req: ServerRequest, socket: WebRequestSocket) {
     super(socket);
+
+    this.#socket = socket;
 
     this.method = req.method;
     const url = (req._url ??= new FastURL(req.url));
@@ -24,12 +28,40 @@ export class WebIncomingMessage extends IncomingMessage {
     }
 
     const onData = (chunk: any) => {
-      this.push(chunk);
+      // Honor backpressure: if the readable buffer is full, pause the source
+      // socket so the entire upload isn't buffered in memory. `_read()` resumes
+      // it once the consumer drains.
+      if (!this.push(chunk)) {
+        socket.pause();
+      }
     };
     socket.on("data", onData);
     socket.once("end", () => {
-      this.emit("end");
+      // Signal EOF via `push(null)` rather than a manual `emit("end")`. Emitting
+      // "end" directly races consumers that attach body listeners after an
+      // `await` (e.g. async middleware in front of `express.json()`) causing a
+      // permanent hang. Mark the message complete first (as Node's HTTP parser
+      // does) so `req.complete` is true, then push EOF so the Readable machinery
+      // emits "end" at the right time.
+      this.complete = true;
+      this.push(null);
       this.off("data", onData);
     });
+  }
+
+  override _read(_size: number): void {
+    // This message is fed manually from the socket "data" listener above rather
+    // than by Node's HTTP parser. Resume the (possibly backpressure-paused)
+    // source when the consumer asks for more data.
+    this.#socket.resume();
+  }
+
+  override _destroy(_err: Error | null, cb: (error?: Error | null) => void): void {
+    // The bridging socket has its own lifecycle (managed by WebServerResponse
+    // and WebRequestSocket). When this readable ends, Node's default
+    // `autoDestroy` would otherwise invoke `IncomingMessage._destroy`, which
+    // tears the socket down and can abort the response before it finishes
+    // flushing. Keep teardown a no-op here so the socket survives.
+    cb();
   }
 }

--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -16,6 +16,9 @@ function getNeedDrainSymbol(res: ServerResponse): symbol | null {
   return needDrainSymbol;
 }
 
+// Statuses that must not carry a response body per the Fetch/HTTP spec.
+const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
+
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
   #socketError?: Error;
@@ -116,7 +119,12 @@ export class WebServerResponse extends ServerResponse {
       headers.push([key, value]);
     }
 
-    return new Response(this.#socket._webResBody, {
+    // Null-body statuses (101, 204, 205, 304) cannot have a body; passing a
+    // stream to `new Response()` for these throws, which would otherwise be
+    // caught and surfaced as a 500 (e.g. Express `res.sendStatus(204)` or a
+    // conditional-GET 304 through `toFetchHandler`).
+    const nullBody = NULL_BODY_STATUSES.has(this.statusCode);
+    return new Response(nullBody ? null : this.#socket._webResBody, {
       status: this.statusCode,
       statusText: this.statusMessage,
       headers: headers,

--- a/src/adapters/_node/web/socket.ts
+++ b/src/adapters/_node/web/socket.ts
@@ -169,7 +169,7 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
       this.#_writeBody(typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk);
     } else if (chunk?.length > 0) {
       this.#headersWritten = true;
-      const headerEnd = chunk.lastIndexOf("\r\n\r\n");
+      const headerEnd = chunk.indexOf("\r\n\r\n");
       if (headerEnd === -1) {
         throw new Error("Invalid HTTP headers chunk!");
       }

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -239,6 +239,129 @@ describe("adapters", () => {
 
     expect(settled).not.toBe("hung");
   });
+
+  // F13: head/body split must use the FIRST CRLFCRLF, not the last, otherwise
+  // response bodies that themselves contain "\r\n\r\n" (multipart, proxied HTTP,
+  // binary) get silently truncated.
+  test("response body containing CRLFCRLF arrives intact", async () => {
+    const payload = "before\r\n\r\nafter\r\n\r\nend";
+    const bodyHandler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end(payload);
+    };
+    const webHandler = toFetchHandler(bodyHandler);
+    const res = await webHandler(new Request("http://localhost/"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe(payload);
+  });
+
+  // F14: null-body statuses (204/304/...) must not throw when constructing the
+  // web Response (which would surface as a 500).
+  test("null-body status 204 does not become a 500", async () => {
+    const handler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(204);
+      res.end();
+    };
+    const webHandler = toFetchHandler(handler);
+    const res = await webHandler(new Request("http://localhost/"));
+    expect(res.status).toBe(204);
+    expect(await res.text()).toBe("");
+  });
+
+  test("conditional-GET 304 does not become a 500", async () => {
+    const handler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(304);
+      res.end();
+    };
+    const webHandler = toFetchHandler(handler);
+    const res = await webHandler(new Request("http://localhost/"));
+    expect(res.status).toBe(304);
+    expect(await res.text()).toBe("");
+  });
+
+  // F15: body listeners attached after an `await` (e.g. async middleware in
+  // front of express.json()) must still receive data + "end", and req.complete
+  // must become true.
+  test("late-attached body listeners still receive data and end", async () => {
+    const handler: NodeHttp1Handler = (req, res) => {
+      return (async () => {
+        // Defer attaching listeners past a microtask/tick.
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        const chunks: Uint8Array[] = [];
+        const body = await new Promise<string>((resolve) => {
+          req.on("data", (chunk) => chunks.push(chunk));
+          req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+        });
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end(JSON.stringify({ body, complete: req.complete }));
+      })();
+    };
+    const webHandler = toFetchHandler(handler);
+    const settled = await Promise.race([
+      Promise.resolve(
+        webHandler(new Request("http://localhost/", { method: "POST", body: "hello world" })),
+      ).then((r) => r.json()),
+      new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("hung waiting for body")), 3000),
+      ),
+    ]);
+    expect(settled).toMatchObject({ body: "hello world", complete: true });
+  });
+
+  // F16: a large upload must apply backpressure rather than buffering the whole
+  // body in memory. A handler that defers reading (e.g. slow async middleware)
+  // must NOT cause the source to flood the internal buffer — with the source
+  // paused on `push() === false`, only about one highWaterMark of data can
+  // accumulate before reading resumes. Without the fix the full upload buffers.
+  test("large upload applies backpressure and arrives completely", async () => {
+    const chunkSize = 64 * 1024;
+    const chunk = "x".repeat(chunkSize);
+    const totalChunks = 32;
+    const expectedLength = chunkSize * totalChunks;
+
+    let bufferedBeforeReading = 0;
+    const handler: NodeHttp1Handler = (req, res) => {
+      return (async () => {
+        // Defer reading so an unthrottled source would have time to flood the
+        // internal buffer with the entire upload.
+        await new Promise((r) => setTimeout(r, 100));
+        bufferedBeforeReading = (req as any).readableLength ?? 0;
+        let received = 0;
+        for await (const c of req as any) {
+          received += (c as Uint8Array).length;
+        }
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end(String(received));
+      })();
+    };
+    const webHandler = toFetchHandler(handler);
+
+    // Fast producer: enqueue everything up front without waiting.
+    const source = new ReadableStream<Uint8Array>({
+      start(controller) {
+        const data = new TextEncoder().encode(chunk);
+        for (let i = 0; i < totalChunks; i++) {
+          controller.enqueue(data);
+        }
+        controller.close();
+      },
+    });
+
+    const res = await webHandler(
+      new Request("http://localhost/", {
+        method: "POST",
+        body: source,
+        // @ts-expect-error duplex is required for a stream body
+        duplex: "half",
+      }),
+    );
+    expect(res.status).toBe(200);
+    // Full body arrives intact.
+    expect(Number(await res.text())).toBe(expectedLength);
+    // The source was throttled: far less than the full upload buffered while the
+    // handler was not reading. (Without the fix this equals expectedLength.)
+    expect(bufferedBeforeReading).toBeLessThan(expectedLength / 2);
+  });
 });
 
 describe("request signal", () => {


### PR DESCRIPTION
Fixes four bugs in the node-compat web layer (`src/adapters/_node/web/*`) used by `toFetchHandler` / `fetchNodeHandler`:

- **F13** (`socket.ts`): split HTTP head/body at the **first** `\r\n\r\n` (`indexOf`, not `lastIndexOf`) so response bodies that themselves contain `\r\n\r\n` (multipart, binary, proxied HTTP) are no longer silently truncated.
- **F14** (`response.ts`): construct a null-body `Response` for null-body statuses (101/204/205/304) instead of passing a stream, which threw and surfaced as a 500 (e.g. Express `res.sendStatus(204)` or a conditional-GET 304).
- **F15** (`incoming.ts`): signal request EOF via `push(null)` (and set `req.complete`) instead of a manual `emit("end")` that races handlers attaching body listeners after an `await` (async middleware in front of `express.json()`), which hung and left `req.complete` false forever.
- **F16** (`incoming.ts`): pause the source socket on `push() === false` and resume it in `_read()` so large uploads apply backpressure instead of buffering the whole body in memory.

Tests extended in `test/node-adapters.test.ts` cover each fix (CRLFCRLF body intact, 204/304 not 500, late-attached listeners still get body + `end`, bounded buffering under a deferred reader).

🤖 Generated with [Claude Code](https://claude.com/claude-code)