### PR TITLE
fix(aws): stabilization batch for AWS Lambda + generic adapters

### DIFF
--- a/docs/1.guide/9.aws-lambda.md
+++ b/docs/1.guide/9.aws-lambda.md
@@ -74,35 +74,39 @@ The function handles all conversions internally:
 
 AWS Lambda supports [response streaming](https://docs.aws.amazon.com/lambda/latest/dg/configuration-response-streaming.html) which allows you to send response data progressively as it becomes available. This improves Time To First Byte (TTFB) and enables streaming large responses (up to 20MB vs 6MB buffered limit).
 
-To use response streaming, wrap your handler with `awslambda.streamifyResponse()` and use `handleLambdaEventWithStream`:
+To use response streaming, build a streaming handler with `toLambdaStreamHandler` and wrap it with `awslambda.streamifyResponse()`. Just like `toLambdaHandler`, it accepts a full `ServerOptions` object, so `middleware`, `plugins`, `error`, and `trustProxy` all apply to the streaming path:
 
 ```ts
-import { handleLambdaEventWithStream, type AWSLambdaStreamingHandler } from "srvx/aws-lambda";
-
-const fetchHandler = async (request: Request) => {
-  // Create a streaming response
-  const stream = new ReadableStream({
-    async start(controller) {
-      controller.enqueue(new TextEncoder().encode("Hello, "));
-      await new Promise((r) => setTimeout(r, 100));
-      controller.enqueue(new TextEncoder().encode("streaming "));
-      await new Promise((r) => setTimeout(r, 100));
-      controller.enqueue(new TextEncoder().encode("world!"));
-      controller.close();
-    },
-  });
-
-  return new Response(stream, {
-    headers: { "Content-Type": "text/plain" },
-  });
-};
+import { toLambdaStreamHandler, type AWSLambdaStreamingHandler } from "srvx/aws-lambda";
+import { serveStatic } from "srvx/static";
 
 // Export a streaming handler
 export const handler: AWSLambdaStreamingHandler = awslambda.streamifyResponse(
-  (event, responseStream, context) =>
-    handleLambdaEventWithStream(fetchHandler, event, responseStream, context),
+  toLambdaStreamHandler({
+    middleware: [serveStatic({ dir: "public" })],
+    fetch(req: Request) {
+      // Create a streaming response
+      const stream = new ReadableStream({
+        async start(controller) {
+          controller.enqueue(new TextEncoder().encode("Hello, "));
+          await new Promise((r) => setTimeout(r, 100));
+          controller.enqueue(new TextEncoder().encode("streaming "));
+          await new Promise((r) => setTimeout(r, 100));
+          controller.enqueue(new TextEncoder().encode("world!"));
+          controller.close();
+        },
+      });
+
+      return new Response(stream, {
+        headers: { "Content-Type": "text/plain" },
+      });
+    },
+  }),
 );
 ```
+
+> [!TIP]
+> The lower-level `handleLambdaEventWithStream(fetchHandler, event, responseStream, context)` is still available if you want to wire a bare fetch handler yourself, but it bypasses `middleware`/`plugins`/`error`/`trustProxy`. Prefer `toLambdaStreamHandler` unless you have a specific reason not to.
 
 > [!NOTE]
 > Response streaming requires a Lambda Function URL with `--invoke-mode RESPONSE_STREAM`, or an API Gateway **REST API (v1)** integration configured with `responseTransferMode: STREAM` (both use the `InvokeWithResponseStream` API under the hood, and srvx's request/response handling is identical for both). HTTP API (v2) and Application Load Balancer do not support progressive streaming yet.

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -34,15 +34,27 @@ export function awsRequest(
   context: AWSContext,
   trustProxy?: TrustProxyOption,
 ): ServerRequest {
+  // Real API Gateway always sends a `headers` object; a null/non-object here
+  // means a malformed/hand-built event and would otherwise surface as an opaque
+  // `TypeError` deep inside header parsing.
+  if (!event.headers || typeof event.headers !== "object") {
+    throw new TypeError("[srvx] Invalid AWS Lambda event: `headers` must be an object.");
+  }
+
   // Resolve the immediate-peer address and trust decision once and pass them
   // down; both the URL and the client IP derivation need them.
   const sourceIp = awsEventIP(event);
   const trusted = isTrustedProxy(trustProxy, sourceIp);
 
+  // Per the fetch spec a GET/HEAD request cannot carry a body; passing one to
+  // `new Request` throws. Raw bytes stay reachable via `runtime.awsLambda.event`.
+  const method = awsEventMethod(event);
+  const hasBody = method !== "GET" && method !== "HEAD";
+
   const req = new Request(awsEventURL(event, trusted), {
-    method: awsEventMethod(event),
+    method,
     headers: awsEventHeaders(event),
-    body: awsEventBody(event),
+    body: hasBody ? awsEventBody(event) : undefined,
   }) as ServerRequest;
 
   req.runtime = {
@@ -129,11 +141,31 @@ function awsEventQuery(event: APIGatewayProxyEvent | APIGatewayProxyEventV2) {
 
 function awsEventHeaders(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): Headers {
   const headers = new Headers();
+
+  // v1 (REST API) events carry repeated headers in `multiValueHeaders`; the
+  // single-valued `headers` map only keeps the last value for each key. Prefer
+  // the multi-value form and skip those keys in the single map to avoid
+  // duplicating a header that appears in both.
+  const multiValueHeaders = (event as APIGatewayProxyEvent).multiValueHeaders;
+  const covered = new Set<string>();
+  if (multiValueHeaders) {
+    for (const [key, values] of Object.entries(multiValueHeaders)) {
+      if (!values) continue;
+      covered.add(key.toLowerCase());
+      for (const value of values) {
+        if (value != null) {
+          headers.append(key, value);
+        }
+      }
+    }
+  }
+
   for (const [key, value] of Object.entries(event.headers)) {
-    if (value) {
+    if (value && !covered.has(key.toLowerCase())) {
       headers.set(key, value);
     }
   }
+
   if ("cookies" in event && event.cookies) {
     for (const cookie of event.cookies) {
       headers.append("cookie", cookie);
@@ -160,14 +192,18 @@ export function awsResponseHeaders(
   response: Response,
   event?: APIGatewayProxyEvent | APIGatewayProxyEventV2,
 ): AWSResponseHeaders {
+  const cookies = response.headers.getSetCookie();
+
   const headers = Object.create(null);
   for (const [key, value] of response.headers) {
+    // `set-cookie` is delivered via `cookies` (v2) / `multiValueHeaders` (v1).
+    // Emitting it here too makes API Gateway merge both and send the last
+    // cookie a second time.
+    if (key === "set-cookie") continue;
     if (value) {
-      headers[key] = Array.isArray(value) ? value.join(",") : String(value);
+      headers[key] = value;
     }
   }
-
-  const cookies = response.headers.getSetCookie();
 
   if (cookies.length === 0) {
     return { headers };
@@ -193,7 +229,11 @@ export async function awsResponseBody(
   }
   const buffer = await toBuffer(response.body as any);
   const contentType = response.headers.get("content-type") || "";
-  return isTextType(contentType)
+  // A compressed body (e.g. `content-encoding: gzip`) is binary regardless of
+  // its content-type; running it through `toString("utf8")` mangles the bytes.
+  const contentEncoding = (response.headers.get("content-encoding") || "").trim().toLowerCase();
+  const isEncoded = contentEncoding !== "" && contentEncoding !== "identity";
+  return !isEncoded && isTextType(contentType)
     ? { body: buffer.toString("utf8") }
     : { body: buffer.toString("base64"), isBase64Encoded: true };
 }
@@ -299,12 +339,18 @@ export async function requestToAwsEvent(request: Request): Promise<AwsLambdaEven
   const url = new URL(request.url);
 
   const headers: Record<string, string> = {};
+  const multiValueHeaders: Record<string, string[]> = {};
   const cookies: string[] = [];
   for (const [key, value] of request.headers) {
     if (key.toLowerCase() === "cookie") {
+      // Real v2 API Gateway events strip `cookie` from `headers` and carry it in
+      // `cookies`; keeping it in the header maps too would double it once
+      // `awsEventHeaders` re-appends `event.cookies` on the round trip.
       cookies.push(value);
+      continue;
     }
     headers[key] = value;
+    (multiValueHeaders[key] ??= []).push(value);
   }
 
   let body: string | undefined;
@@ -332,7 +378,7 @@ export async function requestToAwsEvent(request: Request): Promise<AwsLambdaEven
     multiValueQueryStringParameters: parseMultiValueQuery(url.searchParams),
     pathParameters: undefined,
     stageVariables: undefined,
-    multiValueHeaders: Object.fromEntries([...request.headers].map(([k, v]) => [k, [v]])),
+    multiValueHeaders,
 
     // v2 (HTTP API) fields
     version: "2.0",
@@ -457,7 +503,13 @@ export function awsResultToResponse(result: AwsLambdaResult): Response {
 
   const statusCode = typeof result.statusCode === "number" ? result.statusCode : 200;
 
-  return new Response(body, {
+  // `new Response(body, ...)` throws for null-body statuses when `body` is a
+  // (even empty) string, which broke the documented local-testing round trip
+  // for any 204/304 handler.
+  const nullBody =
+    statusCode === 101 || statusCode === 204 || statusCode === 205 || statusCode === 304;
+
+  return new Response(nullBody ? null : body, {
     status: statusCode,
     headers,
   });

--- a/src/adapters/aws-lambda.ts
+++ b/src/adapters/aws-lambda.ts
@@ -3,6 +3,7 @@ import type { FetchHandler, Server, ServerOptions } from "../types.ts";
 import type { TrustProxyOption } from "../_trust-proxy.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
+import { createWaitUntil } from "../_utils.ts";
 import {
   awsRequest,
   awsResponseBody,
@@ -36,19 +37,39 @@ export function toLambdaHandler(options: ServerOptions): AWSLambdaHandler {
   return (event, context) => server.fetch(event, context);
 }
 
+/**
+ * Streaming counterpart to {@link toLambdaHandler}.
+ *
+ * The returned handler goes through the same server contract as the buffered
+ * one (`plugins`, `middleware`, `error`, `trustProxy` all apply) and is meant to
+ * be wrapped with `awslambda.streamifyResponse(...)`.
+ */
+export function toLambdaStreamHandler(options: ServerOptions): AWSLambdaStreamingHandler {
+  const server = new AWSLambdaServer(options);
+  return (event, responseStream, context) => server.fetchStream(event, responseStream, context);
+}
+
 export async function handleLambdaEvent(
   fetchHandler: FetchHandler,
   event: AwsLambdaEvent,
   context: AWS.Context,
   trustProxy?: TrustProxyOption,
 ): Promise<AWS.APIGatewayProxyResult | AWS.APIGatewayProxyResultV2> {
+  const wait = createWaitUntil();
   const request = awsRequest(event, context, trustProxy);
-  const response = await fetchHandler(request);
-  return {
-    statusCode: response.status,
-    ...awsResponseHeaders(response, event),
-    ...(await awsResponseBody(response)),
-  };
+  Object.defineProperty(request, "waitUntil", { value: wait.waitUntil, configurable: true });
+  try {
+    const response = await fetchHandler(request);
+    return {
+      statusCode: response.status,
+      ...awsResponseHeaders(response, event),
+      ...(await awsResponseBody(response)),
+    };
+  } finally {
+    // Await background tasks registered via `request.waitUntil` before the
+    // invocation returns; the process would otherwise be frozen mid-flight.
+    await wait.wait();
+  }
 }
 
 export async function handleLambdaEventWithStream(
@@ -58,9 +79,15 @@ export async function handleLambdaEventWithStream(
   context: AWS.Context,
   trustProxy?: TrustProxyOption,
 ): Promise<void> {
+  const wait = createWaitUntil();
   const request = awsRequest(event, context, trustProxy);
-  const response = await fetchHandler(request);
-  await awsStreamResponse(response, responseStream, event);
+  Object.defineProperty(request, "waitUntil", { value: wait.waitUntil, configurable: true });
+  try {
+    const response = await fetchHandler(request);
+    await awsStreamResponse(response, responseStream, event);
+  } finally {
+    await wait.wait();
+  }
 }
 
 export async function invokeLambdaHandler(
@@ -76,6 +103,7 @@ class AWSLambdaServer implements Server<AWSLambdaHandler> {
   readonly runtime = "aws-lambda";
   readonly options: Server["options"];
   readonly fetch: AWSLambdaHandler;
+  readonly fetchStream: AWSLambdaStreamingHandler;
 
   constructor(options: ServerOptions) {
     this.options = { ...options, middleware: [...(options.middleware || [])] };
@@ -87,6 +115,19 @@ class AWSLambdaServer implements Server<AWSLambdaHandler> {
 
     this.fetch = (event: AwsLambdaEvent, context: AWS.Context) =>
       handleLambdaEvent(fetchHandler, event, context, this.options.trustProxy);
+
+    this.fetchStream = (
+      event: AwsLambdaEvent,
+      responseStream: AWSLambdaResponseStream,
+      context: AWS.Context,
+    ) =>
+      handleLambdaEventWithStream(
+        fetchHandler,
+        event,
+        responseStream,
+        context,
+        this.options.trustProxy,
+      );
   }
 
   serve() {}

--- a/src/adapters/generic.ts
+++ b/src/adapters/generic.ts
@@ -32,6 +32,17 @@ class GenericServer implements Server {
     this.fetch = (request: Request) => {
       Object.defineProperties(request, {
         waitUntil: { value: this.#wait.waitUntil },
+        runtime: { enumerable: true, value: { name: "generic" } },
+        ip: {
+          enumerable: true,
+          // The generic adapter has no native transport to read a peer address
+          // from, so `ip` is derived from `x-forwarded-for` when present.
+          // Configurable so a trustProxy setup can still override it.
+          configurable: true,
+          get() {
+            return request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() || undefined;
+          },
+        },
       });
       return Promise.resolve(fetchHandler(request));
     };

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -3,6 +3,7 @@ import {
   awsRequest,
   awsResponseBody,
   awsResponseHeaders,
+  awsResultToResponse,
   awsStreamResponse,
   createMockContext,
   type AWSLambdaResponseStream,
@@ -11,6 +12,8 @@ import {
   handleLambdaEvent,
   handleLambdaEventWithStream,
   invokeLambdaHandler,
+  toLambdaHandler,
+  toLambdaStreamHandler,
   type AWSLambdaHandler,
 } from "../src/adapters/aws-lambda.ts";
 import type {
@@ -18,23 +21,6 @@ import type {
   APIGatewayProxyEventV2,
   APIGatewayProxyResult,
 } from "aws-lambda";
-
-// Mock Headers.getAll method for testing
-class MockHeaders extends Headers {
-  private cookies: string[] = [];
-
-  constructor(init?: HeadersInit) {
-    super(init);
-  }
-
-  override getSetCookie(): string[] {
-    return this.cookies;
-  }
-
-  setCookie(cookie: string) {
-    this.cookies.push(cookie);
-  }
-}
 
 describe("[AWS Lambda] Request Utils", () => {
   describe("awsRequest", () => {
@@ -432,7 +418,7 @@ describe("[AWS Lambda] Request Utils", () => {
 
   describe("awsResponseHeaders", () => {
     test("should convert Response headers to AWS format", () => {
-      const headers = new MockHeaders({
+      const headers = new Headers({
         "Content-Type": "application/json",
         "Cache-Control": "no-cache",
         "X-Custom-Header": "custom-value",
@@ -455,30 +441,18 @@ describe("[AWS Lambda] Request Utils", () => {
     });
 
     test("should handle cookies for API Gateway compatibility", () => {
-      const headers = new MockHeaders({
-        "Content-Type": "application/json",
-      });
-      headers.setCookie("sessionId=abc123; HttpOnly; Secure");
-      headers.setCookie("theme=dark; Path=/");
+      // Use a real `Headers`: `set-cookie` therefore participates in header
+      // iteration, which is exactly the case the old `MockHeaders` masked.
+      const headers = new Headers({ "Content-Type": "application/json" });
+      headers.append("set-cookie", "sessionId=abc123; HttpOnly; Secure");
+      headers.append("set-cookie", "theme=dark; Path=/");
 
       const response = new Response('{"message": "success"}', {
         status: 200,
         headers,
       });
 
-      // Replace the response.headers with our MockHeaders instance
-      Object.defineProperty(response, "headers", {
-        value: headers,
-        writable: true,
-        configurable: true,
-      });
-
-      // Verify the mock is working
-      expect(headers.getSetCookie()).toEqual([
-        "sessionId=abc123; HttpOnly; Secure",
-        "theme=dark; Path=/",
-      ]);
-
+      // v1 (default: no event) -> cookies delivered via multiValueHeaders.
       const awsResponse = awsResponseHeaders(response);
 
       expect(awsResponse.cookies).toEqual([
@@ -488,10 +462,37 @@ describe("[AWS Lambda] Request Utils", () => {
       expect(awsResponse.multiValueHeaders).toEqual({
         "set-cookie": ["sessionId=abc123; HttpOnly; Secure", "theme=dark; Path=/"],
       });
+      // Regression (F19): set-cookie must NOT also appear in `headers`, or API
+      // Gateway would merge both and send the last cookie twice.
+      expect(awsResponse.headers["set-cookie"]).toBeUndefined();
+    });
+
+    test("should not duplicate set-cookie in headers for v2 events (F19)", () => {
+      const headers = new Headers({ "Content-Type": "application/json" });
+      headers.append("set-cookie", "a=1");
+      headers.append("set-cookie", "b=2");
+
+      const response = new Response("ok", { status: 200, headers });
+
+      const v2Event: APIGatewayProxyEventV2 = {
+        version: "2.0",
+        routeKey: "GET /",
+        rawPath: "/",
+        rawQueryString: "",
+        headers: { host: "example.com" },
+        isBase64Encoded: false,
+        requestContext: { http: { method: "GET", path: "/" } } as any,
+      };
+
+      const awsResponse = awsResponseHeaders(response, v2Event);
+
+      expect(awsResponse.cookies).toEqual(["a=1", "b=2"]);
+      expect(awsResponse.multiValueHeaders).toBeUndefined();
+      expect(awsResponse.headers["set-cookie"]).toBeUndefined();
     });
 
     test("should handle array headers by joining with commas", () => {
-      const headers = new MockHeaders();
+      const headers = new Headers();
       headers.set("Accept", "application/json");
       headers.append("Accept", "text/html");
       headers.append("Accept", "text/plain");
@@ -507,7 +508,7 @@ describe("[AWS Lambda] Request Utils", () => {
     });
 
     test("should handle null/undefined header values", () => {
-      const headers = new MockHeaders({
+      const headers = new Headers({
         "Valid-Header": "valid-value",
         "Null-Header": null as any,
         "Undefined-Header": undefined as any,
@@ -1145,11 +1146,10 @@ describe("[AWS Lambda] Request Utils", () => {
     test("should pass event to awsResponseHeaders for v2 format", async () => {
       const { mockStream, getMetadata } = createMockResponseStream();
 
-      const headers = new MockHeaders({ "Content-Type": "application/json" });
-      headers.setCookie("session=abc");
+      const headers = new Headers({ "Content-Type": "application/json" });
+      headers.append("set-cookie", "session=abc");
 
       const response = new Response("{}", { status: 200, headers });
-      Object.defineProperty(response, "headers", { value: headers });
 
       const v2Event: APIGatewayProxyEventV2 = {
         version: "2.0",
@@ -1165,6 +1165,9 @@ describe("[AWS Lambda] Request Utils", () => {
 
       const metadata = getMetadata() as any;
       expect(metadata.cookies).toEqual(["session=abc"]);
+      // Regression (F19): the streaming prelude must not also carry set-cookie
+      // in `headers`.
+      expect(metadata.headers["set-cookie"]).toBeUndefined();
     });
   });
 
@@ -1454,6 +1457,187 @@ describe("[AWS Lambda] Request Utils", () => {
         expect(
           metadata.headers["transfer-encoding"] || metadata.headers["content-length"],
         ).toBeTruthy();
+      });
+    });
+  });
+
+  describe("stabilization regressions", () => {
+    function v1Event(overrides: Partial<APIGatewayProxyEvent> = {}): APIGatewayProxyEvent {
+      return {
+        httpMethod: "GET",
+        path: "/",
+        headers: { host: "api.example.com" },
+        body: null,
+        isBase64Encoded: false,
+        multiValueHeaders: {},
+        multiValueQueryStringParameters: {},
+        pathParameters: null,
+        stageVariables: null,
+        requestContext: {} as any,
+        resource: "",
+        queryStringParameters: null,
+        ...overrides,
+      };
+    }
+
+    test("F20: merges v1 multiValueHeaders without duplicating single headers", () => {
+      const request = awsRequest(
+        v1Event({
+          headers: { host: "api.example.com", "x-test": "b" },
+          multiValueHeaders: { "X-Test": ["a", "b"], host: ["api.example.com"] },
+        }),
+        createMockContext(),
+      );
+
+      // Both values are present (repeated header preserved) and the single-map
+      // entry is not appended a second time.
+      expect(request.headers.get("x-test")).toBe("a, b");
+      expect(request.headers.get("host")).toBe("api.example.com");
+    });
+
+    test("F21: compressed body is base64-encoded even for a text content-type", async () => {
+      const gzipped = Buffer.from([0x1f, 0x8b, 0x08, 0x00]);
+      const response = new Response(gzipped, {
+        status: 200,
+        headers: { "content-type": "text/html", "content-encoding": "gzip" },
+      });
+
+      const awsBody = await awsResponseBody(response);
+
+      expect(awsBody.isBase64Encoded).toBe(true);
+      expect(awsBody.body).toBe(gzipped.toString("base64"));
+    });
+
+    test("F21: identity content-encoding still uses utf8 for text", async () => {
+      const response = new Response("hello", {
+        status: 200,
+        headers: { "content-type": "text/plain", "content-encoding": "identity" },
+      });
+
+      const awsBody = await awsResponseBody(response);
+
+      expect(awsBody.isBase64Encoded).toBeUndefined();
+      expect(awsBody.body).toBe("hello");
+    });
+
+    test("F22: 204 handler round-trips through invokeLambdaHandler without throwing", async () => {
+      const handler = toLambdaHandler({
+        fetch: () => new Response(null, { status: 204 }),
+      });
+
+      const response = await invokeLambdaHandler(handler, new Request("https://x.example/"));
+
+      expect(response.status).toBe(204);
+      expect(response.body).toBeNull();
+    });
+
+    test("F22: awsResultToResponse passes null body for 304", () => {
+      const response = awsResultToResponse({ statusCode: 304, body: "" } as any);
+      expect(response.status).toBe(304);
+      expect(response.body).toBeNull();
+    });
+
+    test("F8: cookie round-trips once (no doubling)", async () => {
+      let seenCookie: string | null = null;
+      const handler = toLambdaHandler({
+        fetch: (req) => {
+          seenCookie = req.headers.get("cookie");
+          return new Response("ok");
+        },
+      });
+
+      await invokeLambdaHandler(
+        handler,
+        new Request("https://x.example/", { headers: { cookie: "a=1" } }),
+      );
+
+      expect(seenCookie).toBe("a=1");
+    });
+
+    test("F24: request.waitUntil is awaited before the invocation returns", async () => {
+      let done = false;
+      const fetchHandler = async (req: Request & { waitUntil?: (p: Promise<unknown>) => void }) => {
+        req.waitUntil?.(
+          new Promise<void>((resolve) =>
+            setTimeout(() => {
+              done = true;
+              resolve();
+            }, 10),
+          ),
+        );
+        return new Response("ok");
+      };
+
+      await handleLambdaEvent(fetchHandler as any, v1Event(), createMockContext());
+
+      expect(done).toBe(true);
+    });
+
+    test("F15: null headers throw a clear error", () => {
+      expect(() => awsRequest(v1Event({ headers: null as any }), createMockContext())).toThrow(
+        /headers/,
+      );
+    });
+
+    test("F15: GET with a body is treated as null-body instead of throwing", () => {
+      const request = awsRequest(
+        v1Event({ httpMethod: "GET", body: "should-be-dropped", isBase64Encoded: false }),
+        createMockContext(),
+      );
+      expect(request.body).toBeNull();
+    });
+
+    describe("F23: streaming path applies middleware/error", () => {
+      function createMockResponseStream() {
+        let metadata: unknown;
+        const mockWriter = {
+          write: vi.fn(() => true),
+          end: vi.fn(),
+          once: vi.fn(),
+        };
+        (globalThis as any).awslambda = {
+          HttpResponseStream: {
+            from: vi.fn((_stream: unknown, meta: unknown) => {
+              metadata = meta;
+              return mockWriter;
+            }),
+          },
+        };
+        return { mockStream: {} as AWSLambdaResponseStream, getMetadata: () => metadata };
+      }
+
+      afterEach(() => {
+        delete (globalThis as any).awslambda;
+      });
+
+      test("toLambdaStreamHandler runs middleware", async () => {
+        const { mockStream, getMetadata } = createMockResponseStream();
+
+        const handler = toLambdaStreamHandler({
+          middleware: [() => new Response("from-middleware", { status: 299 })],
+          fetch: () => new Response("from-fetch", { status: 200 }),
+        });
+
+        await handler(v1Event(), mockStream, createMockContext());
+
+        // The middleware short-circuited, proving it was wired into the
+        // streaming path (previously bypassed entirely).
+        expect((getMetadata() as any).statusCode).toBe(299);
+      });
+
+      test("toLambdaStreamHandler applies the error option on a thrown handler", async () => {
+        const { mockStream, getMetadata } = createMockResponseStream();
+
+        const handler = toLambdaStreamHandler({
+          error: () => new Response("handled", { status: 503 }),
+          fetch: () => {
+            throw new Error("boom");
+          },
+        });
+
+        await handler(v1Event(), mockStream, createMockContext());
+
+        expect((getMetadata() as any).statusCode).toBe(503);
       });
     });
   });


### PR DESCRIPTION
Implements the AWS scope (T2/T3) of the v1 stabilization plan. Does not touch F7/trust-proxy (owned by #229).

## Findings fixed

- **F19** — Duplicate `Set-Cookie` delivered to clients. `set-cookie` is no longer emitted via `headers` when it is already carried in `cookies` (v2) / `multiValueHeaders` (v1), on both the buffered and streaming paths, so API Gateway no longer merges both and sends the last cookie twice. Dead `Array.isArray` branch removed. The masking `MockHeaders` test was replaced with real `Headers`.
- **F20** — v1 (REST API) repeated headers were lost because `event.multiValueHeaders` was ignored. `awsEventHeaders` now merges it, avoiding double-counting keys present in both maps.
- **F21** — `text/html` + `content-encoding: gzip` bodies were mangled through `toString("utf8")`. `awsResponseBody` now forces base64 whenever a non-identity `content-encoding` is present.
- **F22** — `awsResultToResponse` passed an empty string body into null-body statuses, throwing for 204/304 handlers in the local-testing flow. It now passes `null` for 101/204/205/304.
- **F23** — Added `toLambdaStreamHandler`, a streaming counterpart to `toLambdaHandler` that goes through the full server contract (plugins/middleware/error/trustProxy). The AWS Lambda docs streaming section now teaches it.
- **F30** — The generic adapter now sets `request.runtime` (name `generic`) and `request.ip`, matching every other adapter.
- **F8 (AWS round-trip half)** — `requestToAwsEvent` now strips the `cookie` header from the synthesized v2 event (matching real API Gateway), so handlers no longer see `cookie: "a=1, a=1"` after `awsEventHeaders` re-appends `event.cookies`.
- **F24** — `request.waitUntil` now works on Lambda: registered promises are awaited before the invocation returns (buffered and streaming paths).
- **F15** — Degenerate events (`headers: null`, GET/HEAD-with-body) now surface a clear error / null-body instead of opaque TypeErrors.

## Tests

- Replaced the `MockHeaders` mock (which stored cookies in a side array that never entered header iteration, masking F19) with real web `Headers`.
- Added regression tests for: v1 multi-value headers, set-cookie dedup on buffered and streaming paths, gzip body base64, 204 round-trip, streaming middleware/error application, waitUntil completion, cookie round-trip without doubling, and the F15 guards.

`pnpm test` (lint + typecheck + vitest w/ coverage): **989 passed, 35 pre-existing skips**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)