### PR TITLE
fix(node): validate `FastResponse` status range in constructor

### DIFF
--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -37,6 +37,26 @@ export const NodeResponse: {
     constructor(body?: BodyInit | null, init?: ResponseInit) {
       this.#body = body;
       this.#init = init;
+      // Native `Response` validates `init.status` at construction and throws a
+      // `RangeError` for anything outside 200-599. Because the fast path never
+      // builds a native `Response`, that check would otherwise be skipped and an
+      // out-of-range status silently reach the wire (or `status: 0` be coerced
+      // to 200 by the getter). Validate once here to match native semantics
+      // while keeping the hot `status` getter free of range checks.
+      if (init !== undefined) {
+        const status = init.status;
+        if (status !== undefined) {
+          // `& 0xffff` reproduces WebIDL's `unsigned short` (ToUint16) coercion
+          // used by native `Response`: it truncates toward zero and wraps mod
+          // 2^16, so e.g. `"204"` -> 204, `599.9` -> 599, `65736` -> 200.
+          const code = (status as number) & 0xffff;
+          if (code < 200 || code > 599) {
+            throw new RangeError(
+              `init["status"] must be in the range of 200 to 599, inclusive.`,
+            );
+          }
+        }
+      }
     }
 
     static [Symbol.hasInstance](val: unknown) {
@@ -44,7 +64,10 @@ export const NodeResponse: {
     }
 
     get status(): number {
-      return this.#response?.status || this.#init?.status || 200;
+      // `??` (not `||`): the constructor has already rejected any out-of-range
+      // status, so a stored value is always a valid 200-599 code that must not
+      // be replaced by the `200` fallback.
+      return this.#response?.status ?? this.#init?.status ?? 200;
     }
 
     get statusText(): string {

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -51,9 +51,7 @@ export const NodeResponse: {
           // 2^16, so e.g. `"204"` -> 204, `599.9` -> 599, `65736` -> 200.
           const code = (status as number) & 0xffff;
           if (code < 200 || code > 599) {
-            throw new RangeError(
-              `init["status"] must be in the range of 200 to 599, inclusive.`,
-            );
+            throw new RangeError(`init["status"] must be in the range of 200 to 599, inclusive.`);
           }
         }
       }

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -569,6 +569,45 @@ describe("FastResponse header dedup", () => {
   });
 });
 
+// FastResponse must validate `init.status` at construction like native
+// `Response`, which throws a RangeError for anything outside 200-599 (the fast
+// path never builds a native Response, so the check was previously skipped).
+describe("FastResponse status validation", () => {
+  test.each([99, 1000, 0, -1, 600])(
+    "throws RangeError for out-of-range status %i",
+    (status) => {
+      expect(() => new FastResponse(null, { status })).toThrow(RangeError);
+      expect(() => new FastResponse(null, { status })).toThrow(
+        `init["status"] must be in the range of 200 to 599, inclusive.`,
+      );
+    },
+  );
+
+  test.each([200, 204, 404, 500, 599])(
+    "accepts valid status %i and exposes it via .status",
+    (status) => {
+      const res = new FastResponse(null, { status });
+      expect(res.status).toBe(status);
+    },
+  );
+
+  test("defaults to 200 when no status is provided", () => {
+    expect(new FastResponse(null).status).toBe(200);
+    expect(new FastResponse(null, {}).status).toBe(200);
+  });
+
+  test("_toNodeResponse carries the validated status", () => {
+    expect(
+      new FastResponse(null, { status: 404 })._toNodeResponse().status,
+    ).toBe(404);
+  });
+
+  test("matches native Response range behavior for out-of-range status", () => {
+    expect(() => new Response(null, { status: 99 })).toThrow(RangeError);
+    expect(() => new FastResponse(null, { status: 99 })).toThrow(RangeError);
+  });
+});
+
 // v1 stabilization: Node-adapter crash/corruption regressions.
 describe("node body crash regressions", () => {
   // F1: the non-middleware branch of callNodeHandler had no `.catch`, so an async

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -573,15 +573,12 @@ describe("FastResponse header dedup", () => {
 // `Response`, which throws a RangeError for anything outside 200-599 (the fast
 // path never builds a native Response, so the check was previously skipped).
 describe("FastResponse status validation", () => {
-  test.each([99, 1000, 0, -1, 600])(
-    "throws RangeError for out-of-range status %i",
-    (status) => {
-      expect(() => new FastResponse(null, { status })).toThrow(RangeError);
-      expect(() => new FastResponse(null, { status })).toThrow(
-        `init["status"] must be in the range of 200 to 599, inclusive.`,
-      );
-    },
-  );
+  test.each([99, 1000, 0, -1, 600])("throws RangeError for out-of-range status %i", (status) => {
+    expect(() => new FastResponse(null, { status })).toThrow(RangeError);
+    expect(() => new FastResponse(null, { status })).toThrow(
+      `init["status"] must be in the range of 200 to 599, inclusive.`,
+    );
+  });
 
   test.each([200, 204, 404, 500, 599])(
     "accepts valid status %i and exposes it via .status",
@@ -597,9 +594,7 @@ describe("FastResponse status validation", () => {
   });
 
   test("_toNodeResponse carries the validated status", () => {
-    expect(
-      new FastResponse(null, { status: 404 })._toNodeResponse().status,
-    ).toBe(404);
+    expect(new FastResponse(null, { status: 404 })._toNodeResponse().status).toBe(404);
   });
 
   test("matches native Response range behavior for out-of-range status", () => {


### PR DESCRIPTION
The `NodeResponse` class (exported as `FastResponse`) skipped the status validation native `Response` performs: `new FastResponse(null, {status: 99})` and `{status: 1000}` passed through unvalidated, and `{status: 0}` was silently coerced to `200` by the `||` fallback in the `status` getter.

This adds a one-time check in the constructor when `init.status` is provided, keeping the hot path fast (the getter itself stays check-free):

- The status is coerced with `& 0xffff` (reproducing WebIDL `unsigned short` conversion, matching native behavior: `"204"` → 204, `599.9` → 599, `65736` → 200) and must fall in 200–599 inclusive, otherwise a `RangeError` is thrown with the same message as native `Response` (`init["status"] must be in the range of 200 to 599, inclusive.`).
- The `status` getter switches `||` → `??` now that any stored status is guaranteed valid, so `status: 0` throws instead of silently becoming 200.
- Internal fast-path construction in the Node adapter is unaffected (it passes a live `nodeRes.statusCode`).

Tests added in `test/node-adapters.test.ts`: 99/1000/0/-1/600 throw `RangeError`; 200/204/404/500/599 accepted; default is 200; parity with native `Response`. Verified with `pnpm vitest run test/node.test.ts test/node-adapters.test.ts` (171 passed, 6 skipped) and `pnpm typecheck`.

Note: this re-lands `0973afe` (cherry-picked onto current `main`), which was briefly fast-forwarded onto `main` by mistake (a `push.default=upstream` mishap) and then removed from `main`; this PR restores it through the intended review flow.

Part of #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fast responses now validate HTTP status codes consistently with native responses.
  * Invalid status codes outside the allowed range are rejected immediately.
  * Valid status codes, including custom values, are preserved correctly instead of being replaced by the default status.

* **Tests**
  * Added coverage for valid, invalid, omitted, and converted response status values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->