### PR TITLE
docs: correct `onError` option to `error`

### DIFF
--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -155,13 +155,13 @@ Client certificates (mutual TLS) are available through the [`mtls()` plugin](/gu
 
 :read-more{to="/guide/tls" title="TLS & mutual TLS"}
 
-### `onError`
+### `error`
 
-Runtime agnostic error handler.
+Runtime agnostic error handler. It runs whenever the `fetch` handler (or any middleware) throws or rejects, and returns the `Response` to send instead.
 
 > [!NOTE]
 >
-> This handler will take over the built-in error handlers of Deno and Bun.
+> This handler will also take over the built-in error handlers of Deno and Bun.
 
 **Example:**
 
@@ -170,7 +170,7 @@ import { serve } from "srvx";
 
 serve({
   fetch: () => new Response("👋 Hello there!"),
-  onError(error) {
+  error(error) {
     return new Response(`<pre>${error}\n${error.stack}</pre>`, {
       headers: { "Content-Type": "text/html" },
     });
@@ -182,7 +182,7 @@ serve({
 
 Maximum allowed size **in bytes** for the request body. Defaults to `undefined` (no limit).
 
-As the body is read, its accumulated length is tracked and, once it exceeds the limit, reading is aborted and rejects with a `413`-style error. The error carries `statusCode: 413`, `status: 413` and `code: "ERR_BODY_TOO_LARGE"`, so a handler (or [`onError`](#onerror)) can map it to an HTTP `413 Payload Too Large` response.
+As the body is read, its accumulated length is tracked and, once it exceeds the limit, reading is aborted and rejects with a `413`-style error. The error carries `statusCode: 413`, `status: 413` and `code: "ERR_BODY_TOO_LARGE"`, so a handler (or [`error`](#error)) can map it to an HTTP `413 Payload Too Large` response.
 
 The limit covers both buffered reads (`request.text()` / `request.json()`) and the streamed body (`request.body`, and therefore `request.arrayBuffer()` / `.blob()` / `.bytes()` / `.formData()`).
 


### PR DESCRIPTION
## Summary
- Docs still referenced the old `onError` option name (heading, anchor link, and example); the actual srvx option is `error`.
- Cherry-picked just the doc correction from #230's F8, without the rest of that batch.

## Test plan
- [x] Doc-only change; visually diffed against #230's docs update to confirm parity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the generic server options guide to use `error` instead of `onError` for the error handler option.
  * Updated the request body size guidance to reference the renamed error handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->