### PR TITLE
fix: web core T3 polish (plugin contract, tracing, log, ready)

### DIFF
--- a/build.config.mjs
+++ b/build.config.mjs
@@ -1,7 +1,41 @@
 import { defineBuildConfig } from "obuild/config";
-import { rm } from "node:fs/promises";
+import { readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import pkg from "./package.json" with { type: "json" };
+
+/**
+ * Remove a `declare module "<spec>" { ... }` augmentation block from emitted `.d.mts`.
+ *
+ * `src/mtls.ts` augments both `"srvx"` (for consumers) and `"./types.ts"` (so srvx's
+ * own type-check resolves `request.tls` through the relative source module). The latter
+ * is meaningless in the published bundle — `./types.ts` does not exist there — and only
+ * survives into `dist/mtls.d.mts` because `skipLibCheck` hides it. Strip it at build time.
+ */
+function stripDeclareModule(code, spec) {
+  const marker = `declare module "${spec}" {`;
+  const start = code.indexOf(marker);
+  if (start === -1) {
+    return code;
+  }
+  let depth = 0;
+  let end = start + marker.length - 1; // index of the opening brace
+  for (; end < code.length; end++) {
+    const ch = code[end];
+    if (ch === "{") {
+      depth++;
+    } else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        end++;
+        break;
+      }
+    }
+  }
+  if (code[end] === "\n") {
+    end++;
+  }
+  return code.slice(0, start) + code.slice(end);
+}
 
 export default defineBuildConfig({
   entries: [
@@ -47,6 +81,11 @@ export default defineBuildConfig({
   hooks: {
     async end(ctx) {
       await rm(join(ctx.pkgDir, "dist/types.mjs"));
+
+      // Strip the dead `declare module "./types.ts"` augmentation (see helper above).
+      const mtlsDts = join(ctx.pkgDir, "dist/mtls.d.mts");
+      const contents = await readFile(mtlsDts, "utf8");
+      await writeFile(mtlsDts, stripDeclareModule(contents, "./types.ts"));
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "sideEffects": false,
   "types": "./dist/types.d.mts",
   "exports": {
+    "./package.json": "./package.json",
     "./deno": "./dist/adapters/deno.mjs",
     "./bun": "./dist/adapters/bun.mjs",
     "./node": "./dist/adapters/node.mjs",

--- a/src/_middleware.ts
+++ b/src/_middleware.ts
@@ -1,23 +1,56 @@
 import type { Server, ServerRequest, ServerHandler, ServerMiddleware } from "./types.ts";
 
+/**
+ * Internal per-middleware interceptor hook.
+ *
+ * When set on a server, {@link wrapFetch} invokes it for every middleware in the
+ * live chain instead of calling the middleware directly, passing the handler and
+ * its current index. Used by the experimental `srvx/tracing` plugin so that
+ * tracing reflects the *final* middleware chain (including middleware that
+ * internal plugins such as `trustProxy`/`error` add after user plugins run).
+ *
+ * @internal
+ */
+export const kMiddlewareInterceptor: unique symbol = Symbol.for("srvx.middlewareInterceptor");
+
+/** @internal */
+export type MiddlewareInterceptor = (
+  handler: ServerMiddleware,
+  index: number,
+  request: ServerRequest,
+  next: () => Response | Promise<Response>,
+) => Response | Promise<Response>;
+
+/**
+ * Build the composed fetch handler for a server (middleware chain + fetch).
+ *
+ * The middleware chain is read **live** from `server.options.middleware` on every
+ * request rather than snapshotted at construction. This makes the extension
+ * contract consistent: middleware appended after construction via
+ * `server.options.middleware.push(...)` — the mechanism plugins use — always take
+ * effect, regardless of whether the array was empty or non-empty when the server
+ * was created. Because plugins are synchronous (see `ServerPlugin`), every
+ * plugin-registered middleware is in place before the first request.
+ */
 export function wrapFetch(server: Server): ServerHandler {
   const fetchHandler = server.options.fetch;
-  const middleware = server.options.middleware || [];
-  return middleware.length === 0
-    ? fetchHandler
-    : (request) => callMiddleware(request, fetchHandler, middleware, 0);
+  return (request) => callMiddleware(request as ServerRequest, fetchHandler, server, 0);
 }
 
 function callMiddleware(
   request: ServerRequest,
   fetchHandler: ServerHandler,
-  middleware: ServerMiddleware[],
+  server: Server,
   index: number,
 ): Response | Promise<Response> {
-  if (index === middleware.length) {
+  const middleware = server.options.middleware;
+  if (!middleware || index >= middleware.length) {
     return fetchHandler(request);
   }
-  return middleware[index](request, () =>
-    callMiddleware(request, fetchHandler, middleware, index + 1),
-  );
+  const handler = middleware[index];
+  const next = () => callMiddleware(request, fetchHandler, server, index + 1);
+  const interceptor = (server as { [kMiddlewareInterceptor]?: MiddlewareInterceptor })[
+    kMiddlewareInterceptor
+  ];
+  return interceptor ? interceptor(handler, index, request, next) : handler(request, next);
 }

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,19 +1,63 @@
-import * as c from "./cli/_utils.ts";
 import type { ServerMiddleware } from "./types.ts";
 
-export interface LogOptions {}
+export interface LogOptions {
+  /**
+   * Sink that receives each formatted log line.
+   *
+   * @default console.log
+   */
+  sink?: (line: string) => void;
 
-const statusColors = { 1: c.blue, 2: c.green, 3: c.yellow } as const;
+  /**
+   * Emit ANSI colors.
+   *
+   * Defaults to auto-detection: colors are enabled only when writing to an interactive
+   * TTY and the [`NO_COLOR`](https://no-color.org/) convention is not set (`FORCE_COLOR`
+   * forces them on). Set explicitly to `true`/`false` to override.
+   */
+  colors?: boolean;
+}
 
-export const log: (options?: LogOptions) => ServerMiddleware = (_options = {}) => {
+const ansi =
+  (open: number, close: number) =>
+  (text: string): string =>
+    `\u001B[${open}m${text}\u001B[${close}m`;
+
+const identity = (text: string): string => text;
+
+function detectColors(): boolean {
+  const proc = globalThis.process;
+  const env = proc?.env ?? {};
+  if (env.FORCE_COLOR) {
+    return true;
+  }
+  if (env.NO_COLOR || env.TERM === "dumb") {
+    return false;
+  }
+  return !!proc?.stdout?.isTTY;
+}
+
+export const log: (options?: LogOptions) => ServerMiddleware = (options = {}) => {
+  const sink = options.sink ?? ((line: string) => console.log(line));
+  const useColors = options.colors ?? detectColors();
+
+  const bold = useColors ? ansi(1, 22) : identity;
+  const red = useColors ? ansi(31, 39) : identity;
+  const green = useColors ? ansi(32, 39) : identity;
+  const yellow = useColors ? ansi(33, 39) : identity;
+  const blue = useColors ? ansi(34, 39) : identity;
+  const gray = useColors ? ansi(90, 39) : identity;
+
+  const statusColors = { 1: blue, 2: green, 3: yellow } as const;
+
   return async (req, next) => {
     const start = performance.now();
     const res = await next();
     const duration = performance.now() - start;
     const statusColor =
-      statusColors[Math.floor(res.status / 100) as unknown as keyof typeof statusColors] || c.red;
-    console.log(
-      `${c.gray(`[${new Date().toLocaleTimeString()}]`)} ${c.bold(req.method)} ${c.blue(req.url)} [${statusColor(res.status + "")}] ${c.gray(`(${duration.toFixed(2)}ms)`)}`,
+      statusColors[Math.floor(res.status / 100) as unknown as keyof typeof statusColors] || red;
+    sink(
+      `${gray(`[${new Date().toLocaleTimeString()}]`)} ${bold(req.method)} ${blue(req.url)} [${statusColor(res.status + "")}] ${gray(`(${duration.toFixed(2)}ms)`)}`,
     );
     return res;
   };

--- a/src/tracing.ts
+++ b/src/tracing.ts
@@ -1,4 +1,5 @@
 import type { Server, ServerRequest, ServerPlugin, ServerMiddleware } from "./types.ts";
+import { kMiddlewareInterceptor, type MiddlewareInterceptor } from "./_middleware.ts";
 
 /**
  * @experimental Channel names, event types and config options may change in future releases.
@@ -54,23 +55,26 @@ export function tracingPlugin(opts: { middleware?: boolean; fetch?: boolean } = 
       };
     }
 
-    // Wrap middleware with tracing
+    // Trace middleware.
+    //
+    // Rather than snapshotting and rewrapping `server.options.middleware` here (at
+    // plugin time), install a per-middleware interceptor that runs at dispatch time
+    // over the *live* chain. Internal plugins (`trustProxy`, `error`, graceful
+    // shutdown) unshift their middleware after user plugins run, so a snapshot taken
+    // now would miss them and freeze stale indices. The interceptor sees the final
+    // chain: every middleware is traced and `index` reflects its real position.
     if (opts.middleware !== false) {
       const middlewareChannel = tracingChannel<RequestEvent, RequestEvent>("srvx.middleware");
-      const originalMiddleware = server.options.middleware;
-      const wrappedMiddleware: ServerMiddleware[] = originalMiddleware.map((handler, index) => {
+      const interceptor: MiddlewareInterceptor = (handler, index, request, next) => {
         const middleware = Object.freeze({ index, handler });
-        return (request, next) => {
-          return middlewareChannel.tracePromise(async () => await handler(request, next), {
-            request,
-            server,
-            middleware,
-          });
-        };
-      });
-
-      // Replace middleware array with wrapped versions
-      server.options.middleware.splice(0, server.options.middleware.length, ...wrappedMiddleware);
+        return middlewareChannel.tracePromise(async () => await handler(request, next), {
+          request: request as ServerRequest,
+          server,
+          middleware,
+        });
+      };
+      (server as { [kMiddlewareInterceptor]?: MiddlewareInterceptor })[kMiddlewareInterceptor] =
+        interceptor;
     }
   };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -280,7 +280,11 @@ export interface Server<Handler = ServerHandler> {
   serve(): void | Promise<Server<Handler>>;
 
   /**
-   * Returns a promise that resolves when the server is ready.
+   * Returns a promise that resolves when the server is listening and ready to accept connections.
+   *
+   * If listening has not been initiated yet — for example when the `manual` option is enabled and
+   * `serve()` has not been called — this resolves immediately with the (not-yet-listening) server.
+   * To guarantee the server is actually listening, call `serve()` and await its returned promise.
    */
   ready(): Promise<Server<Handler>>;
 
@@ -322,6 +326,7 @@ export interface ServerRuntimeContext {
    */
   deno?: {
     info: Deno.ServeHandlerInfo<Deno.NetAddr>;
+    server?: Deno.HttpServer;
   };
 
   /**

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { log, type LogOptions } from "../src/log.ts";
+
+const run = async (options: LogOptions) => {
+  const mw = log(options);
+  return mw(new Request("http://localhost/test") as any, () => new Response("ok", { status: 200 }));
+};
+
+describe("log()", () => {
+  it("sends formatted lines to a custom sink", async () => {
+    const lines: string[] = [];
+    await run({ sink: (line) => lines.push(line), colors: false });
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain("GET");
+    expect(lines[0]).toContain("http://localhost/test");
+    expect(lines[0]).toContain("200");
+  });
+
+  it("emits ANSI colors when explicitly enabled", async () => {
+    const lines: string[] = [];
+    await run({ sink: (line) => lines.push(line), colors: true });
+    expect(lines[0]).toContain("\u001B[");
+  });
+
+  it("strips colors when disabled", async () => {
+    const lines: string[] = [];
+    await run({ sink: (line) => lines.push(line), colors: false });
+    expect(lines[0]).not.toContain("\u001B[");
+  });
+
+  it("honors NO_COLOR for auto color detection", async () => {
+    const prev = process.env.NO_COLOR;
+    process.env.NO_COLOR = "1";
+    try {
+      const lines: string[] = [];
+      await run({ sink: (line) => lines.push(line) });
+      expect(lines[0]).not.toContain("\u001B[");
+    } finally {
+      if (prev === undefined) {
+        delete process.env.NO_COLOR;
+      } else {
+        process.env.NO_COLOR = prev;
+      }
+    }
+  });
+});

--- a/test/middleware.test.ts
+++ b/test/middleware.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { serve } from "../src/adapters/node.ts";
+import type { ServerMiddleware } from "../src/types.ts";
+
+// The extension contract: `server.options.middleware` is read live on every request,
+// so middleware pushed after construction (the mechanism plugins use) always take
+// effect — consistently on both the empty and non-empty initial paths.
+describe("middleware extension contract", () => {
+  const call = (server: ReturnType<typeof serve>) =>
+    server.fetch(new Request("http://localhost/") as any);
+
+  it("applies middleware pushed after construction (empty initial chain)", async () => {
+    const server = serve({ fetch: () => new Response("fetch"), manual: true });
+
+    const tag: ServerMiddleware = async (_req, next) => {
+      const res = await next();
+      res.headers.set("x-added", "1");
+      return res;
+    };
+    server.options.middleware.push(tag);
+
+    const res = await call(server);
+    expect(res.headers.get("x-added")).toBe("1");
+  });
+
+  it("applies middleware pushed after construction (non-empty initial chain)", async () => {
+    const order: string[] = [];
+    const first: ServerMiddleware = async (_req, next) => {
+      order.push("a");
+      return next();
+    };
+    const server = serve({
+      fetch: () => new Response("fetch"),
+      middleware: [first],
+      manual: true,
+    });
+
+    const second: ServerMiddleware = async (_req, next) => {
+      order.push("b");
+      return next();
+    };
+    server.options.middleware.push(second);
+
+    await call(server);
+    expect(order).toEqual(["a", "b"]);
+  });
+});

--- a/test/tracing.test.ts
+++ b/test/tracing.test.ts
@@ -396,6 +396,59 @@ describe("tracing channels", () => {
     expect(events).toContain("fetch.end");
   });
 
+  it("should trace internal middleware with indices from the final chain", async () => {
+    // The `error` plugin unshifts its middleware *after* user plugins run, so the
+    // traced chain must reflect the final order: the internal middleware is traced
+    // at index 0 and the user middleware shifts to index 1.
+    const events: Array<{ name: string; index: number }> = [];
+
+    const middlewareChannel = tracingChannel("srvx.middleware");
+
+    const startHandler = (data: any) => {
+      events.push({ name: data.middleware.handler.name, index: data.middleware.index });
+    };
+
+    middlewareChannel.subscribe({
+      start: startHandler,
+      end: noop,
+      asyncStart: noop,
+      asyncEnd: noop,
+      error: noop,
+    });
+
+    cleanupFns.push(() => {
+      middlewareChannel.unsubscribe({
+        start: startHandler,
+        end: noop,
+        asyncStart: noop,
+        asyncEnd: noop,
+        error: noop,
+      });
+    });
+
+    const userMiddleware: ServerMiddleware = async (request, next) => next();
+    Object.defineProperty(userMiddleware, "name", { value: "user" });
+
+    const server = serve({
+      fetch: () => new Response("OK"),
+      middleware: [userMiddleware],
+      error: () => new Response("error", { status: 500 }),
+      plugins: [tracingPlugin()],
+      manual: true,
+    });
+
+    // The error plugin injected an extra (internal) middleware ahead of the user one.
+    expect(server.options.middleware).toHaveLength(2);
+
+    const request = new Request("http://localhost:3000/");
+    await server.fetch(request);
+
+    // Two middleware traced (internal + user), indices reflect the final chain.
+    expect(events.map((e) => e.index)).toEqual([0, 1]);
+    const user = events.find((e) => e.name === "user");
+    expect(user?.index).toBe(1);
+  });
+
   it("should provide result in asyncEnd events", async () => {
     const results: Array<any> = [];
 


### PR DESCRIPTION
Web-core **T3 polish** batch of the v1 stabilization plan. Excludes PR #230 items (F51/F52/F10/F11 `@experimental`/D6). Prose docs left to the docs agent (JSDoc only here).

## Changes

1. **Plugin extension contract** (`_middleware.ts`) — `wrapFetch` now reads `server.options.middleware` **live on every request** instead of snapshotting at construction. Previously the behavior was inconsistent: if the chain was empty at construction, later `server.options.middleware.push(...)` (the mechanism the docs teach) was silently ignored; if non-empty, pushes took effect. Now push-after-construction always works on both paths. Documented in JSDoc. Compatible with D6 (sync-only plugins → all plugin middleware is in place before the first request).

2. **`deno` runtime type** (`types.ts`) — added `server?: Deno.HttpServer` to the request runtime `deno` context; `deno.ts` already sets it and the docs document it.

3. **Tracing** (`tracing.ts`) — the frozen middleware `index` went stale and internal middleware were untraced, because `errorPlugin`/`trustProxyPlugin` add their middleware *after* user plugins run. Fixed by installing a dispatch-time per-middleware interceptor (via an internal symbol read by `wrapFetch`) instead of snapshotting/rewrapping the array at plugin time. The interceptor sees the **final** live chain: every middleware is traced and `index` reflects its real position. Event shape is unchanged (`srvx/tracing` is experimental per D5 regardless).

4. **`log()`** (`log.ts`) — `LogOptions` gains `sink?: (line) => void` (default `console.log`) and `colors?: boolean` (default: auto — TTY and not `NO_COLOR`, `FORCE_COLOR` forces on), evaluated at factory time. Added `test/log.test.ts`.

5. **`ready()` contract** (`types.ts`) — **Chosen fix: align the JSDoc with reality** (smallest honest fix). Making `ready()` block until `serve()` is invoked would hang forever under `manual: true` and touch every adapter. The JSDoc now states it resolves once listening has started, and resolves immediately if listening was never initiated — pointing callers at `serve()`'s returned promise for a hard guarantee. No behavior change; does not touch F26 (owned by #230).

6. **`package.json` exports** — added `"./package.json": "./package.json"`. Left the single-string subpaths as-is (TS resolves the `.d.mts` beside each `.mjs`); adding explicit `{types,default}` objects is mechanical but pure churn, so noted rather than done.

7. **Build hygiene** (`build.config.mjs`) — an `end` hook strips the dead `declare module "./types.ts"` augmentation from the emitted `dist/mtls.d.mts` (it only survived via `skipLibCheck`). The `srvx` augmentation consumers need is retained. Verified with `pnpm build`.

## Tests

`pnpm test` (lint + typecheck + vitest + coverage): **984 passed, 35 skipped (pre-existing), no type errors**. `pnpm build` clean; confirmed the stripped `dist/mtls.d.mts` no longer contains the dead block. New tests: `test/middleware.test.ts`, `test/log.test.ts`, and a tracing case asserting the internal (`error`) middleware is traced at index 0 with the user middleware shifted to index 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)