### PR TITLE
fix(node/web): stream bridged responses, drop wire framing and hop-by-hop headers

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -44,10 +44,13 @@ export const NodeRequest: {
     #req: NodeServerRequest;
     #url?: URL;
     #bodyStream?: ReadableStream | null;
-    // Tracks body consumption at the srvx level so a second read rejects with
-    // `TypeError: Body is unusable` (like native fetch) instead of hanging on a
-    // re-listened, already-ended IncomingMessage, and so `bodyUsed` can be
-    // served without materializing a native Request over a disturbed stream.
+    // The fetch spec's "disturbed" bit, tracked at the srvx level: set by the
+    // buffered fast path (text()/json()) and by the first read/cancel of the
+    // stream `body` hands out. Every body read rejects with `TypeError: Body is
+    // unusable` once set (like native fetch) instead of hanging on a re-listened,
+    // already-ended IncomingMessage or resolving empty off the null-body Request
+    // that `_request` serves in this state. Also lets `bodyUsed` answer without
+    // materializing a native Request over a disturbed stream.
     #bodyUsed = false;
     #request?: globalThis.Request;
     #headers?: NodeRequestHeaders;
@@ -200,11 +203,22 @@ export const NodeRequest: {
             ? // TODO: HTTP2ServerRequest
               (Readable.toWeb(this.#req as NodeJS.ReadableStream) as unknown as ReadableStream)
             : null;
-        // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
-        // through (`request.body`, and therefore the native `Request` methods
-        // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
-        if (stream && this.#maxRequestBodySize !== undefined) {
-          stream = limitBodyStream(stream, this.#maxRequestBodySize);
+        if (stream) {
+          // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
+          // through (`request.body`, and therefore the native `Request` methods
+          // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
+          if (this.#maxRequestBodySize !== undefined) {
+            stream = limitBodyStream(stream, this.#maxRequestBodySize);
+          }
+          stream = trackDisturbed(stream, () => {
+            // Only while srvx still owns the body. Once `_request` holds it, undici
+            // owns the accounting and reports it per-Request: `clone()` tees this
+            // stream, so a pull here may be the *clone* being read, which must not
+            // mark this request's body used.
+            if (!this.#request) {
+              this.#bodyUsed = true;
+            }
+          });
         }
         this.#bodyStream = stream;
       }
@@ -280,6 +294,40 @@ export const NodeRequest: {
       return this.#readBuffered().then((buf) => JSON.parse(buf.toString()));
     }
 
+    arrayBuffer(): Promise<ArrayBuffer> {
+      return this.#consumeNative("arrayBuffer");
+    }
+
+    bytes(): Promise<Uint8Array<ArrayBuffer>> {
+      return this.#consumeNative("bytes");
+    }
+
+    blob(): Promise<Blob> {
+      return this.#consumeNative("blob");
+    }
+
+    formData(): Promise<FormData> {
+      return this.#consumeNative("formData");
+    }
+
+    // Unlike text()/json() these have no buffered fast path — they hand off to the
+    // native Request, which owns the accounting from there. The one case it cannot
+    // see is a body srvx already consumed: `_request` then serves a *null-body*
+    // Request (see `_request`), whose body is pristine, so undici's own
+    // "Body is unusable" guard never fires and the read resolves empty. Guard here.
+    #consumeNative(method: "arrayBuffer" | "bytes" | "blob" | "formData"): Promise<any> {
+      if (this.#bodyUsed) {
+        return Promise.reject(bodyUnusable());
+      }
+      try {
+        return this._request[method]();
+      } catch (error) {
+        // Materializing `_request` throws synchronously if the body stream is
+        // locked (a consumer holds a reader). Reject like native fetch.
+        return Promise.reject(error);
+      }
+    }
+
     get _request(): globalThis.Request {
       if (!this.#request) {
         // If the body was already consumed via the buffered/stream fast path the
@@ -311,6 +359,39 @@ export const NodeRequest: {
 
   return Request as any;
 })();
+
+/**
+ * Wraps a body stream so `onDisturb` fires the first time it is read or cancelled.
+ *
+ * `request.body` is handed straight to the consumer, so reading it bypasses the
+ * `#bodyUsed` flag that `text()` / `json()` set. A `ReadableStream` doesn't expose
+ * the fetch spec's "disturbed" bit, so observing it means wrapping.
+ *
+ * `highWaterMark: 0` is what keeps this honest: with the default of 1 the stream
+ * would pull a chunk as soon as it is constructed, marking a body as used merely
+ * because a handler touched `request.body`.
+ */
+function trackDisturbed(stream: ReadableStream, onDisturb: () => void): ReadableStream {
+  const reader = stream.getReader();
+  return new ReadableStream(
+    {
+      async pull(controller) {
+        onDisturb();
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      },
+      cancel(reason) {
+        onDisturb();
+        return reader.cancel(reason);
+      },
+    },
+    { highWaterMark: 0 },
+  );
+}
 
 /**
  * Undici uses an incompatible Request constructor depending on private property accessors.

--- a/src/adapters/_node/web/fetch.ts
+++ b/src/adapters/_node/web/fetch.ts
@@ -16,7 +16,7 @@ import { WebServerResponse } from "./response.ts";
  *
  * Otherwise, new Node.js IncomingMessage and ServerResponse objects are created and linked to a custom Duplex stream that bridges the Fetch API streams with Node.js streams.
  *
- * The handler is invoked with these objects, and the response is constructed from the ServerResponse once it is finished.
+ * The handler is invoked with these objects, and the response is constructed from the ServerResponse as soon as its head is available, with the body streaming as the handler writes it.
  *
  * @experimental Behavior might be unstable.
  */
@@ -36,22 +36,43 @@ export async function fetchNodeHandler(
   const nodeReq = new WebIncomingMessage(req, socket);
   const nodeRes = new WebServerResponse(nodeReq, socket);
 
+  const handlerPromise = (async () => handler(nodeReq as any, nodeRes as any))();
+
+  // Once the head is out a 500 is no longer possible, so a late handler failure
+  // can only be surfaced by tearing down the socket, which errors the body
+  // stream the consumer is reading. Before the head, the race below turns the
+  // same failure into a 500 and this is a no-op.
+  handlerPromise.catch((error) => {
+    if (nodeRes.headersSent) {
+      logError(error, req, handler);
+      socket.destroy(error);
+    }
+  });
+
   try {
-    await handler(nodeReq as any, nodeRes as any);
+    // Waiting for the handler to *finish* would hold the response back until the
+    // body is complete: buffering large ones in full and never resolving for an
+    // endless one (SSE). The head is enough to build the Response and stream the
+    // rest. See https://github.com/h3js/srvx/issues/248
+    await Promise.race([handlerPromise, nodeRes.waitForHead()]);
     return await nodeRes.toWebResponse();
   } catch (error: any) {
-    // Client aborts / premature socket closes are routine (the client is already
-    // gone), so don't log them as errors. See https://github.com/h3js/srvx/issues/208
-    const aborted =
-      req.signal?.aborted ||
-      error?.name === "AbortError" ||
-      error?.code === "ERR_STREAM_PREMATURE_CLOSE";
-    if (!aborted) {
-      console.error(error, { cause: { req, handler } });
-    }
+    logError(error, req, handler);
     return new Response(null, {
       status: 500,
       statusText: "Internal Server Error",
     });
+  }
+}
+
+function logError(error: any, req: ServerRequest, handler: NodeHttpHandler): void {
+  // Client aborts / premature socket closes are routine (the client is already
+  // gone), so don't log them as errors. See https://github.com/h3js/srvx/issues/208
+  const aborted =
+    req.signal?.aborted ||
+    error?.name === "AbortError" ||
+    error?.code === "ERR_STREAM_PREMATURE_CLOSE";
+  if (!aborted) {
+    console.error(error, { cause: { req, handler } });
   }
 }

--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -19,20 +19,67 @@ function getNeedDrainSymbol(res: ServerResponse): symbol | null {
 // Statuses that must not carry a response body per the Fetch/HTTP spec.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
+// Connection-level headers describing the synthetic wire this response is
+// written to, not the application response itself. Leaking them into the web
+// `Response` breaks the next hop: `connection: close` disables keep-alive for
+// every bridged response re-served over HTTP/1 and prints an UnsupportedWarning
+// per request over HTTP/2, and `transfer-encoding` mislabels a body that is
+// never chunk-framed here. https://datatracker.ietf.org/doc/html/rfc9110#section-7.6.1
+const HOP_BY_HOP_HEADERS = new Set(["connection", "keep-alive", "transfer-encoding", "upgrade"]);
+
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
   #socketError?: Error;
+
+  // Settles once the response head is stored (see the `_storeHeader` patch
+  // below), rejects if the socket dies before that.
+  #headPromise: Promise<void>;
+  #settleHead!: (error?: Error) => void;
 
   constructor(req: WebIncomingMessage, socket: WebRequestSocket) {
     super(req);
     this.assignSocket(socket);
 
+    this.#headPromise = new Promise<void>((resolve, reject) => {
+      this.#settleHead = (error) => (error ? reject(error) : resolve());
+    });
+    // The head can be rejected with nothing awaiting it yet (e.g. the caller
+    // already bailed out on a handler error), which would otherwise take the
+    // process down as an unhandled rejection. Awaiters still see the rejection.
+    this.#headPromise.catch(() => {});
+
+    // `_storeHeader` is where Node serializes the status line and headers into
+    // `_header` — the single funnel for both explicit `writeHead()` and implicit
+    // (first `write()`/`end()`) heads. It is patched as an own property rather
+    // than overridden on the prototype because Express re-parents the response
+    // object, which would drop a prototype override off the chain.
+    const storeHeader = (ServerResponse.prototype as any)._storeHeader;
+    (this as any)._storeHeader = (firstLine: string, headers: unknown) => {
+      storeHeader.call(this, firstLine, headers);
+
+      // A handler setting `transfer-encoding: chunked` explicitly re-enables the
+      // chunk framing that `useChunkedEncodingByDefault = false` turned off,
+      // which corrupts the captured body (the framing bytes land *inside* it).
+      // Nothing here is written to a real wire, so never frame; the header
+      // itself is dropped from the web `Response` as hop-by-hop below.
+      this.chunkedEncoding = false;
+
+      // The head is complete and frozen from here on (`headersSent` is true), so
+      // the web `Response` can be built while the handler is still writing.
+      this.#settleHead();
+    };
+
     // `super(req)` enables chunked transfer-encoding by default because the
     // synthetic request now reports HTTP/1.1. But this response isn't written to
-    // a real wire: `toWebResponse()` captures the raw body buffer from the
-    // bridging socket and re-wraps it in a web `Response`. Chunk framing would
-    // corrupt that captured body, so keep the output un-chunked (close-delimited).
+    // a real wire: `toWebResponse()` re-wraps the body written to the bridging
+    // socket in a web `Response`. Chunk framing would corrupt that body, so keep
+    // the output un-chunked (close-delimited).
     this.useChunkedEncodingByDefault = false;
+
+    // Node stamps a `Date` for the synthetic wire; that is the serving hop's job
+    // (and it re-stamps one), so don't synthesize it here. A `Date` the handler
+    // sets explicitly is still passed through.
+    this.sendDate = false;
 
     this.once("finish", () => {
       socket.end();
@@ -44,9 +91,17 @@ export class WebServerResponse extends ServerResponse {
     // an AbortError) and emits "error"/"close" without the ServerResponse ever
     // emitting "finish" or "error". Attach this listener synchronously so the
     // socket error is consumed (instead of crashing the process as an unhandled
-    // "error" event) and recorded for waitToFinish() to settle on.
+    // "error" event) and recorded to settle the head waiters on.
     socket.once("error", (err) => {
       this.#socketError ??= err;
+      this.#settleHead(err);
+    });
+
+    // A socket that dies before the head is stored will never produce one, and
+    // the response emits neither "finish" nor "error" — settle the head waiters
+    // instead of hanging them. No-op once the head is stored.
+    socket.once("close", () => {
+      this.#settleHead(this.#socketError ?? prematureCloseError());
     });
 
     // Forward socket "drain" events to the response. Node's HTTP server does
@@ -68,50 +123,24 @@ export class WebServerResponse extends ServerResponse {
     });
 
     // Express can override prototype so we have to bind methods
-    this.waitToFinish = this.waitToFinish.bind(this);
+    this.waitForHead = this.waitForHead.bind(this);
     this.toWebResponse = this.toWebResponse.bind(this);
   }
 
-  waitToFinish(): Promise<void> {
-    if (this.writableFinished) {
-      return Promise.resolve();
-    }
-    // The socket is destroyed before the response finished flushing (e.g. the
-    // client aborted). `writableEnded` may still be true (end() was called) but
-    // the response will never emit "finish", so resolving here would hand back a
-    // body stream that never closes. Reject instead.
-    if (this.#socketError || this.#socket.destroyed) {
-      return Promise.reject(this.#socketError ?? prematureCloseError());
-    }
-    if (this.writableEnded) {
-      return Promise.resolve();
-    }
-    return new Promise<void>((resolve, reject) => {
-      const socket = this.#socket;
-      const settle = (err?: Error) => {
-        this.removeListener("finish", onFinish);
-        this.removeListener("error", onError);
-        socket.removeListener("error", onError);
-        socket.removeListener("close", onClose);
-        if (err) reject(err);
-        else resolve();
-      };
-      const onFinish = () => settle();
-      const onError = (err: Error) => settle(err);
-      const onClose = () => {
-        if (!this.writableFinished) {
-          settle(this.#socketError ?? prematureCloseError());
-        }
-      };
-      this.on("finish", onFinish);
-      this.on("error", onError);
-      socket.on("error", onError);
-      socket.on("close", onClose);
-    });
+  /**
+   * Resolves as soon as the response head (status + headers) is known — i.e. on
+   * `writeHead()` or the first `write()`/`end()` — without waiting for the body,
+   * so it can be streamed. Rejects if the socket dies before a head is stored.
+   */
+  waitForHead(): Promise<void> {
+    return this.#headPromise;
   }
 
   async toWebResponse(): Promise<Response> {
-    await this.waitToFinish();
+    // Only the head is awaited: the body streams out of the bridging socket as
+    // the handler writes it. Waiting for the response to finish would buffer
+    // every body in full and never resolve at all for an endless one (SSE).
+    await this.#headPromise;
 
     const headers: [string, string][] = [];
 
@@ -122,7 +151,7 @@ export class WebServerResponse extends ServerResponse {
       if (sepIndex === -1) continue;
       const key = httpHeader[i].slice(0, Math.max(0, sepIndex));
       const value = httpHeader[i].slice(Math.max(0, sepIndex + 2));
-      if (!key) continue;
+      if (!key || HOP_BY_HOP_HEADERS.has(key.toLowerCase())) continue;
       headers.push([key, value]);
     }
 

--- a/src/adapters/_node/web/socket.ts
+++ b/src/adapters/_node/web/socket.ts
@@ -43,6 +43,7 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
   #_writeBody!: (chunk: Uint8Array) => void;
   #resBodyController?: ReadableStreamDefaultController<Uint8Array>;
   #resBodyClosed?: boolean;
+  #resumeWrite?: () => void;
   _webResBody: ReadableStream;
   #tos: number = 0;
 
@@ -53,17 +54,38 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
 
     this.#request = request;
 
-    this._webResBody = new ReadableStream({
-      start: (controller) => {
-        this.#resBodyController = controller;
-        this.#_writeBody = controller.enqueue.bind(controller);
-        this.once("finish", () => {
-          this.readyState = "closed";
+    this._webResBody = new ReadableStream<Uint8Array>(
+      {
+        start: (controller) => {
+          this.#resBodyController = controller;
+          this.#_writeBody = controller.enqueue.bind(controller);
+          this.once("finish", () => {
+            this.readyState = "closed";
+            this.#resBodyClosed = true;
+            controller.close();
+          });
+        },
+        // The body is handed to the consumer while the handler is still writing
+        // it (see `toWebResponse()`), so writes park once the queue is full and
+        // resume from here. Without this a handler piping a large file outruns
+        // the consumer and the whole body piles up in the queue.
+        pull: () => {
+          const resume = this.#resumeWrite;
+          this.#resumeWrite = undefined;
+          resume?.();
+        },
+        // The consumer dropped the body (e.g. a HEAD response, or it went away).
+        // Tear down the socket so the handler stops writing into a stream that
+        // can no longer take chunks, instead of throwing on a closed controller.
+        cancel: (reason) => {
           this.#resBodyClosed = true;
-          controller.close();
-        });
+          this.destroy(reason instanceof Error ? reason : undefined);
+        },
       },
-    });
+      // Buffer by bytes like a socket would, rather than the default count-based
+      // strategy, which caps the queue at a single chunk of any size.
+      { highWaterMark: 64 * 1024, size: (chunk) => chunk?.byteLength ?? 0 },
+    );
 
     // Wire request abort handling *after* `super()` so the subclass private
     // fields are initialized before any synchronous `destroy()`. Passing the
@@ -166,7 +188,19 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
     callback: (error?: Error | null) => void,
   ): void {
     if (this.#headersWritten) {
+      // The consumer cancelled the body; drop the rest rather than enqueue onto
+      // a closed controller (which throws). The socket is being torn down.
+      if (this.#resBodyClosed) {
+        callback(null);
+        return;
+      }
       this.#_writeBody(typeof chunk === "string" ? Buffer.from(chunk, encoding) : chunk);
+      // Queue is over its limit: hold the write open so `res.write()` reports
+      // backpressure to the handler until the consumer reads (see `pull` above).
+      if ((this.#resBodyController!.desiredSize ?? 1) <= 0) {
+        this.#resumeWrite = () => callback(null);
+        return;
+      }
     } else if (chunk?.length > 0) {
       this.#headersWritten = true;
       const headerEnd = chunk.indexOf("\r\n\r\n");
@@ -191,6 +225,11 @@ export class WebRequestSocket extends Duplex implements NodeSocket {
     if (this.#timeoutTimer) {
       clearTimeout(this.#timeoutTimer);
     }
+    // Drop a write parked on body backpressure without calling it back: the
+    // socket is gone, so completing the write would push data into a destroyed
+    // stream. A handler blocked on it learns from the response's "close"/"error"
+    // event, exactly as it would on a real socket torn down mid-write.
+    this.#resumeWrite = undefined;
     if (this.#reqReader) {
       this.#reqReader.cancel().catch((error) => {
         console.error(error);

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -1068,6 +1068,232 @@ describe("node fetch-spec correctness regressions", () => {
   });
 });
 
+// The node->web bridge treated the captured wire bytes/headers of the synthetic
+// ServerResponse as if they were the application's body/headers.
+// https://github.com/h3js/srvx/issues/248
+describe("node->web bridge", () => {
+  const timeout = <T>(value: T, ms = 3000) =>
+    new Promise<T>((resolve) => setTimeout(() => resolve(value), ms));
+
+  const settle = <T>(promise: Promise<T>) =>
+    Promise.race([
+      promise.then(
+        () => "completed" as const,
+        () => "errored" as const,
+      ),
+      timeout("hung" as const),
+    ]);
+
+  // An explicit `transfer-encoding: chunked` re-enabled the chunk framing that
+  // `useChunkedEncodingByDefault = false` turns off, and the framing bytes ended
+  // up inside the captured body ("5\r\nhello\r\n5\r\nworld\r\n0\r\n\r\n").
+  test("explicit transfer-encoding: chunked does not frame the body", async () => {
+    const handler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(200, { "transfer-encoding": "chunked" });
+      res.write("hello");
+      res.end("world");
+    };
+    const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+    expect(await res.text()).toBe("helloworld");
+    // The body is not chunk-framed, so the header must not claim it is.
+    expect(res.headers.get("transfer-encoding")).toBe(null);
+  });
+
+  // Hop-by-hop headers Node generated for the synthetic wire were copied out of
+  // `_header` verbatim. `connection: close` on every bridged response disables
+  // keep-alive over HTTP/1 and warns per-request over HTTP/2.
+  test("hop-by-hop headers do not leak into the web Response", async () => {
+    const handler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain", "x-app": "1" });
+      res.end("ok");
+    };
+    const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+    const names = [...res.headers.keys()];
+    expect(names).not.toContain("connection");
+    expect(names).not.toContain("keep-alive");
+    expect(names).not.toContain("transfer-encoding");
+    expect(names).not.toContain("upgrade");
+    // Node's synthetic Date is the serving hop's business, not the app's.
+    expect(names).not.toContain("date");
+    // Application headers still pass through.
+    expect(res.headers.get("content-type")).toBe("text/plain");
+    expect(res.headers.get("x-app")).toBe("1");
+  });
+
+  test("a Date set by the handler is still passed through", async () => {
+    const date = "Mon, 01 Jan 2024 00:00:00 GMT";
+    const handler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(200, { date });
+      res.end("ok");
+    };
+    const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+    expect(res.headers.get("date")).toBe(date);
+  });
+
+  // The leaked `connection: close` was written straight through by serve(), so
+  // every bridged response hung up the connection it was served on.
+  test("a bridged response served by srvx does not kill keep-alive", async () => {
+    const handler: NodeHttp1Handler = (_req, res) => {
+      // No content-length, so the synthetic response is close-delimited — which
+      // is exactly when Node generates `connection: close` for the bridge.
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    };
+    const server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      // A plain web Request carries no `runtime.node`, so this goes through the
+      // bridge rather than the direct pass-through path.
+      fetch: (req) => fetchNodeHandler(handler, new Request(req.url) as any),
+    });
+    await server.ready();
+    const u = new URL(server.url!);
+
+    // Two pipelined requests on one socket.
+    const raw = await rawExchange(
+      Number(u.port),
+      u.hostname,
+      `GET /one HTTP/1.1\r\nHost: ${u.hostname}\r\n\r\n` +
+        `GET /two HTTP/1.1\r\nHost: ${u.hostname}\r\nConnection: close\r\n\r\n`,
+    );
+    const text = raw.toString();
+
+    // Both are answered on the one connection; with the leak the server hangs up
+    // after the first and the second request is never answered.
+    expect(text.match(/HTTP\/1\.1 200/g) ?? []).toHaveLength(2);
+    // (the second response closes legitimately — the client asked it to)
+    const [firstHead] = text.split("\r\n\r\n");
+    expect(firstHead).not.toMatch(/connection:\s*close/i);
+    await server.close(true);
+  });
+
+  // toWebResponse() awaited res.end(), so an SSE handler never resolved at all
+  // and every other body was buffered whole before the Response existed.
+  test("an endless SSE response resolves and streams incrementally", async () => {
+    let push!: (data: string) => void;
+    const handler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: 1\n\n");
+      push = (data) => void res.write(data);
+      // typical SSE: never ends
+    };
+
+    const res = await Promise.race([
+      toFetchHandler(handler)(new Request("http://localhost/")),
+      timeout(undefined),
+    ]);
+    expect(res, "the response must not wait for res.end()").toBeDefined();
+    expect(res!.headers.get("content-type")).toBe("text/event-stream");
+
+    const reader = res!.body!.getReader();
+    const read = async () => new TextDecoder().decode((await reader.read()).value);
+    expect(await read()).toBe("data: 1\n\n");
+    // Events written later arrive without the response ever ending.
+    push("data: 2\n\n");
+    expect(await read()).toBe("data: 2\n\n");
+    await reader.cancel();
+  });
+
+  // A fast producer (e.g. static file middleware) used to accumulate the entire
+  // body in the response stream's queue regardless of how fast it was read.
+  test("a fast producer is throttled by the consumer instead of buffering", async () => {
+    const chunkSize = 64 * 1024;
+    const chunk = "x".repeat(chunkSize);
+    const totalChunks = 64;
+    let written = 0;
+
+    const handler: NodeHttp1Handler = (_req, res) => {
+      return (async () => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        for (let i = 0; i < totalChunks; i++) {
+          written++;
+          if (!res.write(chunk)) {
+            await new Promise<void>((resolve) => res.once("drain", () => resolve()));
+          }
+        }
+        res.end();
+      })();
+    };
+
+    const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+    // Let an unthrottled producer race ahead while nothing reads the body.
+    await new Promise((r) => setTimeout(r, 100));
+    const writtenBeforeReading = written;
+
+    // The whole body still arrives once it is read.
+    const body = await Promise.race([res.arrayBuffer(), timeout(undefined)]);
+    expect(body?.byteLength).toBe(chunkSize * totalChunks);
+    // The producer parked on backpressure instead of queueing everything.
+    // (Without the fix this equals totalChunks.)
+    expect(writtenBeforeReading).toBeLessThan(totalChunks / 2);
+  });
+
+  test("cancelling the response body tears down the handler's response", async () => {
+    let onClose!: () => void;
+    const closed = new Promise<void>((resolve) => (onClose = resolve));
+    const handler: NodeHttp1Handler = (_req, res) => {
+      return new Promise<void>((resolve) => {
+        res.on("error", () => {}); // teardown mid-write is expected here
+        res.on("close", () => {
+          onClose();
+          resolve();
+        });
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.write("first");
+      });
+    };
+
+    const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+    await res.body!.cancel();
+
+    expect(await Promise.race([closed.then(() => "closed"), timeout("hung")])).toBe("closed");
+  });
+
+  // Once the head is out a 500 is impossible, so the failure has to surface on
+  // the body stream — without an unhandled rejection taking the process down.
+  test("a handler failing after the head errors the body stream", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (error: unknown) => rejections.push(error);
+    process.on("unhandledRejection", onRejection);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const handler: NodeHttp1Handler = (_req, res) => {
+      return (async () => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.write("partial");
+        await new Promise((r) => setTimeout(r, 10));
+        throw new Error("boom");
+      })();
+    };
+
+    try {
+      const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+      expect(res.status).toBe(200); // the head was already committed
+      expect(await settle(res.text())).toBe("errored");
+      await new Promise((r) => setTimeout(r, 50));
+      expect(rejections).toHaveLength(0);
+      expect(errorSpy).toHaveBeenCalled(); // logged for diagnostics
+    } finally {
+      process.off("unhandledRejection", onRejection);
+      errorSpy.mockRestore();
+    }
+  });
+
+  test("a handler failing before the head is still a 500", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler: NodeHttp1Handler = async () => {
+      throw new Error("boom");
+    };
+    const res = await Promise.race([
+      toFetchHandler(handler)(new Request("http://localhost/")),
+      timeout(undefined),
+    ]);
+    expect(res?.status).toBe(500);
+    expect(await res?.text()).toBe("");
+    errorSpy.mockRestore();
+  });
+});
+
 // Raw HTTP/1.1 helpers: write `payload`, collect every byte until the server
 // closes the connection (driven by a `Connection: close` on the last request).
 function rawExchange(port: number, host: string, payload: string): Promise<Buffer> {

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -682,6 +682,154 @@ describe("node body crash regressions", () => {
     await server.close(true);
   });
 
+  // https://github.com/h3js/srvx/issues/247
+  // Only text()/json() guarded against a second read. The rest of the body
+  // methods are inherited from the native Request, which `_request` hands a
+  // *null* body once srvx has consumed the real one — so undici's own guard saw
+  // a pristine body and they resolved empty, silently masking double-read bugs
+  // that throw on every other runtime.
+  test("every body method rejects after the body is consumed", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        await req.text();
+        const outcomes: Record<string, string> = { bodyUsed: String(req.bodyUsed) };
+        for (const method of [
+          "arrayBuffer",
+          "bytes",
+          "blob",
+          "formData",
+          "text",
+          "json",
+        ] as const) {
+          outcomes[method] = await (req[method]() as Promise<unknown>).then(
+            () => "resolved",
+            (error) =>
+              error instanceof TypeError && /unusable/.test(error.message)
+                ? "TypeError: unusable"
+                : `other: ${error}`,
+          );
+        }
+        return Response.json(outcomes);
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({
+      bodyUsed: "true",
+      arrayBuffer: "TypeError: unusable",
+      bytes: "TypeError: unusable",
+      blob: "TypeError: unusable",
+      formData: "TypeError: unusable",
+      text: "TypeError: unusable",
+      json: "TypeError: unusable",
+    });
+    await server.close(true);
+  });
+
+  // https://github.com/h3js/srvx/issues/247 (related)
+  // Draining `req.body` never flipped `bodyUsed`, so a later read still looked
+  // like a first read: it reached the `_request` getter, which threw
+  // "... disturbed or locked" *synchronously* out of the handler.
+  test("streaming the body directly marks it used and rejects later reads", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        let streamed = "";
+        for await (const chunk of req.body!) {
+          streamed += new TextDecoder().decode(chunk as Uint8Array);
+        }
+        return Response.json({
+          streamed,
+          bodyUsed: req.bodyUsed,
+          arrayBuffer: await req.arrayBuffer().then(
+            () => "resolved",
+            (error) => (error instanceof TypeError ? "TypeError" : `other: ${error}`),
+          ),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({
+      streamed: "hello",
+      bodyUsed: true,
+      arrayBuffer: "TypeError",
+    });
+    await server.close(true);
+  });
+
+  // The flip side of the above: `bodyUsed` tracks the spec's "disturbed" bit, so
+  // merely *touching* `request.body` must not consume it. Guards the body
+  // stream's `highWaterMark: 0` — with a read-ahead buffer it would pull a chunk
+  // on construction and mark an untouched body as used.
+  test("accessing req.body without reading it does not mark the body used", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const hasBody = req.body !== null;
+        const bodyUsed = req.bodyUsed;
+        // The body is undisturbed, so a buffered read must still work.
+        return Response.json({ hasBody, bodyUsed, text: await req.text() });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({ hasBody: true, bodyUsed: false, text: "hello" });
+    await server.close(true);
+  });
+
+  // `clone()` tees the body, so reading the clone must leave the original
+  // readable — the "disturbed" tracking on the underlying stream must not
+  // mistake a pull driven by the clone for a read of this request's body.
+  test("reading a clone leaves the original body readable", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const fromClone = await req.clone().text();
+        return Response.json({
+          fromClone,
+          fromOriginal: await req.text().then(
+            (text) => `resolved(${text})`,
+            (error) => `${error}`,
+          ),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({ fromClone: "hello", fromOriginal: "resolved(hello)" });
+    await server.close(true);
+  });
+
+  // The native Request owns the accounting once it holds the real body: a first
+  // arrayBuffer() must read it, and only the second read rejects.
+  test("arrayBuffer() reads the body once and rejects on a second read", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const first = new TextDecoder().decode(await req.arrayBuffer());
+        return Response.json({
+          first,
+          bodyUsed: req.bodyUsed,
+          second: await req.arrayBuffer().then(
+            () => "resolved",
+            (error) => (error instanceof TypeError ? "TypeError" : `other: ${error}`),
+          ),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({ first: "hello", bodyUsed: true, second: "TypeError" });
+    await server.close(true);
+  });
+
   // GET/HEAD are always null-body per the fetch spec, regardless of what was on
   // the wire and regardless of property-access order.
   for (const order of ["text-first", "body-first"] as const) {


### PR DESCRIPTION
Fixes #248.

All three issues share the root cause from the issue: `toWebResponse()` treated the captured wire bytes and wire headers of the synthetic `ServerResponse` as if they were the application's body and headers, and waited for the response to *finish* before handing one back.

### 1. Explicit `transfer-encoding: chunked` corrupts the body

`useChunkedEncodingByDefault = false` only covers the default — setting the header explicitly re-enabled framing, and the framing bytes landed *inside* the body. Now `chunkedEncoding` is forced back to `false` once the head is stored, so nothing is ever framed for a wire that isn't real. The `transfer-encoding` header is dropped as hop-by-hop, so the body and its framing header agree.

### 2. Hop-by-hop headers leak

`connection`, `keep-alive`, `transfer-encoding` and `upgrade` are now filtered out of the head parse. Node's synthetic `Date` is no longer generated either (`sendDate = false`) — stamping it is the serving hop's job, and it re-stamps one. A `Date` the handler sets explicitly still passes through.

I confirmed the consequence you predicted, with one wrinkle worth recording: it only reproduces through the **bridge** path. `serve({ fetch: (req) => fetchNodeHandler(handler, req) })` passes srvx's own request straight through to `callNodeHandler` (`req.runtime.node` is set), so it never builds a synthetic response. Forcing the bridge with a plain `Request`, two pipelined requests on one socket:

```
# before — connection: close leaked to the wire, server hung up after #1
"HTTP/1.1 200 OK\r\nconnection: close\r\n...\r\n\r\n2\r\nok\r\n0\r\n\r\n"   (1 response)

# after
"HTTP/1.1 200 OK\r\n...Connection: keep-alive\r\nKeep-Alive: timeout=5..."   (2 responses)
```

Also worth noting: with a `content-length` the leak is `connection: keep-alive` instead, which *overrode a client's `Connection: close`* request. Same fix covers it.

### 3. Full buffering breaks streaming/SSE

The `Response` now resolves as soon as the head is stored — on `writeHead()` or the first `write()` — and the body streams as the handler writes it. `fetchNodeHandler` no longer awaits the handler before building the response; it races the handler against the head, so a handler that fails *before* the head is still a 500. Once the head is out a 500 is impossible, so a late failure tears the socket down and errors the body stream rather than hanging.

Writes now park on the consumer's backpressure (`pull`) instead of queueing unbounded, so a handler piping a large file can't outrun its reader — this is what makes "large payloads buffer fully in memory" actually go away rather than just move. Cancelling the body tears the response down instead of throwing on a closed controller (newly reachable now that consumers get the body early).

Express SSE through `toFetchHandler`, served over a real socket:

```
[sse] response headers after 26 ms, status 200
  event 1 at +26ms: "data: 1"
  event 2 at +45ms: "data: 2"
  event 3 at +66ms: "data: 3"
```

### Notes for review

- The head is settled from an **own-property patch of `_storeHeader`** rather than a prototype override: it's the single funnel for both explicit `writeHead()` and implicit heads, and an own property survives Express's `Object.setPrototypeOf` re-parenting (the same reason the existing methods are bound in the constructor). The existing express fixture proves this — its head can only settle via that patch.
- **`waitToFinish()` is removed.** `toWebResponse()` was its only caller and the class isn't exported; its socket-error/premature-close semantics moved into the head promise. Happy to keep it if you'd rather.
- 9 tests added; 7 fail on the current source with exactly the issue's symptoms (chunk framing in the body, `connection` in the headers, SSE never resolving, 64/64 chunks buffered, cancel, late failure), 2 are guards for behavior that must not break (explicit `Date` passes through, pre-head failure is still a 500).
- Full suite green on top of #247 (1031 passed), lint/format/typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request body consumption behavior, including accurate `bodyUsed` tracking and standard errors for repeated reads.
  * Fixed response streaming to support incremental delivery, backpressure, cancellation, and connection reuse.
  * Prevented internal connection headers from appearing in bridged web responses.
  * Improved handling of errors occurring before or after response headers are sent.

* **Tests**
  * Added coverage for request body usage, cloning, streaming, SSE delivery, cancellation, backpressure, headers, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->