### PR TITLE
fix(node/web): don't permanently cache a missed kNeedDrain symbol lookup

### DIFF
--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -5,14 +5,14 @@ import type { WebIncomingMessage } from "./incoming.ts";
 // Node's OutgoingMessage sets an internal `kNeedDrain` symbol to true when a
 // write returns false, and clears it (emitting "drain") from the HTTP server's
 // socketOnDrain handler. We don't have access to that symbol publicly, so we
-// resolve it from the instance once and cache it. Resolving may fail across
-// Node versions; in that case we fall back to always re-emitting "drain".
-let needDrainSymbol: symbol | null | undefined;
-function getNeedDrainSymbol(res: ServerResponse): symbol | null {
-  if (needDrainSymbol === undefined) {
-    needDrainSymbol =
-      Object.getOwnPropertySymbols(res).find((s) => s.description === "kNeedDrain") ?? null;
-  }
+// resolve it from the instance and cache it. The symbol may not be materialized
+// on the instance yet at first lookup (it is only set the first time a write is
+// backpressured), so a miss must NOT be cached: we keep `undefined` (retry on
+// the next call) until the symbol is actually found. Until then we fall back to
+// always re-emitting "drain".
+let needDrainSymbol: symbol | undefined;
+function getNeedDrainSymbol(res: ServerResponse): symbol | undefined {
+  needDrainSymbol ??= Object.getOwnPropertySymbols(res).find((s) => s.description === "kNeedDrain");
   return needDrainSymbol;
 }
 


### PR DESCRIPTION
Part of #249.

## Bug

`getNeedDrainSymbol` (`src/adapters/_node/web/response.ts`) resolves Node's internal `kNeedDrain` symbol from a `ServerResponse` instance and caches it module-wide. The cache was assigned `null` on a missed lookup and only recomputed while still `undefined`:

```ts
let needDrainSymbol: symbol | null | undefined;
function getNeedDrainSymbol(res: ServerResponse): symbol | null {
  if (needDrainSymbol === undefined) {
    needDrainSymbol =
      Object.getOwnPropertySymbols(res).find((s) => s.description === "kNeedDrain") ?? null;
  }
  return needDrainSymbol;
}
```

Node only materializes `kNeedDrain` on an instance the **first time a write is backpressured**. Because the assigned-socket path forwards every socket `"drain"` event to the response, the first `"drain"` can fire on an instance that has not yet materialized the symbol. When that happens the lookup misses and caches `null` for the entire process lifetime. From then on the `kNeedDrain` guard in the `socket.on("drain", ...)` handler is skipped for **every** response, so the handler re-emits spurious `"drain"` events even when the response was not backpressured.

## Fix

Use `undefined` as the single "not found yet, retry" sentinel and only cache the value once the symbol is actually found, so subsequent lookups retry until it materializes:

```ts
let needDrainSymbol: symbol | undefined;
function getNeedDrainSymbol(res: ServerResponse): symbol | undefined {
  needDrainSymbol ??= Object.getOwnPropertySymbols(res).find((s) => s.description === "kNeedDrain");
  return needDrainSymbol;
}
```

All truthy-check call sites (`if (kNeedDrain && ...)`, `if (kNeedDrain)`) behave identically with `undefined` in place of `null`.

## Testing

The function is module-private and reproducing the poisoning would require driving Node's internal `kNeedDrain` materialization timing across two separate connections, so no dedicated unit test is added; the existing backpressure regression test (`test/node-adapters.test.ts`, "backpressure-aware handler does not deadlock", #208) continues to pass. Verified with `pnpm vitest run test/node.test.ts test/node-adapters.test.ts test/node-streams.test.ts` (all pass), `pnpm typecheck`, and oxlint/oxfmt on the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)