### PR TITLE
refactor: improve edge adapters and tests

### DIFF
--- a/src/adapters/bunny.ts
+++ b/src/adapters/bunny.ts
@@ -44,7 +44,8 @@ class BunnyServer implements Server {
 
     const fetchHandler = wrapFetch(this);
 
-    const waitUntil = (this.waitUntil = (p: Promise<unknown>) => (globalThis as any).Bunny?.unstable?.waitUntil?.(p));
+    const waitUntil = (this.waitUntil = (p: Promise<unknown>) =>
+      (globalThis as any).Bunny?.unstable?.waitUntil?.(p));
 
     this.fetch = (request: Request) => {
       Object.defineProperties(request, {

--- a/src/adapters/bunny.ts
+++ b/src/adapters/bunny.ts
@@ -44,7 +44,15 @@ class BunnyServer implements Server {
 
     const fetchHandler = wrapFetch(this);
 
-    const waitUntil = (this.waitUntil = (p: Promise<unknown>) => Bunny.unstable?.waitUntil?.(p));
+    const waitUntil = (this.waitUntil = (p: Promise<unknown>) => {
+      // `Bunny` is a bare global that only exists inside the Bunny runtime.
+      // Referencing it directly (even with optional chaining) throws a
+      // `ReferenceError` when the adapter runs elsewhere (e.g. `manual: true`
+      // in tests or another runtime), so guard with a `typeof` check first.
+      if (typeof Bunny !== "undefined") {
+        Bunny.unstable?.waitUntil?.(p);
+      }
+    });
 
     this.fetch = (request: Request) => {
       Object.defineProperties(request, {

--- a/src/adapters/bunny.ts
+++ b/src/adapters/bunny.ts
@@ -44,15 +44,7 @@ class BunnyServer implements Server {
 
     const fetchHandler = wrapFetch(this);
 
-    const waitUntil = (this.waitUntil = (p: Promise<unknown>) => {
-      // `Bunny` is a bare global that only exists inside the Bunny runtime.
-      // Referencing it directly (even with optional chaining) throws a
-      // `ReferenceError` when the adapter runs elsewhere (e.g. `manual: true`
-      // in tests or another runtime), so guard with a `typeof` check first.
-      if (typeof Bunny !== "undefined") {
-        Bunny.unstable?.waitUntil?.(p);
-      }
-    });
+    const waitUntil = (this.waitUntil = (p: Promise<unknown>) => (globalThis as any).Bunny?.unstable?.waitUntil?.(p));
 
     this.fetch = (request: Request) => {
       Object.defineProperties(request, {

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -10,11 +10,29 @@ export function serve(options: ServerOptions): Server<CF.ExportedHandlerFetchHan
   return new CloudflareServer(options);
 }
 
+/**
+ * Cloudflare Workers server adapter.
+ *
+ * The recommended entrypoint is the **module-worker** syntax: export the
+ * server (or its `.fetch` handler) as the module default so the runtime invokes
+ * `fetch(request, env, context)` directly. Only then are `env` bindings (KV, D1,
+ * Durable Objects, secrets, ...) available on `request.runtime.cloudflare.env`.
+ *
+ * For legacy **service-worker** syntax, `serve()` also registers a global
+ * `fetch` event listener. In that mode Cloudflare exposes bindings as globals
+ * rather than through the event, so `env` is unavailable and
+ * `request.runtime.cloudflare.env` is an empty object.
+ */
 class CloudflareServer implements Server<CloudflareFetchHandler> {
   readonly runtime = "cloudflare";
   readonly options: Server["options"];
   readonly serveOptions: CF.ExportedHandler;
   readonly fetch: CF.ExportedHandlerFetchHandler;
+
+  // Retained so `close()` can remove exactly the listener `serve()` added and
+  // repeated `serve()` calls do not stack duplicate listeners (which would
+  // trigger a double `respondWith()` error on Cloudflare).
+  #fetchListener?: (event: FetchEvent) => void;
 
   constructor(options: ServerOptions) {
     this.options = { ...options, middleware: [...(options.middleware || [])] };
@@ -31,9 +49,11 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
           enumerable: true,
           value: { name: "cloudflare", cloudflare: { env, context } },
         },
-        // TODO
         ip: {
           enumerable: true,
+          // `configurable` so `trustProxy` can override it, matching the
+          // bun/deno adapters.
+          configurable: true,
           get() {
             return request.headers.get("cf-connecting-ip");
           },
@@ -54,10 +74,20 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
   }
 
   serve() {
-    addEventListener("fetch", (event) => {
-      // @ts-expect-error
-      event.respondWith(this.fetch(event.request, {}, event));
-    });
+    // Service-worker syntax only. Guard against double-registration: calling
+    // `serve()` twice (or `manual: true` then `serve()`) must not stack a
+    // second listener, otherwise both would call `respondWith()` on the same
+    // event and Cloudflare throws.
+    if (this.#fetchListener) {
+      return;
+    }
+    this.#fetchListener = (event) => {
+      // Service-worker events carry no `env`; bindings are only reachable in
+      // module-worker syntax (see the class doc comment).
+      // @ts-expect-error `respondWith` is FetchEvent-only.
+      event.respondWith(this.fetch(event.request, (event as any).env || {}, event));
+    };
+    addEventListener("fetch", this.#fetchListener as EventListener);
   }
 
   ready(): Promise<Server<CF.ExportedHandlerFetchHandler>> {
@@ -65,6 +95,10 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
   }
 
   close() {
+    if (this.#fetchListener) {
+      removeEventListener("fetch", this.#fetchListener as EventListener);
+      this.#fetchListener = undefined;
+    }
     return Promise.resolve();
   }
 }

--- a/src/adapters/service-worker.ts
+++ b/src/adapters/service-worker.ts
@@ -27,6 +27,9 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
 
   #fetchListener?: (event: FetchEvent) => void | Promise<void>;
   #listeningPromise?: Promise<any>;
+  // The registration `serve()` created (browser-window mode), so `close()`
+  // unregisters only our own worker instead of every worker on the origin.
+  #registration?: ServiceWorkerRegistration;
 
   constructor(options: ServerOptions) {
     this.options = { ...options, middleware: [...(options.middleware || [])] };
@@ -68,7 +71,8 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
           type: "module",
           scope: this.options.serviceWorker?.scope,
         })
-        .then(() => {
+        .then((registration) => {
+          this.#registration = registration;
           // If the page is already controlled by an active service worker,
           // it can handle requests right away and no reload is needed.
           if (navigator.serviceWorker.controller) {
@@ -123,14 +127,11 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
       removeEventListener("fetch", this.#fetchListener!);
     }
 
-    // unregister the service worker
+    // Unregister only the worker this instance registered, not every worker
+    // on the origin.
     if (isBrowserWindow) {
-      const registrations = await navigator.serviceWorker.getRegistrations();
-      for (const registration of registrations) {
-        if (registration.active) {
-          await registration.unregister();
-        }
-      }
+      await this.#registration?.unregister();
+      this.#registration = undefined;
     } else if (isServiceWorker) {
       await self.registration.unregister();
     }

--- a/test/_error-fixture.ts
+++ b/test/_error-fixture.ts
@@ -1,0 +1,27 @@
+import type { ServerOptions } from "../src/types.ts";
+
+// Runtime-detected adapter, mirroring `_fixture.ts`.
+// prettier-ignore
+const runtime = (globalThis as any).Deno ? "deno" : (globalThis.Bun ? "bun" : "node");
+const { serve } = (await import(
+  `../src/adapters/${runtime}.ts`
+)) as typeof import("../src/types.ts");
+
+// Intentionally NO `error` option: with `error` unset the `errorPlugin` no-ops
+// and handler exceptions propagate straight to the runtime. This fixture exists
+// to observe what each runtime does with an unhandled throw (F9 error paths).
+const server = serve({
+  hostname: "localhost",
+  fetch(req) {
+    const { pathname } = new URL(req.url);
+    if (pathname === "/throw") {
+      throw new Error("unhandled sync error");
+    }
+    if (pathname === "/throw-async") {
+      return Promise.reject(new Error("unhandled async error"));
+    }
+    return new Response("ok");
+  },
+} satisfies ServerOptions);
+
+await server.ready();

--- a/test/_error-tests.ts
+++ b/test/_error-tests.ts
@@ -1,0 +1,53 @@
+import { fileURLToPath } from "node:url";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import { execa, type ResultPromise as ExecaRes } from "execa";
+import { getRandomPort, waitForPort } from "get-port-please";
+
+const testDir = fileURLToPath(new URL(".", import.meta.url));
+
+/**
+ * F9 (error paths): spawn `_error-fixture.ts` (a server with **no** `error`
+ * option) under the given runtime and assert that an unhandled handler throw
+ * does not take the process down and the client still gets a response.
+ *
+ * Deno and Bun both surface an uncaught handler error as `500` and keep
+ * serving. Node's in-process behavior differs (the throw escapes as an
+ * `uncaughtException` that would crash the process) and is documented
+ * separately in `node-error-paths.test.ts`.
+ */
+export function addExecUnhandledThrowTests(cmd: string): void {
+  let childProc: ExecaRes;
+  let baseURL: string;
+  let exited = false;
+
+  beforeAll(async () => {
+    const port = await getRandomPort("localhost");
+    baseURL = `http://localhost:${port}/`;
+    const [bin, ...args] = cmd.replace("./", testDir).split(" ");
+    childProc = execa(bin, args, { env: { PORT: port.toString() } });
+    // Ignore the non-zero exit / SIGTERM that teardown provokes.
+    childProc.catch(() => {});
+    childProc.on("exit", () => {
+      exited = true;
+    });
+    await waitForPort(port, { host: "localhost", delay: 50, retries: 100 });
+  });
+
+  afterAll(async () => {
+    await childProc.kill();
+  });
+
+  for (const path of ["/throw", "/throw-async"]) {
+    test(`unhandled throw at ${path} returns 500 without crashing`, async () => {
+      const res = await fetch(baseURL + path.slice(1));
+      // Deno and Bun answer an uncaught handler error with a 500.
+      expect(res.status).toBe(500);
+      await res.text().catch(() => {});
+      // The process is still alive: a follow-up request succeeds.
+      expect(exited).toBe(false);
+      const ok = await fetch(baseURL);
+      expect(ok.status).toBe(200);
+      expect(await ok.text()).toBe("ok");
+    });
+  }
+}

--- a/test/bun.test.ts
+++ b/test/bun.test.ts
@@ -1,6 +1,11 @@
 import { describe } from "vitest";
 import { testsExec } from "./_utils.ts";
+import { addExecUnhandledThrowTests } from "./_error-tests.ts";
 
 describe("bun", () => {
   testsExec("bun run ./_fixture.ts", { runtime: "bun" });
+});
+
+describe("bun (unhandled errors)", () => {
+  addExecUnhandledThrowTests("bun run ./_error-fixture.ts");
 });

--- a/test/bunny.test.ts
+++ b/test/bunny.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { serve } from "../src/adapters/bunny.ts";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("bunny adapter", () => {
+  test("throws a clear error when the Bunny runtime is absent", () => {
+    // No `Bunny` global -> `serve()` (called from the constructor) throws.
+    expect(() => serve({ fetch: () => new Response("ok") })).toThrow(/Bunny runtime not detected/);
+  });
+
+  test("waitUntil is safe to call outside the Bunny runtime (manual mode)", () => {
+    // Regression: the waitUntil closure used to dereference the bare `Bunny`
+    // global unconditionally -> `ReferenceError` when running elsewhere.
+    const server = serve({ manual: true, fetch: () => new Response("ok") });
+    expect(() => server.waitUntil!(Promise.resolve())).not.toThrow();
+  });
+
+  test("registers the handler with Bunny.v1.serve", async () => {
+    let registered: ((req: Request) => Response | Promise<Response>) | undefined;
+    vi.stubGlobal("Bunny", {
+      v1: { serve: (h: any) => (registered = h) },
+    });
+
+    serve({ fetch: () => new Response("hello") });
+
+    expect(typeof registered).toBe("function");
+    const res = await registered!(new Request("http://localhost/"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("hello");
+  });
+
+  test("does not register twice across repeated serve() calls", () => {
+    const serveSpy = vi.fn();
+    vi.stubGlobal("Bunny", { v1: { serve: serveSpy } });
+
+    const server = serve({ fetch: () => new Response("ok") }); // serve() #1 (constructor)
+    server.serve(); // #2
+    server.serve(); // #3
+
+    expect(serveSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("delegates waitUntil to Bunny.unstable.waitUntil", () => {
+    const waitUntilSpy = vi.fn();
+    vi.stubGlobal("Bunny", {
+      v1: { serve: () => {} },
+      unstable: { waitUntil: waitUntilSpy },
+    });
+
+    const server = serve({ fetch: () => new Response("ok") });
+    const p = Promise.resolve();
+    server.waitUntil!(p);
+    expect(waitUntilSpy).toHaveBeenCalledWith(p);
+  });
+
+  test("sets request.ip from x-real-ip and request.runtime", async () => {
+    let registered: ((req: Request) => Response | Promise<Response>) | undefined;
+    vi.stubGlobal("Bunny", { v1: { serve: (h: any) => (registered = h) } });
+
+    let seenIp: string | null | undefined;
+    let seenRuntime: string | undefined;
+    serve({
+      fetch: (req) => {
+        seenIp = req.ip;
+        seenRuntime = req.runtime?.name;
+        return new Response("ok");
+      },
+    });
+
+    await registered!(new Request("http://localhost/", { headers: { "x-real-ip": "1.2.3.4" } }));
+    expect(seenIp).toBe("1.2.3.4");
+    expect(seenRuntime).toBe("bunny");
+  });
+});

--- a/test/cloudflare.test.ts
+++ b/test/cloudflare.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { serve } from "../src/adapters/cloudflare.ts";
+
+// NOTE: This is a best-effort in-process test. The plan's preferred option is a
+// `@cloudflare/vitest-pool-workers` smoke job, but that pool requires its own
+// vitest project/worker runtime (wrangler + a separate config) that conflicts
+// with the existing single-config Node-based suite. Instead we mock the
+// service-worker `addEventListener`/`removeEventListener` globals and exercise
+// the module-worker `fetch(request, env, context)` export directly, which
+// covers all three F29 behaviors (single registration, `close()` removal, and
+// `env` threading) plus the `configurable` `ip`.
+
+function mockContext() {
+  return { waitUntil: vi.fn(), passThroughOnException: vi.fn() } as any;
+}
+
+describe("cloudflare adapter", () => {
+  let listeners: Array<{ type: string; listener: EventListener }>;
+
+  beforeEach(() => {
+    listeners = [];
+    vi.stubGlobal("addEventListener", (type: string, listener: EventListener) => {
+      listeners.push({ type, listener });
+    });
+    vi.stubGlobal("removeEventListener", (type: string, listener: EventListener) => {
+      const i = listeners.findIndex((l) => l.type === type && l.listener === listener);
+      if (i !== -1) listeners.splice(i, 1);
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("module-worker export", () => {
+    test("threads real env and context into request.runtime.cloudflare", async () => {
+      const server = serve({ manual: true, fetch: () => new Response("ok") });
+
+      const env = { MY_KV: {}, SECRET: "s3cr3t" };
+      const ctx = mockContext();
+      let seen: any;
+      const server2 = serve({
+        manual: true,
+        fetch: (req) => {
+          seen = (req as any).runtime;
+          return new Response("ok");
+        },
+      });
+      await server2.fetch(new Request("http://localhost/") as any, env as any, ctx);
+
+      expect(seen.name).toBe("cloudflare");
+      expect(seen.cloudflare.env).toBe(env);
+      expect(seen.cloudflare.context).toBe(ctx);
+      // Keep `server` referenced so its constructor path is covered too.
+      expect(server.runtime).toBe("cloudflare");
+    });
+
+    test("wires waitUntil to context.waitUntil", async () => {
+      const ctx = mockContext();
+      let captured: ((p: Promise<unknown>) => void) | undefined;
+      const server = serve({
+        manual: true,
+        fetch: (req) => {
+          captured = (req as any).waitUntil;
+          return new Response("ok");
+        },
+      });
+      await server.fetch(new Request("http://localhost/") as any, {} as any, ctx);
+      const p = Promise.resolve();
+      captured!(p);
+      expect(ctx.waitUntil).toHaveBeenCalledWith(p);
+    });
+
+    test("sets request.ip from cf-connecting-ip and it is configurable", async () => {
+      let ip: string | null | undefined;
+      const server = serve({
+        manual: true,
+        fetch: (req) => {
+          ip = (req as any).ip;
+          // `configurable: true` lets trustProxy-style overrides redefine it.
+          expect(Object.getOwnPropertyDescriptor(req, "ip")?.configurable).toBe(true);
+          return new Response("ok");
+        },
+      });
+      await server.fetch(
+        new Request("http://localhost/", { headers: { "cf-connecting-ip": "9.9.9.9" } }) as any,
+        {} as any,
+        mockContext(),
+      );
+      expect(ip).toBe("9.9.9.9");
+    });
+  });
+
+  describe("service-worker fetch listener (F29)", () => {
+    test("registers exactly one fetch listener on serve()", () => {
+      serve({ fetch: () => new Response("ok") }); // auto-serve in constructor
+      expect(listeners.filter((l) => l.type === "fetch")).toHaveLength(1);
+    });
+
+    test("does not stack listeners across repeated serve() calls", () => {
+      const server = serve({ manual: true, fetch: () => new Response("ok") });
+      server.serve();
+      server.serve();
+      server.serve();
+      expect(listeners.filter((l) => l.type === "fetch")).toHaveLength(1);
+    });
+
+    test("close() removes the listener it registered", async () => {
+      const server = serve({ fetch: () => new Response("ok") });
+      expect(listeners.filter((l) => l.type === "fetch")).toHaveLength(1);
+      await server.close();
+      expect(listeners.filter((l) => l.type === "fetch")).toHaveLength(0);
+    });
+
+    test("the listener responds via event.respondWith", async () => {
+      serve({ fetch: () => new Response("hello", { status: 201 }) });
+      const listener = listeners.find((l) => l.type === "fetch")!.listener;
+
+      let responded: Promise<Response> | undefined;
+      const event = {
+        request: new Request("http://localhost/"),
+        respondWith: (r: any) => (responded = r),
+        waitUntil: vi.fn(),
+      };
+      listener(event as any);
+
+      const res = await responded!;
+      expect(res.status).toBe(201);
+      expect(await res.text()).toBe("hello");
+    });
+  });
+});

--- a/test/deno.test.ts
+++ b/test/deno.test.ts
@@ -1,8 +1,13 @@
 import { describe } from "vitest";
 import { testsExec } from "./_utils.ts";
+import { addExecUnhandledThrowTests } from "./_error-tests.ts";
 
 describe("deno", () => {
   testsExec("deno run -A ./_fixture.ts", {
     runtime: "deno",
   });
+});
+
+describe("deno (unhandled errors)", () => {
+  addExecUnhandledThrowTests("deno run -A ./_error-fixture.ts");
 });

--- a/test/generic.test.ts
+++ b/test/generic.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "vitest";
+import { serve } from "../src/adapters/generic.ts";
+
+describe("generic adapter", () => {
+  test("serves a basic response via server.fetch", async () => {
+    const server = serve({
+      fetch: () => new Response("ok"),
+    });
+    expect(server.runtime).toBe("generic");
+    const res = await server.fetch(new Request("http://localhost/"));
+    expect(res.status).toBe(200);
+    expect(await res.text()).toBe("ok");
+  });
+
+  test("serve() is a no-op and ready() resolves to the server", async () => {
+    const server = serve({ fetch: () => new Response("ok") });
+    expect(server.serve()).toBeUndefined();
+    await expect(server.ready()).resolves.toBe(server);
+  });
+
+  test("exposes request.runtime is unset but waitUntil is available", async () => {
+    let hadWaitUntil = false;
+    const server = serve({
+      fetch: (req) => {
+        hadWaitUntil = typeof req.waitUntil === "function";
+        return new Response("ok");
+      },
+    });
+    await server.fetch(new Request("http://localhost/"));
+    expect(hadWaitUntil).toBe(true);
+  });
+
+  test("runs middleware", async () => {
+    const server = serve({
+      middleware: [(req, next) => (req.headers.has("x-mw") ? new Response("from-mw") : next())],
+      fetch: () => new Response("handler"),
+    });
+    expect(await (await server.fetch(new Request("http://localhost/"))).text()).toBe("handler");
+    expect(
+      await (
+        await server.fetch(new Request("http://localhost/", { headers: { "x-mw": "1" } }))
+      ).text(),
+    ).toBe("from-mw");
+  });
+
+  test("runs plugins", async () => {
+    const server = serve({
+      plugins: [
+        (s) => {
+          s.options.middleware!.unshift(async (_req, next) => {
+            const res = await next();
+            res.headers.set("x-plugin", "1");
+            return res;
+          });
+        },
+      ],
+      fetch: () => new Response("ok"),
+    });
+    const res = await server.fetch(new Request("http://localhost/"));
+    expect(res.headers.get("x-plugin")).toBe("1");
+  });
+
+  test("honors the error option", async () => {
+    const server = serve({
+      error: (err) => new Response(`caught: ${(err as Error).message}`, { status: 500 }),
+      fetch: () => {
+        throw new Error("boom");
+      },
+    });
+    const res = await server.fetch(new Request("http://localhost/"));
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("caught: boom");
+  });
+
+  test("close() awaits pending waitUntil promises", async () => {
+    let resolved = false;
+    const server = serve({
+      fetch: (req) => {
+        req.waitUntil!(
+          new Promise<void>((resolve) =>
+            setTimeout(() => {
+              resolved = true;
+              resolve();
+            }, 20),
+          ),
+        );
+        return new Response("ok");
+      },
+    });
+    await server.fetch(new Request("http://localhost/"));
+    expect(resolved).toBe(false);
+    await server.close();
+    expect(resolved).toBe(true);
+  });
+});

--- a/test/node-error-paths.test.ts
+++ b/test/node-error-paths.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { serve } from "../src/adapters/node.ts";
+
+// F9 (error paths): with no `error` option the `errorPlugin` no-ops and handler
+// exceptions propagate to the runtime. This documents the *actual* Node
+// behavior (see `test/_error-tests.ts` for the Deno/Bun counterparts, which
+// answer 500 and stay alive).
+//
+// Node currently lets an unhandled throw escape the request handler as a
+// process-level `uncaughtException`/`unhandledRejection` and sends no response
+// on that connection -- i.e. an unguarded server would crash. We install a
+// temporary handler to capture it (preventing the vitest worker from dying) and
+// assert the observed behavior + that the server keeps serving afterwards.
+// Fixing the divergence (making Node answer 500 like Deno/Bun) belongs to the
+// Node adapter scope, not this edge-adapter batch.
+describe("node adapter unhandled errors (F9)", () => {
+  let restore: (() => void) | undefined;
+
+  afterEach(() => {
+    restore?.();
+    restore = undefined;
+  });
+
+  async function withServer(
+    handler: (req: Request) => Response | Promise<Response>,
+    fn: (url: string) => Promise<void>,
+  ) {
+    const server = serve({ hostname: "localhost", port: 0, fetch: handler });
+    await server.ready();
+    try {
+      await fn(server.url!);
+    } finally {
+      await server.close(true);
+    }
+  }
+
+  test("sync throw escapes as uncaughtException and does not silently succeed", async () => {
+    const captured: unknown[] = [];
+    const onUncaught = (err: unknown) => captured.push(err);
+    process.prependListener("uncaughtException", onUncaught);
+    restore = () => process.removeListener("uncaughtException", onUncaught);
+
+    await withServer(
+      (req) => {
+        if (new URL(req.url).pathname === "/throw") {
+          throw new Error("unhandled sync error");
+        }
+        return new Response("ok");
+      },
+      async (url) => {
+        // The throwing request gets no proper response: Node leaves the socket
+        // hanging (and surfaces the throw as an uncaughtException), so the fetch
+        // never completes -- bound it with a short timeout. Either way it must
+        // NOT be a silent 2xx.
+        const status = await fetch(url + "throw", { signal: AbortSignal.timeout(1000) })
+          .then((r) => r.status)
+          .catch(() => undefined);
+        // Give the event loop a tick for the uncaughtException to fire.
+        await new Promise((r) => setTimeout(r, 50));
+
+        const uncaught = captured.some((e) => (e as Error)?.message === "unhandled sync error");
+        expect(uncaught || (status !== undefined && status >= 500)).toBe(true);
+
+        // The server itself survives (we swallowed the exception): a normal
+        // request still succeeds.
+        const ok = await fetch(url);
+        expect(ok.status).toBe(200);
+        expect(await ok.text()).toBe("ok");
+      },
+    );
+  });
+});


### PR DESCRIPTION
Edge-adapter batch of the v1 stabilization plan.

## Fixes

### Cloudflare — F29 (locked: keep the global `fetch` listener, fix the bugs)
- **No double-registration**: `serve()` retains its listener; repeated calls (or `manual: true` then `serve()`) no longer stack a second listener, which previously caused a double `respondWith()` error.
- **`close()` removes the listener** it registered.
- **Threads `env`** through the service-worker listener instead of a hardcoded `{}`. Cloudflare exposes bindings as globals in service-worker syntax, so `env` is only meaningfully available via **module-worker** syntax — documented in the class JSDoc.
- **`request.ip` is now `configurable: true`** (matching bun/deno) so `trustProxy` can override it; still populated from `cf-connecting-ip`.

### Bunny
- Guard the `waitUntil` closure with `typeof Bunny !== "undefined"` so it no longer throws a `ReferenceError` when the adapter runs outside the Bunny runtime (e.g. `manual: true`).

### Service worker
- `close()` unregisters **only** the registration `serve()` created, instead of every service worker on the origin.

## Tests

### F46 — adapter coverage
- `test/generic.test.ts` — in-process tests (middleware, plugins, `error`, `waitUntil`/`close`).
- `test/bunny.test.ts` — mocked `Bunny` global (registration, single-registration, `waitUntil` delegation, `ip`, and the no-runtime `ReferenceError` regression).
- `test/cloudflare.test.ts` — best-effort **in-process** test with mocked service-worker globals + direct module-worker `fetch(request, env, context)` calls, covering all three F29 behaviors and the configurable `ip`.
  - Note: the plan's preferred `@cloudflare/vitest-pool-workers` smoke job needs its own worker runtime + wrangler + a separate vitest project, which conflicts with the existing single-config Node suite, so the in-process fallback was used (as the plan allows).

### F9 — error paths (one unhandled-throw test per runtime)
- `test/_error-fixture.ts` — a server with **no** `error` option (so `errorPlugin` no-ops and throws propagate to the runtime).
- Deno & Bun (`test/_error-tests.ts`, wired into `deno.test.ts` / `bun.test.ts` — zero extra CI wiring): both answer **500** and keep serving.
- Node (`test/node-error-paths.test.ts`, in-process): documents Node's current behavior — an unhandled throw escapes as an `uncaughtException` and leaves the connection hanging (an unguarded server would crash). Making Node answer 500 like Deno/Bun belongs to the Node adapter scope, so it is **documented, not fixed** here.

## Verification
- `pnpm lint` clean, `pnpm typecheck` clean (after `pnpm build`), full `vitest run`: **1002 passed / 35 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Bunny runtime compatibility when accessing optional runtime APIs.
  - Prevented duplicate Cloudflare service-worker request handlers during repeated server starts.
  - Ensured Cloudflare shutdown removes only the handler registered by the server.
  - Improved proxy IP configuration flexibility for Cloudflare requests.
  - Service-worker shutdown now unregisters only the registration created by the server.
  - Improved resilience when request handlers throw synchronous or asynchronous errors, helping servers remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->