### PR TITLE
fix(node): Node adapter correctness fixes (statusText, empty body, HEAD streaming, send errors, sync bridge)

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -133,23 +133,10 @@ export const NodeRequest: {
     }
 
     get headers(): Headers {
-      // Return the srvx-side Headers object whenever it exists, even after the
-      // native Request has materialized. Materializing `_request` always reads
-      // `this.headers` (so `#headers` is populated) but the native constructor
-      // copies the entries into its own Headers instance. Switching the getter
-      // to `this.#request.headers` there would leave a reference taken earlier
-      // (`const h = req.headers; req._request; h.set(...)`) pointing at a now-
-      // detached object whose mutations are invisible. Keeping `#headers`
-      // canonical keeps those references live.
-      if (this.#headers) {
-        return this.#headers;
-      }
       if (this.#request) {
-        // Unreachable in practice: materializing `_request` reads `this.headers`
-        // first, so `#headers` is always set. Kept as defense in depth.
         return this.#request.headers;
       }
-      return (this.#headers = new NodeRequestHeaders(this.#req));
+      return (this.#headers ||= new NodeRequestHeaders(this.#req));
     }
 
     get _abortController() {
@@ -299,11 +286,7 @@ export const NodeRequest: {
           // @ts-expect-error Undici specific
           duplex: body ? "half" : undefined,
         });
-        // Keep `#headers` so `get headers()` returns the same object identity
-        // before and after materialization (see the note there). The native
-        // Request holds its own snapshot copy: mutations made after this point
-        // show up in `req.headers` but not in `#request.headers` — and thus not
-        // in `clone()` or `formData()`, which delegate to the native Request.
+        this.#headers = undefined;
         this.#bodyStream = undefined;
       }
 

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -133,10 +133,21 @@ export const NodeRequest: {
     }
 
     get headers(): Headers {
+      // Return the srvx-side Headers object whenever it exists, even after the
+      // native Request has materialized. Materializing `_request` always reads
+      // `this.headers` (so `#headers` is populated) but the native constructor
+      // copies the entries into its own Headers instance. Switching the getter
+      // to `this.#request.headers` there would leave a reference taken earlier
+      // (`const h = req.headers; req._request; h.set(...)`) pointing at a now-
+      // detached object whose mutations are invisible. Keeping `#headers`
+      // canonical keeps those references live.
+      if (this.#headers) {
+        return this.#headers;
+      }
       if (this.#request) {
         return this.#request.headers;
       }
-      return (this.#headers ||= new NodeRequestHeaders(this.#req));
+      return (this.#headers = new NodeRequestHeaders(this.#req));
     }
 
     get _abortController() {
@@ -232,7 +243,14 @@ export const NodeRequest: {
       }
       this.#bodyUsed = true;
       if (this.#bodyStream !== undefined) {
-        return new Response(this.#bodyStream).text();
+        // `new Response(stream)` throws *synchronously* if the stream is already
+        // locked/disturbed (e.g. a consumer took `req.body` and read it
+        // directly). Surface that as a rejected promise, matching native fetch.
+        try {
+          return new Response(this.#bodyStream).text();
+        } catch (error) {
+          return Promise.reject(error);
+        }
       }
       return this.#readBuffered().then((buf) => buf.toString());
     }
@@ -250,7 +268,12 @@ export const NodeRequest: {
       }
       this.#bodyUsed = true;
       if (this.#bodyStream !== undefined) {
-        return new Response(this.#bodyStream).json();
+        // See text(): a locked/disturbed stream must reject, not throw.
+        try {
+          return new Response(this.#bodyStream).json();
+        } catch (error) {
+          return Promise.reject(error);
+        }
       }
       // Parse in a single continuation (readBody -> parse) instead of going
       // through text() — one less promise + microtask hop per body read.
@@ -274,7 +297,9 @@ export const NodeRequest: {
           // @ts-expect-error Undici specific
           duplex: body ? "half" : undefined,
         });
-        this.#headers = undefined;
+        // Keep `#headers` so `get headers()` returns the same object identity
+        // before and after materialization (see the note there). The native
+        // Request holds its own copy; the srvx-side object remains canonical.
         this.#bodyStream = undefined;
       }
 

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -145,6 +145,8 @@ export const NodeRequest: {
         return this.#headers;
       }
       if (this.#request) {
+        // Unreachable in practice: materializing `_request` reads `this.headers`
+        // first, so `#headers` is always set. Kept as defense in depth.
         return this.#request.headers;
       }
       return (this.#headers = new NodeRequestHeaders(this.#req));
@@ -299,7 +301,9 @@ export const NodeRequest: {
         });
         // Keep `#headers` so `get headers()` returns the same object identity
         // before and after materialization (see the note there). The native
-        // Request holds its own copy; the srvx-side object remains canonical.
+        // Request holds its own snapshot copy: mutations made after this point
+        // show up in `req.headers` but not in `#request.headers` — and thus not
+        // in `clone()` or `formData()`, which delegate to the native Request.
         this.#bodyStream = undefined;
       }
 

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -28,8 +28,6 @@ export const NodeResponse: {
 } = /* @__PURE__ */ (() => {
   const NativeResponse = globalThis.Response;
 
-  const STATUS_CODES = globalThis.process?.getBuiltinModule?.("node:http")?.STATUS_CODES || {};
-
   class NodeResponse implements Partial<Response> {
     #body?: BodyInit | null;
     #init?: ResponseInit;
@@ -50,9 +48,11 @@ export const NodeResponse: {
     }
 
     get statusText(): string {
-      return (
-        this.#response?.statusText || this.#init?.statusText || STATUS_CODES[this.status] || ""
-      );
+      // Default to the spec's empty reason phrase (matching native `Response`,
+      // Bun and Deno) rather than Node's `STATUS_CODES` phrase (e.g. "OK"). Node
+      // still fills in a reason phrase on the wire when we pass "" to
+      // `writeHead`.
+      return this.#response?.statusText || this.#init?.statusText || "";
     }
 
     get headers(): Headers {
@@ -119,7 +119,10 @@ export const NodeResponse: {
       let contentLength: string | number | undefined | null;
       if (this.#response) {
         body = this.#response.body;
-      } else if (this.#body) {
+      } else if (this.#body != null) {
+        // `!= null` (not a truthy check): an empty-string body is falsy but must
+        // still receive the implicit `text/plain` content-type and a
+        // `content-length: 0`, matching native `Response("")`.
         if (this.#body instanceof ReadableStream) {
           body = this.#body;
         } else if (typeof this.#body === "string") {
@@ -187,7 +190,9 @@ export const NodeResponse: {
       if (contentType && !hasContentTypeHeader) {
         headers.push("content-type", contentType);
       }
-      if (contentLength && !hasContentLength) {
+      // `!= null` so a computed `content-length: 0` (e.g. an empty-string body)
+      // is emitted, matching native `Response`.
+      if (contentLength != null && !hasContentLength) {
         headers.push("content-length", String(contentLength));
       }
 

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -49,9 +49,9 @@ export const NodeResponse: {
 
     get statusText(): string {
       // Default to the spec's empty reason phrase (matching native `Response`,
-      // Bun and Deno) rather than Node's `STATUS_CODES` phrase (e.g. "OK"). Node
-      // still fills in a reason phrase on the wire when we pass "" to
-      // `writeHead`.
+      // Bun and Deno) rather than Node's `STATUS_CODES` phrase (e.g. "OK").
+      // Node uses an explicit "" verbatim in `writeHead`, so the wire status
+      // line carries an empty reason phrase too (legal per RFC 9112).
       return this.#response?.statusText || this.#init?.statusText || "";
     }
 

--- a/src/adapters/_node/send.ts
+++ b/src/adapters/_node/send.ts
@@ -38,15 +38,24 @@ export function sendNodeResponse(
 export function sendNodeResponseDetached(
   nodeRes: NodeServerResponse,
   webRes: Response | NodeResponse,
+  silent?: boolean,
 ): Promise<void> | void {
   try {
     return _sendNodeResponse(nodeRes, webRes, true);
   } catch (error) {
-    handleSendError(nodeRes, error);
+    handleSendError(nodeRes, error, silent);
   }
 }
 
-function handleSendError(nodeRes: NodeServerResponse, _error: unknown): void {
+function handleSendError(nodeRes: NodeServerResponse, error: unknown, silent?: boolean): void {
+  // A synchronous throw here is almost always a serialization bug (e.g. an
+  // invalid header name/value passed to `writeHead`). Without a diagnostic the
+  // client just sees a bare 500 with no way to trace the cause. Surface the
+  // underlying error on the server (unless silenced) while keeping the client
+  // response detail-free.
+  if (!silent) {
+    console.error("[srvx] Failed to send response:", error);
+  }
   if (nodeRes.headersSent) {
     // Response already committed — the only recovery is to tear down the socket.
     nodeRes.destroy();
@@ -189,6 +198,15 @@ export function streamBody(
   if (nodeRes.destroyed) {
     stream.cancel();
     return;
+  }
+
+  // HEAD responses must carry no body. Cancel the stream immediately instead of
+  // pumping it to completion — an unbounded body (e.g. an SSE stream) would
+  // otherwise pump forever. Headers are already written by the caller; just end
+  // the response. Matches Deno/Bun, which discard the body for HEAD.
+  if ((nodeRes as NodeHttp.ServerResponse).req?.method === "HEAD") {
+    stream.cancel().catch(() => {});
+    return endNodeResponse(nodeRes);
   }
 
   const reader = stream.getReader();

--- a/src/adapters/_node/web/incoming.ts
+++ b/src/adapters/_node/web/incoming.ts
@@ -15,8 +15,34 @@ export class WebIncomingMessage extends IncomingMessage {
     const url = (req._url ??= new FastURL(req.url));
     this.url = url.pathname + url.search;
 
+    // Node's HTTP parser normally fills these in. On this synthetic message they
+    // stay at their defaults (`httpVersion === null`, empty `rawHeaders`) unless
+    // populated, which breaks consumers that read them — e.g. morgan's
+    // `:http-version` token and keep-alive negotiation. The web fetch bridge has
+    // no wire protocol version, so report HTTP/1.1 (the semantics fetch models).
+    this.httpVersionMajor = 1;
+    this.httpVersionMinor = 1;
+    this.httpVersion = "1.1";
+
+    // `rawHeaders` is the flat `[name, value, name, value, …]` list Node exposes.
+    // Web `Headers` lower-cases names and has no wire order, so this is a
+    // best-effort reconstruction; `set-cookie` is expanded to one entry each.
+    const rawHeaders = this.rawHeaders;
     for (const [key, value] of req.headers.entries()) {
-      this.headers[key.toLowerCase()] = value;
+      const lowerKey = key.toLowerCase();
+      if (lowerKey === "set-cookie") {
+        continue;
+      }
+      this.headers[lowerKey] = value;
+      rawHeaders.push(key, value);
+    }
+    const setCookie = req.headers.getSetCookie?.() ?? [];
+    if (setCookie.length > 0) {
+      // Node keeps `set-cookie` as an array on `headers` and one raw entry each.
+      (this.headers as Record<string, string | string[]>)["set-cookie"] = setCookie;
+      for (const cookie of setCookie) {
+        rawHeaders.push("set-cookie", cookie);
+      }
     }
     if (
       req.method !== "GET" &&

--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -27,6 +27,13 @@ export class WebServerResponse extends ServerResponse {
     super(req);
     this.assignSocket(socket);
 
+    // `super(req)` enables chunked transfer-encoding by default because the
+    // synthetic request now reports HTTP/1.1. But this response isn't written to
+    // a real wire: `toWebResponse()` captures the raw body buffer from the
+    // bridging socket and re-wraps it in a web `Response`. Chunk framing would
+    // corrupt that captured body, so keep the output un-chunked (close-delimited).
+    this.useChunkedEncodingByDefault = false;
+
     this.once("finish", () => {
       socket.end();
     });

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -86,8 +86,10 @@ class NodeServer implements Server {
       // node:http ignores the listener's return value — use the detached
       // variant to skip the per-response end-tracking Promise.
       return res instanceof Promise
-        ? res.then((resolvedRes) => sendNodeResponseDetached(nodeRes, resolvedRes))
-        : sendNodeResponseDetached(nodeRes, res);
+        ? res.then((resolvedRes) =>
+            sendNodeResponseDetached(nodeRes, resolvedRes, this.options.silent),
+          )
+        : sendNodeResponseDetached(nodeRes, res, this.options.silent);
     };
 
     this.node = { handler, server: undefined };

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -66,6 +66,11 @@ export type LoadedServerEntry = {
    *
    * This is resolved from `module.fetch`, `module.default.fetch`,
    * or upgraded from a legacy Node.js handler.
+   *
+   * A bare `export default function` is disambiguated by its declared parameter
+   * count (arity): `< 2` params is treated as a web `fetch` handler, `>= 2` as a
+   * legacy Node `(req, res)` handler. See the note at the resolution site for
+   * the edge cases this heuristic gets wrong and how to opt out.
    */
   fetch?: ServerHandler;
 
@@ -170,6 +175,19 @@ export async function loadServerEntry(opts: LoadOptions): Promise<LoadedServerEn
 
   let fetchHandler =
     mod?.fetch || mod?.default?.fetch || mod?.default?.default?.fetch || interceptedServer?.fetch;
+  // Arity heuristic: a bare `export default function` could be either a web
+  // `fetch` handler `(request) => Response` or a legacy Node handler
+  // `(req, res) => void`. There is no runtime marker distinguishing them, so we
+  // fall back to the declared parameter count: `< 2` params → treat as a web
+  // `fetch` handler, `>= 2` → fall through to the Node-compat path below.
+  //
+  // This is a best-effort guess with two known edge cases it gets wrong:
+  //   - a Node handler that only declares `(req)` (1 param) is misread as fetch;
+  //   - a web handler that declares a second `(request, context)`-style param
+  //     (2 params) is misread as Node-compat.
+  // Handlers using rest/default params (`...args`, `req = x`) report a `length`
+  // of `0`, so they are always treated as fetch. Export an explicit
+  // `{ fetch }` (or `default: { fetch }`) to opt out of the heuristic entirely.
   if (!fetchHandler && typeof mod?.default === "function" && mod.default.length < 2) {
     fetchHandler = mod.default;
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -361,14 +361,26 @@ export interface ServerRequestContext {
 
 export interface ServerRequest extends Request {
   /**
-   * Access to Node.js native instance of request.
+   * The underlying web-standard `Request` backing this request.
+   *
+   * On the Node.js adapter `ServerRequest` is a lazy wrapper that only
+   * materializes a full web `Request` (undici's implementation) when needed;
+   * `_request` exposes that instance. On web runtimes it is the native
+   * `Request`. It is **not** the Node.js `IncomingMessage` — reach that via
+   * `runtime.node.req`.
+   *
+   * Supported API. The underscore is legacy naming, not a privacy marker; its
+   * shape is frozen for the v1 semver guarantee.
    *
    * See https://srvx.h3.dev/guide/node#noderequest
    */
   _request?: Request;
 
   /**
-   * Access to the parsed URL
+   * Access to the parsed URL of this request.
+   *
+   * Supported API. The underscore is legacy naming, not a privacy marker; its
+   * shape is frozen for the v1 semver guarantee.
    */
   _url?: URL;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -369,9 +369,6 @@ export interface ServerRequest extends Request {
 
   /**
    * Access to the parsed URL of this request.
-   *
-   * Supported API. The underscore is legacy naming, not a privacy marker; its
-   * shape is frozen for the v1 semver guarantee.
    */
   _url?: URL;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -363,15 +363,6 @@ export interface ServerRequest extends Request {
   /**
    * The underlying web-standard `Request` backing this request.
    *
-   * On the Node.js adapter `ServerRequest` is a lazy wrapper that only
-   * materializes a full web `Request` (undici's implementation) when needed;
-   * `_request` exposes that instance. On web runtimes it is the native
-   * `Request`. It is **not** the Node.js `IncomingMessage` — reach that via
-   * `runtime.node.req`.
-   *
-   * Supported API. The underscore is legacy naming, not a privacy marker; its
-   * shape is frozen for the v1 semver guarantee.
-   *
    * See https://srvx.h3.dev/guide/node#noderequest
    */
   _request?: Request;

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -1,6 +1,6 @@
 import { createServer } from "node:http";
 import { connect, type AddressInfo } from "node:net";
-import { describe, expect, test } from "vitest";
+import { describe, expect, test, vi } from "vitest";
 
 import type { NodeHttp1Handler, NodeServerRequest, NodeServerResponse } from "../src/types.ts";
 import {
@@ -759,6 +759,190 @@ describe("node body crash regressions", () => {
     expect([...responses[0].body]).toEqual([3, 4, 5, 6]);
     expect(responses[1].body.toString()).toBe("second");
     await server.close(true);
+  });
+});
+
+// v1 stabilization: Node-adapter T3 correctness batch.
+describe("node T3 correctness", () => {
+  const headerPairs = (headers: string[]) => {
+    const pairs: [string, string][] = [];
+    for (let i = 0; i < headers.length; i += 2) {
+      pairs.push([headers[i], headers[i + 1]]);
+    }
+    return pairs;
+  };
+
+  // A streaming body for a HEAD request must be cancelled immediately, not
+  // pumped to completion (an unbounded SSE stream would pump forever).
+  test("HEAD cancels a streaming body instead of pumping it", async () => {
+    let cancelled = false;
+    let pulls = 0;
+    const server = serve({
+      port: 0,
+      fetch() {
+        const stream = new ReadableStream({
+          pull(controller) {
+            pulls++;
+            controller.enqueue(new TextEncoder().encode("data\n"));
+          },
+          cancel() {
+            cancelled = true;
+          },
+        });
+        return new Response(stream);
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "HEAD" });
+    expect(res.status).toBe(200);
+    expect((await res.arrayBuffer()).byteLength).toBe(0);
+    // Let the cancellation settle.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(cancelled).toBe(true);
+    // The stream was cancelled up front rather than pumped.
+    expect(pulls).toBeLessThanOrEqual(1);
+    await server.close(true);
+  });
+
+  // statusText defaults to the spec's empty reason phrase, not Node's phrase.
+  test("statusText defaults to empty string, not Node's reason phrase", () => {
+    expect(new FastResponse("x", { status: 200 }).statusText).toBe("");
+    expect(new FastResponse("x", { status: 404 }).statusText).toBe("");
+    expect(new FastResponse("x", { status: 200, statusText: "Custom" }).statusText).toBe("Custom");
+  });
+
+  // An empty-string body still gets the implicit text content-type + length 0,
+  // matching native Response("").
+  test("empty-string body keeps default content-type and content-length", () => {
+    const { headers } = new FastResponse("")._toNodeResponse();
+    const pairs = headerPairs(headers);
+    expect(pairs).toContainEqual(["content-type", "text/plain; charset=UTF-8"]);
+    expect(pairs).toContainEqual(["content-length", "0"]);
+
+    // Sanity: a native Response agrees on the content-type.
+    expect(new Response("").headers.get("content-type")).toBe("text/plain;charset=UTF-8");
+  });
+
+  // text()/json() on a locked/disturbed body stream must reject, not throw
+  // synchronously.
+  test("text() on a locked body stream rejects instead of throwing", async () => {
+    let outcome = "unset";
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        // Disturb the body stream directly (bypassing srvx's own bodyUsed
+        // tracking) so text() hits the `new Response(stream)` path with a
+        // locked/disturbed stream.
+        const reader = req.body!.getReader();
+        await reader.cancel();
+        outcome = await req.text().then(
+          () => "resolved",
+          (error) => (error instanceof TypeError ? "TypeError" : "other-error"),
+        );
+        return new Response(outcome);
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.text()).toBe("TypeError");
+    await server.close(true);
+  });
+
+  // A headers reference taken before `_request` materialization must stay live.
+  test("headers reference stays live across _request materialization", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const h = req.headers;
+        // Force materialization of the underlying native Request.
+        void req._request;
+        h.set("x-added-after", "1");
+        return Response.json({
+          sameIdentity: req.headers === h,
+          viaGetter: req.headers.get("x-added-after"),
+          viaRef: h.get("x-added-after"),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!);
+    expect(await res.json()).toEqual({
+      sameIdentity: true,
+      viaGetter: "1",
+      viaRef: "1",
+    });
+    await server.close(true);
+  });
+
+  // A synchronous send failure (e.g. an invalid header value hitting writeHead)
+  // must be logged for diagnostics (unless silenced) and returned as a bare 500
+  // without leaking details to the client.
+  test("send error is logged and returns a bare 500", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const server = serve({
+      port: 0,
+      fetch() {
+        // An invalid header value throws synchronously inside writeHead().
+        return new FastResponse("body", { headers: [["x-bad", "bad\r\ninjected"]] });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe(""); // no error detail leaked to the client
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+    await server.close(true);
+  });
+
+  test("send error is not logged when the server is silent", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const server = serve({
+      port: 0,
+      silent: true,
+      fetch() {
+        return new FastResponse("body", { headers: [["x-bad", "bad\r\ninjected"]] });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!);
+    expect(res.status).toBe(500);
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+    await server.close(true);
+  });
+
+  // The synthetic IncomingMessage built for the web->node bridge must expose
+  // httpVersion / rawHeaders (morgan's :http-version, keep-alive logic).
+  test("synthetic IncomingMessage exposes httpVersion and rawHeaders", async () => {
+    const handler: NodeHttp1Handler = (req, res) => {
+      const idx = req.rawHeaders.findIndex((h) => h.toLowerCase() === "x-test");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          httpVersion: req.httpVersion,
+          major: req.httpVersionMajor,
+          minor: req.httpVersionMinor,
+          rawXTestValue: idx === -1 ? null : req.rawHeaders[idx + 1],
+        }),
+      );
+    };
+
+    const res = await fetchNodeHandler(
+      handler,
+      new Request("http://localhost/", { headers: { "x-test": "abc" } }),
+    );
+    expect(await res.json()).toMatchObject({
+      httpVersion: "1.1",
+      major: 1,
+      minor: 1,
+      rawXTestValue: "abc",
+    });
   });
 });
 

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -762,8 +762,9 @@ describe("node body crash regressions", () => {
   });
 });
 
-// v1 stabilization: Node-adapter T3 correctness batch.
-describe("node T3 correctness", () => {
+// Regressions where the Node adapter diverged from native fetch semantics
+// (Response defaults, HEAD handling, send diagnostics, node-compat bridge).
+describe("node fetch-spec correctness regressions", () => {
   const headerPairs = (headers: string[]) => {
     const pairs: [string, string][] = [];
     for (let i = 0; i < headers.length; i += 2) {

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -850,33 +850,6 @@ describe("node T3 correctness", () => {
     await server.close(true);
   });
 
-  // A headers reference taken before `_request` materialization must stay live.
-  test("headers reference stays live across _request materialization", async () => {
-    const server = serve({
-      port: 0,
-      async fetch(req) {
-        const h = req.headers;
-        // Force materialization of the underlying native Request.
-        void req._request;
-        h.set("x-added-after", "1");
-        return Response.json({
-          sameIdentity: req.headers === h,
-          viaGetter: req.headers.get("x-added-after"),
-          viaRef: h.get("x-added-after"),
-        });
-      },
-    });
-    await server.ready();
-
-    const res = await fetch(server.url!);
-    expect(await res.json()).toEqual({
-      sameIdentity: true,
-      viaGetter: "1",
-      viaRef: "1",
-    });
-    await server.close(true);
-  });
-
   // A synchronous send failure (e.g. an invalid header value hitting writeHead)
   // must be logged for diagnostics (unless silenced) and returned as a bare 500
   // without leaking details to the client.


### PR DESCRIPTION
## Summary

A batch of correctness fixes for the Node adapter, aligning its behavior with native `fetch`/`Response`/`Request` and with Deno/Bun. Each fix has a regression test in `test/node-adapters.test.ts`.

## Fixes

- **`req.text()` / `req.json()` reject instead of throwing.** Reading a body stream that's already locked or disturbed (e.g. something else consumed `req.body` directly) now returns a rejected promise, matching native `fetch`, instead of throwing synchronously.

- **`statusText` defaults to `""`, not Node's `"OK"`.** `NodeResponse` no longer looks up Node's `http.STATUS_CODES` table for a default reason phrase. It now matches native `Response`, Bun, and Deno, which all default to an empty string.

- **Empty-string response bodies get correct headers.** `new NodeResponse("")` previously skipped the `content-type: text/plain` and `content-length: 0` headers because `""` is falsy. Both are now set correctly, matching native `Response("")`.

- **HEAD responses no longer pump the body stream.** A streaming body attached to a HEAD response is now cancelled immediately instead of read to completion — previously an unbounded stream (e.g. SSE) would pump forever on a HEAD request. Matches Deno/Bun.

- **Send errors are now logged.** If sending a response fails synchronously (e.g. an invalid header), the error is now logged via `console.error` (unless the server was created with `silent: true`) instead of being swallowed. The client still just gets a bare 500.

- **Synthetic `IncomingMessage` now reports HTTP version and raw headers.** The Node-compat bridge used for legacy `(req, res)` handlers previously left `httpVersion`/`httpVersionMajor`/`httpVersionMinor` at their defaults and didn't populate `rawHeaders`, breaking things like morgan's `:http-version` token. These are now filled in, including proper `set-cookie` array handling. Because reporting HTTP/1.1 makes `ServerResponse` chunk-encode by default, the bridge's response is explicitly kept un-chunked so the raw captured body isn't corrupted by chunk framing.

- **Documented the `loader.ts` handler-detection heuristic.** No behavior change — added comments explaining how a bare `export default function` is disambiguated between a web `fetch` handler and a legacy Node handler (by parameter count), and the known edge cases where that guess is wrong.

- **Clarified `_request` / `_url` JSDoc.** `_request`'s doc incorrectly said it held "Node.js native instance of request" — it actually holds the web-standard `Request`. Fixed the wording.

Not included: a fix for `_request`/`headers` snapshot identity was attempted and reverted (`1754b02`) — it trades early-reference liveness for a frozen headers snapshot and needs its own discussion. Tracked separately in #245. Also out of scope: no `upgrade` listener support (documented limitation, not a regression from this PR).

## Testing

`pnpm test` (lint + typecheck + vitest --coverage) passes.
