### PR TITLE
fix: shutdown and close correctness (F25, F27, F34)

### DIFF
--- a/src/_plugins.ts
+++ b/src/_plugins.ts
@@ -30,14 +30,33 @@ export const gracefulShutdownPlugin: ServerPlugin = (server) => {
 
   let isClosing = false;
   let isClosed = false;
+  let forceCloseTimer: ReturnType<typeof setTimeout> | undefined;
 
   const w = server.options.silent ? () => {} : process.stderr.write.bind(process.stderr);
 
+  // Remove every listener this plugin registered. Called on all shutdown paths
+  // (graceful, forced, timed-out) and on programmatic `close()` so repeated
+  // serve()/close() cycles don't accumulate listeners or pin each Server.
+  const removeListeners = () => {
+    // Cancel the deferred force-close registration so it can't re-add a listener
+    // after cleanup has already run.
+    if (forceCloseTimer) clearTimeout(forceCloseTimer);
+    globalThis.process.removeListener("SIGINT", shutdown);
+    globalThis.process.removeListener("SIGTERM", shutdown);
+    globalThis.process.removeListener("SIGINT", forceClose);
+  };
+
   const forceClose = async () => {
     if (isClosed) return;
-    w(c.red("\x1b[2K\rForcibly closing connections...\n"));
     isClosed = true;
-    await server.close(true);
+    w(c.red("\x1b[2K\rForcibly closing connections...\n"));
+    try {
+      await nativeClose(true);
+    } catch (error) {
+      w(c.red(`\x1b[2K\rError while force closing connections: ${error}\n`));
+    } finally {
+      removeListeners();
+    }
   };
 
   const shutdown = async () => {
@@ -47,34 +66,58 @@ export const gracefulShutdownPlugin: ServerPlugin = (server) => {
 
     // Force close with second Ctrl+C
     // CLIs might trigger multiple SIGINTs, so we delay the listener registration
-    setTimeout(() => {
+    forceCloseTimer = setTimeout(() => {
       globalThis.process.once("SIGINT", forceClose);
     }, 100);
 
     isClosing = true;
-    const closePromise = server.close();
+    // Never let a rejecting `close()` surface as an unhandledRejection (which
+    // would crash the process and skip force-close); capture it and fall through
+    // to the force-close path instead.
+    let closeError: unknown;
+    const closePromise = nativeClose().catch((error) => {
+      closeError = error;
+    });
 
-    // Countdown with updates each second
-    for (let remaining = gracefulTimeout; remaining > 0; remaining--) {
-      w(
-        c.gray(
-          `\rStopping server gracefully (${remaining}s)... Press ${c.bold("Ctrl+C")} again to force close.`,
-        ),
-      );
-      const closed = await Promise.race([
-        closePromise.then(() => true),
-        new Promise<false>((r) => setTimeout(() => r(false), 1000)),
-      ]);
-      if (closed) {
-        w("\x1b[2K\r" + c.green("Server closed successfully.\n"));
-        isClosed = true;
-        return;
+    try {
+      // Countdown with updates each second
+      for (let remaining = gracefulTimeout; remaining > 0; remaining--) {
+        w(
+          c.gray(
+            `\rStopping server gracefully (${remaining}s)... Press ${c.bold("Ctrl+C")} again to force close.`,
+          ),
+        );
+        const closed = await Promise.race([
+          closePromise.then(() => true),
+          new Promise<false>((r) => setTimeout(() => r(false), 1000)),
+        ]);
+        if (closeError) {
+          w("\x1b[2K\r" + c.red(`Graceful shutdown failed: ${closeError}\n`));
+          await forceClose();
+          return;
+        }
+        if (closed) {
+          w("\x1b[2K\r" + c.green("Server closed successfully.\n"));
+          isClosed = true;
+          return;
+        }
       }
-    }
 
-    // Graceful period expired: force close
-    w("\x1b[2K\rGraceful shutdown timed out.\n");
-    await forceClose();
+      // Graceful period expired: force close
+      w("\x1b[2K\rGraceful shutdown timed out.\n");
+      await forceClose();
+    } finally {
+      removeListeners();
+    }
+  };
+
+  // Wrap `close()` so a programmatic close (no signal) also removes the signal
+  // listeners; `nativeClose` is the un-wrapped original used internally to avoid
+  // recursion.
+  const nativeClose = server.close.bind(server);
+  server.close = (closeAll?: boolean) => {
+    removeListeners();
+    return nativeClose(closeAll);
   };
 
   for (const sig of ["SIGINT", "SIGTERM"] as const) {

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -37,7 +37,6 @@ class BunServer implements Server<BunFetchHandler> {
     for (const plugin of options.plugins || []) plugin(this);
 
     trustProxyPlugin(this);
-    gracefulShutdownPlugin(this);
 
     const fetchHandler = wrapFetch(this);
 
@@ -50,6 +49,10 @@ class BunServer implements Server<BunFetchHandler> {
       loader({ server: this });
       return;
     }
+
+    // Registered after the loader early-return (matching Node) so the outer CLI
+    // server owns the SIGINT/SIGTERM handlers, not the inner intercepted one.
+    gracefulShutdownPlugin(this);
 
     this.#wait = createWaitUntil();
     this.waitUntil = this.#wait.waitUntil;

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -35,6 +35,11 @@ class DenoServer implements Server<DenoFetchHandler> {
   #listeningPromise?: Promise<void>;
   #listeningInfo?: { hostname: string; port: number };
 
+  // Deno.serve exposes no `closeAllConnections`-style API; the only way to force
+  // in-flight requests (SSE/WebSocket) closed is to abort the signal it was
+  // started with. Used by `close(true)`.
+  #abortController?: AbortController;
+
   #wait: ReturnType<typeof createWaitUntil> | undefined;
 
   constructor(options: ServerOptions) {
@@ -43,7 +48,6 @@ class DenoServer implements Server<DenoFetchHandler> {
     for (const plugin of options.plugins || []) plugin(this);
 
     trustProxyPlugin(this);
-    gracefulShutdownPlugin(this);
 
     const fetchHandler = wrapFetch(this);
 
@@ -56,6 +60,10 @@ class DenoServer implements Server<DenoFetchHandler> {
       loader({ server: this });
       return;
     }
+
+    // Registered after the loader early-return (matching Node) so the outer CLI
+    // server owns the SIGINT/SIGTERM handlers, not the inner intercepted one.
+    gracefulShutdownPlugin(this);
 
     this.#wait = createWaitUntil();
     this.waitUntil = this.#wait.waitUntil;
@@ -109,9 +117,11 @@ class DenoServer implements Server<DenoFetchHandler> {
     }
     const onListenPromise = Promise.withResolvers<void>();
     this.#listeningPromise = onListenPromise.promise;
+    this.#abortController = new AbortController();
     this.deno!.server = Deno.serve(
       {
         ...this.serveOptions,
+        signal: this.#abortController.signal,
         onListen: (info) => {
           this.#listeningInfo = info;
           if (this.options.deno?.onListen) {
@@ -140,7 +150,14 @@ class DenoServer implements Server<DenoFetchHandler> {
     return Promise.resolve(this.#listeningPromise).then(() => this);
   }
 
-  async close(): Promise<void> {
+  async close(closeAll?: boolean): Promise<void> {
+    // `close(true)` must forcibly terminate in-flight connections. Deno.serve has
+    // no per-connection close, so abort the signal it was started with; the
+    // graceful `shutdown()` below then resolves immediately instead of hanging on
+    // an open SSE/WebSocket.
+    if (closeAll) {
+      this.#abortController?.abort();
+    }
     await Promise.all([this.#wait?.wait(), Promise.resolve(this.deno?.server?.shutdown())]);
   }
 }

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -74,6 +74,11 @@ export async function cliServe(cliOpts: CLIOptions): Promise<void> {
       gracefulShutdown: !!cliOpts.prod,
       port: cliOpts.port ?? serverOptions.port,
       hostname: cliOpts.hostname ?? cliOpts.host ?? serverOptions.hostname,
+      // In loader mode the user's `serve({ maxRequestBodySize })` call is
+      // intercepted before it ever listens, so the limit lives only on the inner
+      // server's options — thread it onto the outer server that actually serves.
+      maxRequestBodySize:
+        serverOptions.maxRequestBodySize ?? loaded.srvxServer?.options?.maxRequestBodySize,
       tls,
       error: (error) => {
         console.error(error);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -146,6 +146,26 @@ describe("cli", () => {
       }
     });
 
+    it("F27: threads an inline serve() maxRequestBodySize through the loader", async () => {
+      const port = await getRandomPort("localhost");
+      const entry = resolve(fixtureDir, "..", "cli-max-body", "server.ts");
+      const child = runCli(["--prod", "--entry", entry, "--port", String(port)]);
+      try {
+        await waitForPort(port, { host: "localhost", delay: 50, retries: 100 });
+        const ok = await fetch(`http://localhost:${port}/`, { method: "POST", body: "1234" });
+        expect(ok.status).toBe(200);
+        expect(await ok.text()).toBe("1234");
+        const tooBig = await fetch(`http://localhost:${port}/`, {
+          method: "POST",
+          body: "0123456789",
+        });
+        expect(tooBig.status).toBe(413);
+      } finally {
+        child.kill("SIGTERM");
+        await child.catch(() => {});
+      }
+    });
+
     it("F42: `--tls` without cert/key errors instead of downgrading to http", async () => {
       const port = await getRandomPort("localhost");
       const { stderr, exitCode } = await runCli([

--- a/test/fixtures/cli-max-body/server.ts
+++ b/test/fixtures/cli-max-body/server.ts
@@ -1,0 +1,16 @@
+// CLI fixture: calls serve() with an inline `maxRequestBodySize`. Under the CLI
+// loader this call is intercepted before it listens, so the limit lives only on
+// the intercepted inner server — the loader must thread it onto the outer server
+// (F27). Echoes the body, or the error code/status on overflow.
+import { serve } from "srvx";
+
+serve({
+  maxRequestBodySize: 8,
+  fetch: async (req: Request) => {
+    try {
+      return new Response(await req.text());
+    } catch (error: any) {
+      return new Response(error.code ?? "ERR", { status: error.statusCode ?? 500 });
+    }
+  },
+});

--- a/test/fixtures/graceful-server.ts
+++ b/test/fixtures/graceful-server.ts
@@ -1,0 +1,34 @@
+// Fixture for the graceful-shutdown integration tests. Spawned as a child
+// process so real SIGINT/SIGTERM signals can be delivered without terminating
+// the test runner. `gracefulShutdown: true` forces the plugin on even under
+// `CI`/`TEST` (which otherwise auto-disable it). Reads PORT from the env.
+const runtime = (globalThis as any).Deno ? "deno" : (globalThis as any).Bun ? "bun" : "node";
+const { serve } = (await import(
+  `../../src/adapters/${runtime}.ts`
+)) as typeof import("../../src/types.ts");
+
+const gracefulTimeout = process.env.GRACEFUL_TIMEOUT
+  ? { gracefulTimeout: Number(process.env.GRACEFUL_TIMEOUT) }
+  : true;
+
+const server = serve({
+  hostname: "localhost",
+  port: Number(process.env.PORT || 0),
+  gracefulShutdown: gracefulTimeout,
+  silent: true,
+  fetch: async (req) => {
+    const url = new URL(req.url);
+    if (url.pathname === "/slow") {
+      // In-flight when the signal arrives; graceful shutdown must let it finish.
+      await new Promise((resolve) => setTimeout(resolve, 400));
+      return new Response("slow-done");
+    }
+    if (url.pathname === "/hang") {
+      // Never responds — exercises the graceful-timeout -> force-close path.
+      await new Promise(() => {});
+    }
+    return new Response("ok");
+  },
+});
+
+await server.ready();

--- a/test/graceful-shutdown.test.ts
+++ b/test/graceful-shutdown.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from "vitest";
+import { fileURLToPath } from "node:url";
+import { execa } from "execa";
+import { getRandomPort, waitForPort } from "get-port-please";
+import { gracefulShutdownPlugin } from "../src/_plugins.ts";
+import { serve } from "../src/adapters/node.ts";
+
+const fixture = fileURLToPath(new URL("./fixtures/graceful-server.ts", import.meta.url));
+
+function grabShutdownListener(): () => Promise<void> {
+  // The plugin registers its `shutdown` handler last, for both SIGINT/SIGTERM.
+  const listeners = process.listeners("SIGINT");
+  return listeners[listeners.length - 1] as () => Promise<void>;
+}
+
+describe("graceful shutdown plugin (in-process)", () => {
+  it("closes the server gracefully and removes its signal listeners", async () => {
+    const before = {
+      int: process.listenerCount("SIGINT"),
+      term: process.listenerCount("SIGTERM"),
+    };
+    const closeCalls: (boolean | undefined)[] = [];
+    const server = {
+      options: { gracefulShutdown: true, silent: true },
+      close: (all?: boolean) => {
+        closeCalls.push(all);
+        return Promise.resolve();
+      },
+    } as any;
+
+    gracefulShutdownPlugin(server);
+    const shutdown = grabShutdownListener();
+    await shutdown();
+
+    // Graceful close (not force), and every listener cleaned up afterwards.
+    expect(closeCalls).toEqual([undefined]);
+    expect(process.listenerCount("SIGINT")).toBe(before.int);
+    expect(process.listenerCount("SIGTERM")).toBe(before.term);
+  });
+
+  it("survives a rejecting close() and falls through to force-close", async () => {
+    const before = process.listenerCount("SIGINT");
+    const rejections: unknown[] = [];
+    const onRejection = (error: unknown) => rejections.push(error);
+    process.on("unhandledRejection", onRejection);
+
+    const closeCalls: (boolean | undefined)[] = [];
+    const server = {
+      options: { gracefulShutdown: true, silent: true },
+      close: (all?: boolean) => {
+        closeCalls.push(all);
+        // Graceful close rejects; the force close (all === true) succeeds.
+        return all ? Promise.resolve() : Promise.reject(new Error("close boom"));
+      },
+    } as any;
+
+    gracefulShutdownPlugin(server);
+    const shutdown = grabShutdownListener();
+    await shutdown();
+    // Let any stray microtask/unhandledRejection surface.
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    process.off("unhandledRejection", onRejection);
+
+    expect(closeCalls).toEqual([undefined, true]); // graceful attempted, then forced
+    expect(rejections).toEqual([]); // no unhandledRejection crashed the process
+    expect(process.listenerCount("SIGINT")).toBe(before);
+  });
+
+  it("does not accumulate signal listeners across serve()/close() cycles", async () => {
+    const before = {
+      int: process.listenerCount("SIGINT"),
+      term: process.listenerCount("SIGTERM"),
+    };
+    for (let i = 0; i < 3; i++) {
+      const server = serve({
+        port: 0,
+        hostname: "localhost",
+        gracefulShutdown: true,
+        silent: true,
+        fetch: () => new Response("ok"),
+      });
+      await server.ready();
+      await server.close();
+    }
+    expect(process.listenerCount("SIGINT")).toBe(before.int);
+    expect(process.listenerCount("SIGTERM")).toBe(before.term);
+  });
+});
+
+describe("graceful shutdown (child process)", () => {
+  it("completes an in-flight request on SIGINT, then exits cleanly", async () => {
+    const port = await getRandomPort("localhost");
+    const child = execa(process.execPath, [fixture], {
+      env: { PORT: String(port), NO_COLOR: "1" },
+      reject: false,
+    });
+    try {
+      await waitForPort(port, { host: "localhost", delay: 50, retries: 200 });
+      const inflight = fetch(`http://localhost:${port}/slow`);
+      // Give the request time to reach the handler before signalling.
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      child.kill("SIGINT");
+
+      const res = await inflight;
+      expect(await res.text()).toBe("slow-done");
+
+      const result = await child;
+      expect(result.exitCode).toBe(0);
+    } finally {
+      child.kill("SIGKILL");
+      await child.catch(() => {});
+    }
+  });
+
+  it("honors gracefulTimeout and force-closes a hung request", async () => {
+    const port = await getRandomPort("localhost");
+    const child = execa(process.execPath, [fixture], {
+      env: { PORT: String(port), GRACEFUL_TIMEOUT: "1", NO_COLOR: "1" },
+      reject: false,
+    });
+    try {
+      await waitForPort(port, { host: "localhost", delay: 50, retries: 200 });
+      const hung = fetch(`http://localhost:${port}/hang`).catch(() => "aborted");
+      await new Promise((resolve) => setTimeout(resolve, 150));
+
+      const start = Date.now();
+      child.kill("SIGINT");
+      const result = await child;
+      const elapsed = Date.now() - start;
+      await hung;
+
+      // Exited despite the never-responding request: force close fired after the
+      // ~1s graceful window rather than hanging forever.
+      expect(result.exitCode).toBe(0);
+      expect(elapsed).toBeLessThan(6000);
+    } finally {
+      child.kill("SIGKILL");
+      await child.catch(() => {});
+    }
+  });
+});


### PR DESCRIPTION
Shutdown/close-correctness batch of the v1 stabilization plan.

## F25 — Deno `close(true)` drops its argument
`deno.ts` only ever called the graceful `shutdown()` and wired no `AbortSignal` into `Deno.serve`, so on Deno a double-Ctrl+C printed "Forcibly closing connections…" and then **hung** on an open SSE/WebSocket. Node and Bun already honor the flag.

- Wire an `AbortController` into `Deno.serve` and abort it on `close(true)` — Deno exposes no per-connection close, so aborting the serve signal is the only way to force in-flight connections closed; the graceful `shutdown()` then resolves immediately instead of hanging.

## F27 — plugin registration order + dropped `maxRequestBodySize` in loader mode
- Move `gracefulShutdownPlugin(this)` **after** the `__srvxLoader__` early-return on Deno and Bun (matching Node). Previously both the inner loader-intercepted instance and the outer CLI server attached SIGINT/SIGTERM handlers → two competing countdowns.
- Thread an inline `serve({ maxRequestBodySize })` from the intercepted inner server's options onto the outer CLI server. In loader mode the user's `serve()` is intercepted before it listens, so the limit lived only on the inner server and was silently dropped.

## F34 — graceful shutdown crash + listener leak
- Capture a rejecting `close()` during graceful shutdown (log, then fall through to force-close) instead of letting it surface as an `unhandledRejection` that crashes the process and skips force-close.
- Remove the SIGINT/SIGTERM listeners on every shutdown path **and** on programmatic `close()` (via a thin wrapper), and cancel the deferred force-close timer, so repeated `serve()`/`close()` cycles no longer accumulate listeners or pin each `Server`.

## Tests
New `test/graceful-shutdown.test.ts` — graceful shutdown previously had zero coverage and is auto-disabled under `CI`/`TEST`. Uses `gracefulShutdown: true` to force it on regardless of env:
- **In-process** (plugin driven directly, no real signals): graceful close + listener cleanup; rejecting `close()` falls through to force-close without an unhandledRejection; no listener accumulation across serve/close cycles (real Node adapter).
- **Child process** (real SIGINT): in-flight request completes then exits 0; `gracefulTimeout` honored → force-closes a hung request.
- Added a CLI test asserting the loader threads an inline `maxRequestBodySize` (413 on overflow).

`bun`/`deno` share the same runtime-agnostic `_plugins.ts` path exercised by the in-process tests; F25 was additionally verified with a Deno SSE smoke test (`close(true)` now resolves instead of hanging).

## Results
`pnpm test` green: 983 passed, 35 skipped (pre-existing skips). Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable graceful shutdown handling, including forced closure for hanging requests.
  * Added support for enforcing maximum request body sizes in CLI-served applications.
  * Deno servers can now terminate in-flight connections during forced shutdown.

* **Bug Fixes**
  * Improved cleanup of shutdown signal handlers and prevented unhandled shutdown errors.
  * Fixed shutdown behavior across Bun and Deno loader scenarios.

* **Tests**
  * Added coverage for graceful shutdown, forced termination, signal cleanup, and request size limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->