### PR TITLE
fix(node): guard already-destroyed streamBody cancel against unhandled rejection

### DIFF
--- a/src/adapters/_node/send.ts
+++ b/src/adapters/_node/send.ts
@@ -196,7 +196,7 @@ export function streamBody(
 ): Promise<void> | void {
   // stream is already destroyed
   if (nodeRes.destroyed) {
-    stream.cancel();
+    stream.cancel().catch(() => {});
     return;
   }
 

--- a/test/node-streams.test.ts
+++ b/test/node-streams.test.ts
@@ -1,6 +1,8 @@
 import { Readable } from "node:stream";
 import { describe, expect, test } from "vitest";
 import { serve, FastResponse } from "../src/adapters/node.ts";
+import { streamBody } from "../src/adapters/_node/send.ts";
+import type { NodeServerResponse } from "../src/types.ts";
 
 describe("node response stream error handling", () => {
   test("client abort propagates to node readable stream", async () => {
@@ -245,6 +247,34 @@ describe("node response stream error handling", () => {
     const res = await fetch(server.url!);
     expect(res.status).toBe(500);
     await server.close(true);
+  });
+
+  // Regression: when the response is already destroyed on entry to streamBody
+  // (client gone before we start pumping), we cancel the web stream. If the
+  // stream's cancel algorithm rejects (or the stream is locked), the unhandled
+  // rejection would crash the process under `--unhandled-rejections=throw`.
+  // The cancel() call must be guarded like the HEAD path.
+  test("streamBody: destroyed response + cancel-rejecting stream has no unhandled rejection", async () => {
+    const unhandled: unknown[] = [];
+    const onUnhandled = (err: unknown) => unhandled.push(err);
+    process.prependListener("unhandledRejection", onUnhandled);
+    try {
+      const stream = new ReadableStream({
+        cancel() {
+          throw new Error("cancel failed");
+        },
+      });
+      const destroyedRes = { destroyed: true } as unknown as NodeServerResponse;
+
+      // Should return synchronously (undefined) without leaking a rejection.
+      expect(streamBody(stream, destroyedRes)).toBeUndefined();
+
+      // Let the microtask queue flush so a would-be unhandledRejection fires.
+      await new Promise((r) => setTimeout(r, 50));
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      process.removeListener("unhandledRejection", onUnhandled);
+    }
   });
 
   test("duck-typed pipe object (e.g. React PipeableStream) works", async () => {


### PR DESCRIPTION
Part of #249.

## Bug

In `streamBody` (`src/adapters/_node/send.ts`), when `nodeRes.destroyed` is already true on entry (the client is gone before we start pumping the body), the web `ReadableStream` is cancelled to release its resources:

```ts
if (nodeRes.destroyed) {
  stream.cancel(); // <- no .catch()
  return;
}
```

`ReadableStream.cancel()` returns a **rejected** promise when the stream is locked or when its underlying `cancel` algorithm throws/rejects. This call had no `.catch()`, so that rejection is unhandled. Under Node's default `--unhandled-rejections=throw` an unhandled rejection crashes the process.

The HEAD path a few lines below already guards the identical call: `stream.cancel().catch(() => {});`.

## Fix

Add `.catch(() => {})` to the destroyed-path `stream.cancel()` so it matches the HEAD path. One-line change.

## Test

Added a regression test in `test/node-streams.test.ts` that unit-tests `streamBody` directly: it passes a fake already-destroyed `nodeRes` and a `ReadableStream` whose `cancel()` throws, installs a temporary `unhandledRejection` listener, and asserts no rejection leaks. Verified the test fails on the unpatched code (1 unhandled rejection captured) and passes with the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)