### PR TITLE
fix(node): reject body reads after the body is consumed

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -5,7 +5,7 @@ import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
 import { createBodyTooLargeError, limitBodyStream } from "../../_body-limit.ts";
-import { isDisturbed, Readable } from "node:stream";
+import { Readable } from "node:stream";
 
 export type NodeRequestContext = {
   req: NodeServerRequest;
@@ -229,12 +229,17 @@ export const NodeRequest: {
     // (text()/json()); a consumer reading or cancelling the stream `body` handed
     // out bypasses it, so consult the stream's own disturbed bit via
     // `isDisturbed` (the same primitive undici's guards use — a `ReadableStream`
-    // doesn't expose it) and latch the answer. Latching matters: `_request`
-    // calls this *before* releasing `#bodyStream` to the native Request, past
-    // which undici owns the accounting — its tee reads this stream on `clone()`,
-    // which must not count as a read of this request's body.
+    // doesn't expose it; the `Readable` static alias is used because `@types/node`
+    // doesn't declare the module-level export) and latch the answer. Latching
+    // matters: `_request` calls this *before* releasing `#bodyStream` to the
+    // native Request, past which undici owns the accounting — its tee reads this
+    // stream on `clone()`, which must not count as a read of this request's body.
     #isBodyUsed(): boolean {
-      if (!this.#bodyUsed && this.#bodyStream && isDisturbed(this.#bodyStream)) {
+      if (
+        !this.#bodyUsed &&
+        this.#bodyStream &&
+        Readable.isDisturbed(this.#bodyStream as unknown as NodeJS.ReadableStream)
+      ) {
         this.#bodyUsed = true;
       }
       return this.#bodyUsed;

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -44,10 +44,13 @@ export const NodeRequest: {
     #req: NodeServerRequest;
     #url?: URL;
     #bodyStream?: ReadableStream | null;
-    // Tracks body consumption at the srvx level so a second read rejects with
-    // `TypeError: Body is unusable` (like native fetch) instead of hanging on a
-    // re-listened, already-ended IncomingMessage, and so `bodyUsed` can be
-    // served without materializing a native Request over a disturbed stream.
+    // The fetch spec's "disturbed" bit, tracked at the srvx level: set by the
+    // buffered fast path (text()/json()) and by the first read/cancel of the
+    // stream `body` hands out. Every body read rejects with `TypeError: Body is
+    // unusable` once set (like native fetch) instead of hanging on a re-listened,
+    // already-ended IncomingMessage or resolving empty off the null-body Request
+    // that `_request` serves in this state. Also lets `bodyUsed` answer without
+    // materializing a native Request over a disturbed stream.
     #bodyUsed = false;
     #request?: globalThis.Request;
     #headers?: NodeRequestHeaders;
@@ -200,11 +203,22 @@ export const NodeRequest: {
             ? // TODO: HTTP2ServerRequest
               (Readable.toWeb(this.#req as NodeJS.ReadableStream) as unknown as ReadableStream)
             : null;
-        // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
-        // through (`request.body`, and therefore the native `Request` methods
-        // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
-        if (stream && this.#maxRequestBodySize !== undefined) {
-          stream = limitBodyStream(stream, this.#maxRequestBodySize);
+        if (stream) {
+          // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
+          // through (`request.body`, and therefore the native `Request` methods
+          // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
+          if (this.#maxRequestBodySize !== undefined) {
+            stream = limitBodyStream(stream, this.#maxRequestBodySize);
+          }
+          stream = trackDisturbed(stream, () => {
+            // Only while srvx still owns the body. Once `_request` holds it, undici
+            // owns the accounting and reports it per-Request: `clone()` tees this
+            // stream, so a pull here may be the *clone* being read, which must not
+            // mark this request's body used.
+            if (!this.#request) {
+              this.#bodyUsed = true;
+            }
+          });
         }
         this.#bodyStream = stream;
       }
@@ -280,6 +294,40 @@ export const NodeRequest: {
       return this.#readBuffered().then((buf) => JSON.parse(buf.toString()));
     }
 
+    arrayBuffer(): Promise<ArrayBuffer> {
+      return this.#consumeNative("arrayBuffer");
+    }
+
+    bytes(): Promise<Uint8Array<ArrayBuffer>> {
+      return this.#consumeNative("bytes");
+    }
+
+    blob(): Promise<Blob> {
+      return this.#consumeNative("blob");
+    }
+
+    formData(): Promise<FormData> {
+      return this.#consumeNative("formData");
+    }
+
+    // Unlike text()/json() these have no buffered fast path — they hand off to the
+    // native Request, which owns the accounting from there. The one case it cannot
+    // see is a body srvx already consumed: `_request` then serves a *null-body*
+    // Request (see `_request`), whose body is pristine, so undici's own
+    // "Body is unusable" guard never fires and the read resolves empty. Guard here.
+    #consumeNative(method: "arrayBuffer" | "bytes" | "blob" | "formData"): Promise<any> {
+      if (this.#bodyUsed) {
+        return Promise.reject(bodyUnusable());
+      }
+      try {
+        return this._request[method]();
+      } catch (error) {
+        // Materializing `_request` throws synchronously if the body stream is
+        // locked (a consumer holds a reader). Reject like native fetch.
+        return Promise.reject(error);
+      }
+    }
+
     get _request(): globalThis.Request {
       if (!this.#request) {
         // If the body was already consumed via the buffered/stream fast path the
@@ -311,6 +359,39 @@ export const NodeRequest: {
 
   return Request as any;
 })();
+
+/**
+ * Wraps a body stream so `onDisturb` fires the first time it is read or cancelled.
+ *
+ * `request.body` is handed straight to the consumer, so reading it bypasses the
+ * `#bodyUsed` flag that `text()` / `json()` set. A `ReadableStream` doesn't expose
+ * the fetch spec's "disturbed" bit, so observing it means wrapping.
+ *
+ * `highWaterMark: 0` is what keeps this honest: with the default of 1 the stream
+ * would pull a chunk as soon as it is constructed, marking a body as used merely
+ * because a handler touched `request.body`.
+ */
+function trackDisturbed(stream: ReadableStream, onDisturb: () => void): ReadableStream {
+  const reader = stream.getReader();
+  return new ReadableStream(
+    {
+      async pull(controller) {
+        onDisturb();
+        const { done, value } = await reader.read();
+        if (done) {
+          controller.close();
+        } else {
+          controller.enqueue(value);
+        }
+      },
+      cancel(reason) {
+        onDisturb();
+        return reader.cancel(reason);
+      },
+    },
+    { highWaterMark: 0 },
+  );
+}
 
 /**
  * Undici uses an incompatible Request constructor depending on private property accessors.

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -5,7 +5,7 @@ import { NodeRequestURL } from "./url.ts";
 import { NodeRequestHeaders } from "./headers.ts";
 import { lazyInherit } from "../../_inherit.ts";
 import { createBodyTooLargeError, limitBodyStream } from "../../_body-limit.ts";
-import { Readable } from "node:stream";
+import { isDisturbed, Readable } from "node:stream";
 
 export type NodeRequestContext = {
   req: NodeServerRequest;
@@ -45,12 +45,13 @@ export const NodeRequest: {
     #url?: URL;
     #bodyStream?: ReadableStream | null;
     // The fetch spec's "disturbed" bit, tracked at the srvx level: set by the
-    // buffered fast path (text()/json()) and by the first read/cancel of the
-    // stream `body` hands out. Every body read rejects with `TypeError: Body is
-    // unusable` once set (like native fetch) instead of hanging on a re-listened,
-    // already-ended IncomingMessage or resolving empty off the null-body Request
-    // that `_request` serves in this state. Also lets `bodyUsed` answer without
-    // materializing a native Request over a disturbed stream.
+    // buffered fast path (text()/json()) directly, and latched from the stream
+    // `body` hands out by `#isBodyUsed()`. Every body read rejects with
+    // `TypeError: Body is unusable` once set (like native fetch) instead of
+    // hanging on a re-listened, already-ended IncomingMessage or resolving empty
+    // off the null-body Request that `_request` serves in this state. Also lets
+    // `bodyUsed` answer without materializing a native Request over a disturbed
+    // stream.
     #bodyUsed = false;
     #request?: globalThis.Request;
     #headers?: NodeRequestHeaders;
@@ -203,22 +204,11 @@ export const NodeRequest: {
             ? // TODO: HTTP2ServerRequest
               (Readable.toWeb(this.#req as NodeJS.ReadableStream) as unknown as ReadableStream)
             : null;
-        if (stream) {
-          // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
-          // through (`request.body`, and therefore the native `Request` methods
-          // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
-          if (this.#maxRequestBodySize !== undefined) {
-            stream = limitBodyStream(stream, this.#maxRequestBodySize);
-          }
-          stream = trackDisturbed(stream, () => {
-            // Only while srvx still owns the body. Once `_request` holds it, undici
-            // owns the accounting and reports it per-Request: `clone()` tees this
-            // stream, so a pull here may be the *clone* being read, which must not
-            // mark this request's body used.
-            if (!this.#request) {
-              this.#bodyUsed = true;
-            }
-          });
+        // Enforce `maxRequestBodySize` at the single choke point every consumer funnels
+        // through (`request.body`, and therefore the native `Request` methods
+        // `arrayBuffer()` / `blob()` / `bytes()` / `formData()` and streaming).
+        if (stream && this.#maxRequestBodySize !== undefined) {
+          stream = limitBodyStream(stream, this.#maxRequestBodySize);
         }
         this.#bodyStream = stream;
       }
@@ -229,10 +219,25 @@ export const NodeRequest: {
       // Serve from srvx state: after a fast-path read the native Request is never
       // materialized (or is materialized with a null body), so it would otherwise
       // report `false` or throw when the underlying stream is disturbed.
-      if (this.#bodyUsed) {
+      if (this.#isBodyUsed()) {
         return true;
       }
       return this.#request ? this.#request.bodyUsed : false;
+    }
+
+    // The spec's "disturbed" check. `#bodyUsed` only sees the buffered fast path
+    // (text()/json()); a consumer reading or cancelling the stream `body` handed
+    // out bypasses it, so consult the stream's own disturbed bit via
+    // `isDisturbed` (the same primitive undici's guards use — a `ReadableStream`
+    // doesn't expose it) and latch the answer. Latching matters: `_request`
+    // calls this *before* releasing `#bodyStream` to the native Request, past
+    // which undici owns the accounting — its tee reads this stream on `clone()`,
+    // which must not count as a read of this request's body.
+    #isBodyUsed(): boolean {
+      if (!this.#bodyUsed && this.#bodyStream && isDisturbed(this.#bodyStream)) {
+        this.#bodyUsed = true;
+      }
+      return this.#bodyUsed;
     }
 
     // Buffer the raw request body once; consumers add their own single
@@ -245,7 +250,7 @@ export const NodeRequest: {
     text(): Promise<string> {
       // A second read of an already-consumed body must reject like native fetch
       // rather than re-listen to an ended stream (which would hang).
-      if (this.#bodyUsed) {
+      if (this.#isBodyUsed()) {
         return Promise.reject(bodyUnusable());
       }
       if (this.#request) {
@@ -270,7 +275,7 @@ export const NodeRequest: {
     }
 
     json(): Promise<any> {
-      if (this.#bodyUsed) {
+      if (this.#isBodyUsed()) {
         return Promise.reject(bodyUnusable());
       }
       if (this.#request) {
@@ -316,7 +321,7 @@ export const NodeRequest: {
     // Request (see `_request`), whose body is pristine, so undici's own
     // "Body is unusable" guard never fires and the read resolves empty. Guard here.
     #consumeNative(method: "arrayBuffer" | "bytes" | "blob" | "formData"): Promise<any> {
-      if (this.#bodyUsed) {
+      if (this.#isBodyUsed()) {
         return Promise.reject(bodyUnusable());
       }
       try {
@@ -336,7 +341,7 @@ export const NodeRequest: {
         // disturbed or locked") and poisons `bodyUsed` / `clone()` / `formData()`
         // / `blob()` / `mode` / `referrer`. Serve a null-body Request instead and
         // let `bodyUsed` reflect srvx state.
-        const body = this.#bodyUsed ? null : this.body;
+        const body = this.#isBodyUsed() ? null : this.body;
         this.#request = new NativeRequest(this.url, {
           method: this.method,
           headers: this.headers,
@@ -359,39 +364,6 @@ export const NodeRequest: {
 
   return Request as any;
 })();
-
-/**
- * Wraps a body stream so `onDisturb` fires the first time it is read or cancelled.
- *
- * `request.body` is handed straight to the consumer, so reading it bypasses the
- * `#bodyUsed` flag that `text()` / `json()` set. A `ReadableStream` doesn't expose
- * the fetch spec's "disturbed" bit, so observing it means wrapping.
- *
- * `highWaterMark: 0` is what keeps this honest: with the default of 1 the stream
- * would pull a chunk as soon as it is constructed, marking a body as used merely
- * because a handler touched `request.body`.
- */
-function trackDisturbed(stream: ReadableStream, onDisturb: () => void): ReadableStream {
-  const reader = stream.getReader();
-  return new ReadableStream(
-    {
-      async pull(controller) {
-        onDisturb();
-        const { done, value } = await reader.read();
-        if (done) {
-          controller.close();
-        } else {
-          controller.enqueue(value);
-        }
-      },
-      cancel(reason) {
-        onDisturb();
-        return reader.cancel(reason);
-      },
-    },
-    { highWaterMark: 0 },
-  );
-}
 
 /**
  * Undici uses an incompatible Request constructor depending on private property accessors.

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -814,9 +814,8 @@ describe("node body crash regressions", () => {
   });
 
   // The flip side of the above: `bodyUsed` tracks the spec's "disturbed" bit, so
-  // merely *touching* `request.body` must not consume it. Guards the body
-  // stream's `highWaterMark: 0` — with a read-ahead buffer it would pull a chunk
-  // on construction and mark an untouched body as used.
+  // merely *touching* `request.body` must not consume it — `isDisturbed` on the
+  // handed-out stream must stay false until an actual read or cancel.
   test("accessing req.body without reading it does not mark the body used", async () => {
     const server = serve({
       port: 0,
@@ -831,6 +830,29 @@ describe("node body crash regressions", () => {
 
     const res = await fetch(server.url!, { method: "POST", body: "hello" });
     expect(await res.json()).toEqual({ hasBody: true, bodyUsed: false, text: "hello" });
+    await server.close(true);
+  });
+
+  // Cancelling the body disturbs it per the fetch spec, exactly like reading it:
+  // `bodyUsed` flips and later reads reject.
+  test("cancelling req.body marks the body used and rejects later reads", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        await req.body!.cancel();
+        return Response.json({
+          bodyUsed: req.bodyUsed,
+          text: await req.text().then(
+            () => "resolved",
+            (error) => (error instanceof TypeError ? "TypeError" : `other: ${error}`),
+          ),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({ bodyUsed: true, text: "TypeError" });
     await server.close(true);
   });
 

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -682,6 +682,154 @@ describe("node body crash regressions", () => {
     await server.close(true);
   });
 
+  // https://github.com/h3js/srvx/issues/247
+  // Only text()/json() guarded against a second read. The rest of the body
+  // methods are inherited from the native Request, which `_request` hands a
+  // *null* body once srvx has consumed the real one — so undici's own guard saw
+  // a pristine body and they resolved empty, silently masking double-read bugs
+  // that throw on every other runtime.
+  test("every body method rejects after the body is consumed", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        await req.text();
+        const outcomes: Record<string, string> = { bodyUsed: String(req.bodyUsed) };
+        for (const method of [
+          "arrayBuffer",
+          "bytes",
+          "blob",
+          "formData",
+          "text",
+          "json",
+        ] as const) {
+          outcomes[method] = await (req[method]() as Promise<unknown>).then(
+            () => "resolved",
+            (error) =>
+              error instanceof TypeError && /unusable/.test(error.message)
+                ? "TypeError: unusable"
+                : `other: ${error}`,
+          );
+        }
+        return Response.json(outcomes);
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({
+      bodyUsed: "true",
+      arrayBuffer: "TypeError: unusable",
+      bytes: "TypeError: unusable",
+      blob: "TypeError: unusable",
+      formData: "TypeError: unusable",
+      text: "TypeError: unusable",
+      json: "TypeError: unusable",
+    });
+    await server.close(true);
+  });
+
+  // https://github.com/h3js/srvx/issues/247 (related)
+  // Draining `req.body` never flipped `bodyUsed`, so a later read still looked
+  // like a first read: it reached the `_request` getter, which threw
+  // "... disturbed or locked" *synchronously* out of the handler.
+  test("streaming the body directly marks it used and rejects later reads", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        let streamed = "";
+        for await (const chunk of req.body!) {
+          streamed += new TextDecoder().decode(chunk as Uint8Array);
+        }
+        return Response.json({
+          streamed,
+          bodyUsed: req.bodyUsed,
+          arrayBuffer: await req.arrayBuffer().then(
+            () => "resolved",
+            (error) => (error instanceof TypeError ? "TypeError" : `other: ${error}`),
+          ),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({
+      streamed: "hello",
+      bodyUsed: true,
+      arrayBuffer: "TypeError",
+    });
+    await server.close(true);
+  });
+
+  // The flip side of the above: `bodyUsed` tracks the spec's "disturbed" bit, so
+  // merely *touching* `request.body` must not consume it. Guards the body
+  // stream's `highWaterMark: 0` — with a read-ahead buffer it would pull a chunk
+  // on construction and mark an untouched body as used.
+  test("accessing req.body without reading it does not mark the body used", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const hasBody = req.body !== null;
+        const bodyUsed = req.bodyUsed;
+        // The body is undisturbed, so a buffered read must still work.
+        return Response.json({ hasBody, bodyUsed, text: await req.text() });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({ hasBody: true, bodyUsed: false, text: "hello" });
+    await server.close(true);
+  });
+
+  // `clone()` tees the body, so reading the clone must leave the original
+  // readable — the "disturbed" tracking on the underlying stream must not
+  // mistake a pull driven by the clone for a read of this request's body.
+  test("reading a clone leaves the original body readable", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const fromClone = await req.clone().text();
+        return Response.json({
+          fromClone,
+          fromOriginal: await req.text().then(
+            (text) => `resolved(${text})`,
+            (error) => `${error}`,
+          ),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({ fromClone: "hello", fromOriginal: "resolved(hello)" });
+    await server.close(true);
+  });
+
+  // The native Request owns the accounting once it holds the real body: a first
+  // arrayBuffer() must read it, and only the second read rejects.
+  test("arrayBuffer() reads the body once and rejects on a second read", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const first = new TextDecoder().decode(await req.arrayBuffer());
+        return Response.json({
+          first,
+          bodyUsed: req.bodyUsed,
+          second: await req.arrayBuffer().then(
+            () => "resolved",
+            (error) => (error instanceof TypeError ? "TypeError" : `other: ${error}`),
+          ),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { method: "POST", body: "hello" });
+    expect(await res.json()).toEqual({ first: "hello", bodyUsed: true, second: "TypeError" });
+    await server.close(true);
+  });
+
   // GET/HEAD are always null-body per the fetch spec, regardless of what was on
   // the wire and regardless of property-access order.
   for (const order of ["text-first", "body-first"] as const) {


### PR DESCRIPTION
Fixes #247.

### The bug

`_request` serves a **null-body** native Request once srvx has consumed the body. That request's body is pristine, so undici's own `Body is unusable` guard never fires and `arrayBuffer()` / `bytes()` / `blob()` / `formData()` read an empty body and resolve happily. Only `text()` / `json()` had explicit guards. This silently masks double-read bugs that throw on every other runtime.

The "related" item in the issue turned out to be worse than reported. Draining `req.body` directly left `bodyUsed` false, so a later read looked like a *first* read, reached the `_request` getter, and threw `Response body object should not be disturbed or locked` **synchronously out of the handler** — not a rejection, a crash:

```
TypeError: Response body object should not be disturbed or locked
    at extractBody (node:internal/deps/undici/undici:6912:17)
    at new Request (node:internal/deps/undici/undici:12269:48)
    at get _request (src/adapters/_node/request.ts:292:25)
    at desc.value [as arrayBuffer] (src/_inherit.ts:32:20)
```

### The fix

- **Guard the remaining body methods.** `arrayBuffer` / `bytes` / `blob` / `formData` reject via a shared `#consumeNative` helper, which also wraps the delegation in try/catch so a synchronous throw while materializing `_request` over a locked stream becomes a rejection. That's what fixes the handler crash above.
- **Check the spec's "disturbed" bit lazily via `node:stream`'s `isDisturbed()`** — the same primitive undici's own guards use. `#isBodyUsed()` consults it on the stream `body` handed out and latches the answer into `#bodyUsed`, with zero cost on the streaming path itself (no wrapper stream, no per-chunk hop). Merely *touching* `request.body` doesn't disturb it, so that stays free too. Pinned by a test.
- **The latch runs before `_request` releases the stream to the native Request.** Past that point undici owns the accounting: it tees the stream on `clone()`, so its reads must not count against this request. Without this, `req.clone()` then reading the clone would wrongly poison the original — breaking the common clone-to-inspect middleware pattern. Pinned by a test.

### Verification

srvx now matches native undici on every case — consumed-body reads, direct streaming, cancel, body-touch, first/second read, and clone:

| case | before | after / native |
| --- | --- | --- |
| `arrayBuffer()` after `text()` | `resolved(0)` | `TypeError: Body is unusable` |
| `bytes()` / `blob()` after `text()` | `resolved(0)` | `TypeError: Body is unusable` |
| `arrayBuffer()` after draining `body` | sync throw out of handler | `TypeError: Body is unusable` |
| `bodyUsed` after draining `body` | `false` | `true` |
| `bodyUsed` after `body.cancel()` | `false` | `true` |
| touch `body`, then `text()` | `resolved` | `resolved` (unchanged) |
| `clone().text()`, then `text()` | `resolved` | `resolved` (unchanged) |

7 regression tests added. Lint/format clean; typecheck unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request body handling to better match standard Fetch behavior.
  * `bodyUsed` now updates correctly when the body is disturbed or consumed.
  * Request body readers (e.g., `text`, `json`, `arrayBuffer`, `formData`) now reject consistently after the body has already been used.
  * Cloned requests can be read independently without unintentionally consuming the original.
* **Tests**
  * Added regression coverage for body-consumption semantics and single-read behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
