### PR TITLE
fix(node): make patchGlobalRequest idempotent

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -320,6 +320,12 @@ export const NodeRequest: {
  * Alternatively you can use `new Request(req._request || req)` instead of patching global Request.
  */
 export function patchGlobalRequest(): typeof Request {
+  // Idempotent: if the global is already patched, return the installed class
+  // so `patchGlobalRequest() === globalThis.Request` holds on repeated calls.
+  if ((globalThis.Request as any)._srvx) {
+    return globalThis.Request as unknown as typeof Request;
+  }
+
   const NativeRequest = getNativeRequest();
 
   const PatchedRequest = class Request extends NativeRequest {
@@ -339,9 +345,7 @@ export function patchGlobalRequest(): typeof Request {
       super(input, options);
     }
   };
-  if (!(globalThis.Request as any)._srvx) {
-    globalThis.Request = PatchedRequest as unknown as typeof globalThis.Request;
-  }
+  globalThis.Request = PatchedRequest as unknown as typeof globalThis.Request;
   return PatchedRequest;
 }
 

--- a/test/node-request-formdata.test.ts
+++ b/test/node-request-formdata.test.ts
@@ -29,7 +29,6 @@ describe.runIf(isNode)("node request body methods survive a patched globalThis.R
     }
   });
 
-
   test("formData/blob/arrayBuffer/bytes work after patchGlobalRequest()", async () => {
     // Patch the global, then load a *fresh* request module copy so its IIFE
     // runs while globalThis.Request is the patched subclass.

--- a/test/node-request-formdata.test.ts
+++ b/test/node-request-formdata.test.ts
@@ -13,22 +13,6 @@ import { patchGlobalRequest } from "../src/adapters/node.ts";
 const isNode = !globalThis.Deno && !globalThis.Bun;
 
 describe.runIf(isNode)("node request body methods survive a patched globalThis.Request", () => {
-  // Regression test for https://github.com/h3js/srvx/issues/249
-  // Repeated `patchGlobalRequest()` calls must be idempotent and return the
-  // exact class installed as `globalThis.Request`, not a fresh subclass.
-  test("patchGlobalRequest() is idempotent", () => {
-    const OriginalRequest = globalThis.Request;
-    try {
-      const first = patchGlobalRequest();
-      expect(first).toBe(globalThis.Request);
-      const second = patchGlobalRequest();
-      expect(second).toBe(first);
-      expect(second).toBe(globalThis.Request);
-    } finally {
-      globalThis.Request = OriginalRequest;
-    }
-  });
-
   test("formData/blob/arrayBuffer/bytes work after patchGlobalRequest()", async () => {
     // Patch the global, then load a *fresh* request module copy so its IIFE
     // runs while globalThis.Request is the patched subclass.

--- a/test/node-request-formdata.test.ts
+++ b/test/node-request-formdata.test.ts
@@ -13,6 +13,23 @@ import { patchGlobalRequest } from "../src/adapters/node.ts";
 const isNode = !globalThis.Deno && !globalThis.Bun;
 
 describe.runIf(isNode)("node request body methods survive a patched globalThis.Request", () => {
+  // Regression test for https://github.com/h3js/srvx/issues/249
+  // Repeated `patchGlobalRequest()` calls must be idempotent and return the
+  // exact class installed as `globalThis.Request`, not a fresh subclass.
+  test("patchGlobalRequest() is idempotent", () => {
+    const OriginalRequest = globalThis.Request;
+    try {
+      const first = patchGlobalRequest();
+      expect(first).toBe(globalThis.Request);
+      const second = patchGlobalRequest();
+      expect(second).toBe(first);
+      expect(second).toBe(globalThis.Request);
+    } finally {
+      globalThis.Request = OriginalRequest;
+    }
+  });
+
+
   test("formData/blob/arrayBuffer/bytes work after patchGlobalRequest()", async () => {
     // Patch the global, then load a *fresh* request module copy so its IIFE
     // runs while globalThis.Request is the patched subclass.


### PR DESCRIPTION
## Problem

`patchGlobalRequest()` is meant to install a srvx `Request` subclass as `globalThis.Request` so `new Request(req)` works in Node.js. It is intended to be safe to call more than once, but a second call was not idempotent:

- The assignment to `globalThis.Request` is guarded by `!(globalThis.Request as any)._srvx`, so a second call correctly skips re-installing the global.
- However, the function still builds and **returns a brand-new `PatchedRequest` class** on every call.

As a result, `patchGlobalRequest() === globalThis.Request` was `false` on the second (and every subsequent) call — the returned class was a fresh subclass that was never installed as the global. Any caller relying on the return value being the actual installed `Request` (e.g. `instanceof` checks, or capturing the class) could end up with a stale, uninstalled class.

## Fix

Make the function idempotent: if the global is already patched (`_srvx` marker present), return the installed `globalThis.Request` immediately instead of constructing a new class. This also removes the now-redundant assignment guard.

Repeated calls now return the exact class installed as `globalThis.Request`.

## Test

Added a regression test asserting that repeated `patchGlobalRequest()` calls return the same class and that it is identical to `globalThis.Request` (with the original global restored afterwards).

Part of #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling so repeated initialization no longer replaces the existing request implementation.
  * Ensured consistent behavior when request support is initialized multiple times.

* **Tests**
  * Added regression coverage verifying repeated initialization reuses the same request implementation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->