### PR TITLE
fix(node): reset lifecycle on close and make ready() wait for listen

### DIFF
--- a/src/adapters/_node/web/incoming.ts
+++ b/src/adapters/_node/web/incoming.ts
@@ -71,7 +71,7 @@ export class WebIncomingMessage extends IncomingMessage {
       // emits "end" at the right time.
       this.complete = true;
       this.push(null);
-      this.off("data", onData);
+      socket.off("data", onData);
     });
   }
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -53,6 +53,10 @@ class NodeServer implements Server {
 
   #listeningPromise?: Promise<void>;
   #listenError?: Error;
+  // Resolves once the server has started listening (rejects if it fails).
+  // Distinct from #listeningPromise so that ready() awaits the *next* listen in
+  // `manual` mode (and after a close/restart) instead of resolving stale.
+  #ready?: PromiseWithResolvers<void>;
 
   #wait?: ReturnType<typeof createWaitUntil>;
 
@@ -139,9 +143,20 @@ class NodeServer implements Server {
 
     this.node.server = server;
 
+    this.#newReady();
+
     if (!options.manual) {
       this.serve().catch(() => {});
     }
+  }
+
+  // (Re)create the deferred that ready() awaits. The rejection is guarded so a
+  // listen failure that nobody observes via ready() does not surface as an
+  // unhandled rejection (serve()/ready() remain the real error surfaces).
+  #newReady(): PromiseWithResolvers<void> {
+    const ready = Promise.withResolvers<void>();
+    ready.promise.catch(() => {});
+    return (this.#ready = ready);
   }
 
   serve(): Promise<this> {
@@ -155,17 +170,20 @@ class NodeServer implements Server {
     }
 
     this.#listenError = undefined;
+    const ready = this.#ready ?? this.#newReady();
     this.#listeningPromise = new Promise<void>((resolve, reject) => {
       const onError = (error: Error) => {
         server.off("listening", onListening);
         this.#listenError = error;
         this.#listeningPromise = undefined;
+        ready.reject(error);
         reject(error);
       };
 
       const onListening = () => {
         server.off("error", onError);
         printListening(this.options, this.url);
+        ready.resolve();
         resolve();
       };
 
@@ -192,7 +210,9 @@ class NodeServer implements Server {
     if (this.#listenError) {
       return Promise.reject(this.#listenError);
     }
-    return Promise.resolve(this.#listeningPromise).then(() => this);
+    // Wait until the server has actually started listening. In `manual` mode
+    // (before serve() is called) this stays pending instead of resolving early.
+    return (this.#ready ?? this.#newReady()).promise.then(() => this);
   }
 
   async close(closeAll?: boolean): Promise<void> {
@@ -209,5 +229,11 @@ class NodeServer implements Server {
         server.close((error?: Error) => (error ? reject(error) : resolve()));
       }),
     ]);
+    // Reset lifecycle state so the server can be restarted: a subsequent serve()
+    // calls server.listen() again, and ready() waits for that fresh listen
+    // instead of resolving against the stale (already-settled) one.
+    this.#listeningPromise = undefined;
+    this.#listenError = undefined;
+    this.#newReady();
   }
 }

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -515,6 +515,65 @@ describe("node server startup", () => {
       await server.close();
     });
   });
+
+  // close() must reset the internal listening state so a subsequent serve()
+  // actually re-invokes server.listen() instead of returning the stale,
+  // already-resolved promise (which left the server permanently down).
+  test("server can be restarted with serve() after close()", async () => {
+    const server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response("ok"),
+    });
+
+    await server.ready();
+    const res1 = await fetch(server.url!);
+    expect(res1.status).toBe(200);
+    expect(await res1.text()).toBe("ok");
+
+    await server.close();
+
+    // Restart on a fresh listen (port 0 -> new random port).
+    await server.serve();
+    await server.ready();
+    const res2 = await fetch(server.url!);
+    expect(res2.status).toBe(200);
+    expect(await res2.text()).toBe("ok");
+
+    await server.close();
+  });
+
+  // In manual mode ready() must not resolve until serve() has been called and
+  // the server is actually listening (previously it resolved immediately
+  // because #listeningPromise was still undefined).
+  test("ready() waits for serve() in manual mode", async () => {
+    const server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      manual: true,
+      fetch: () => new Response("ok"),
+    });
+
+    let readyResolved = false;
+    const readyPromise = server.ready().then(() => {
+      readyResolved = true;
+    });
+
+    // Give ready() the chance to (incorrectly) resolve before serve() is called.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(readyResolved).toBe(false);
+    expect(server.url).toBeUndefined();
+
+    await server.serve();
+    await readyPromise;
+    expect(readyResolved).toBe(true);
+    expect(server.url).toBeTruthy();
+
+    const res = await fetch(server.url!);
+    expect(await res.text()).toBe("ok");
+
+    await server.close();
+  });
 });
 
 describe("FastResponse header dedup", () => {


### PR DESCRIPTION
Part of #249 (Node adapter: minor correctness findings from v1 audit).

## Problem

Two lifecycle nits in `src/adapters/node.ts`:

**(a) Server can't be restarted after `close()`.** `serve()` short-circuits when `#listeningPromise` is truthy, but `close()` never reset it. So calling `serve()` after `close()` just returned the stale, already-resolved promise and never re-invoked `server.listen()` — the server stayed down.

**(b) `ready()` resolves too early in `manual` mode.** `ready()` awaited `#listeningPromise`, which stays `undefined` until `serve()` is called. In `manual: true` mode this meant `ready()` resolved immediately, before the server had ever started listening.

## Fix

- `close()` now resets `#listeningPromise` and `#listenError`, so a subsequent `serve()` starts a fresh `server.listen()` and the server restarts.
- Introduce a dedicated `#ready` deferred that resolves once the server is actually listening (rejects on listen failure). It is (re)created for each fresh listen and on close, and `ready()` awaits it — so in `manual` mode it stays pending until `serve()` is called and listening begins. The rejection is guarded (`.catch`) so an unobserved listen error doesn't surface as an unhandled rejection; `serve()`/`ready()` remain the real error surfaces.

### Note on cross-runtime semantics

Bun's `ready()` always resolves immediately and Deno's has the same early-resolve behavior as Node did in `manual` mode. Per the audit guidance, this PR prefers the stronger, well-defined contract — "`ready()` resolves once the server is listening" — for the Node adapter.

## Tests

Added two regression tests in `test/node-adapters.test.ts` (both fail without the fix):
- `serve()` after `close()` restarts and serves requests again.
- `ready()` does not resolve before `serve()` in `manual` mode.

`pnpm vitest run test/node.test.ts test/node-adapters.test.ts` → 160 passed / 6 skipped. `pnpm typecheck` clean (after build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup/shutdown lifecycle so `ready()` reliably tracks the *next* `listen()` attempt.
  * Fixed repeated `serve()` cycles after `close()` by resetting listening state, errors, and readiness waiters.
  * Ensured `manual: true` servers stay unready until `serve()` is called and the server is confirmed listening (including keeping `url` unset until then).
* **Tests**
  * Added regression tests covering both re-listen after close and manual-start readiness behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->