### PR TITLE
fix(node/web): remove `"data"` listener from the socket it was added to

### DIFF
--- a/src/adapters/_node/web/incoming.ts
+++ b/src/adapters/_node/web/incoming.ts
@@ -71,7 +71,7 @@ export class WebIncomingMessage extends IncomingMessage {
       // emits "end" at the right time.
       this.complete = true;
       this.push(null);
-      this.off("data", onData);
+      socket.off("data", onData);
     });
   }
 


### PR DESCRIPTION
In `WebIncomingMessage`, `onData` is registered with `socket.on("data", onData)`, but the `"end"` cleanup called `this.off("data", onData)` — `this` being the `IncomingMessage`, not the socket — so the listener was never actually removed from the emitter it was added to. Harmless in practice today since the socket is discarded shortly after, but the cleanup now targets the right emitter: `socket.off("data", onData)`.

Verified with `pnpm vitest run test/node.test.ts test/node-adapters.test.ts` (158 passed, 6 skipped) and `pnpm typecheck`.

Note: this re-lands `58b157b`, which was briefly fast-forwarded onto `main` by mistake (a `push.default=upstream` mishap) and then removed from `main`; this PR restores it through the intended review flow.

Part of #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)