### PR TITLE
fix(node): copy `FastResponse` init headers instead of adopting them

### DIFF
--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -62,9 +62,13 @@ export const NodeResponse: {
       if (this.#headers) {
         return this.#headers;
       }
-      const initHeaders = this.#init?.headers;
-      return (this.#headers =
-        initHeaders instanceof Headers ? initHeaders : new Headers(initHeaders));
+      // Copy the init headers instead of adopting the caller's instance, so that
+      // mutating `res.headers` can't leak back into a shared "template" Headers
+      // (CORS/security presets, per-route defaults), matching native `Response`.
+      // The copy is lazy: it only happens once someone reaches for `.headers`.
+      // The read-only path (`_toNodeResponse()`) iterates `#init.headers`
+      // directly and stays zero-copy.
+      return (this.#headers = new Headers(this.#init?.headers));
     }
 
     get ok(): boolean {

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -695,6 +695,68 @@ describe("FastResponse header dedup", () => {
   });
 });
 
+// https://github.com/h3js/srvx/issues/250
+describe("FastResponse copies init Headers", () => {
+  const headerPairs = (headers: string[]) => {
+    const pairs: [string, string][] = [];
+    for (let i = 0; i < headers.length; i += 2) {
+      pairs.push([headers[i], headers[i + 1]]);
+    }
+    return pairs;
+  };
+
+  test("mutating res.headers does not leak into a shared Headers init", () => {
+    const shared = new Headers({ a: "1" });
+
+    const res = new FastResponse("x", { headers: shared });
+    res.headers.set("b", "2");
+
+    expect(shared.has("b")).toBe(false);
+    expect(res.headers.get("a")).toBe("1");
+    expect(res.headers.get("b")).toBe("2");
+  });
+
+  test("a shared Headers template survives reuse across responses", () => {
+    const preset = new Headers({ "x-preset": "1" });
+
+    const first = new FastResponse("x", { headers: preset });
+    first.headers.append("set-cookie", "session=abc");
+
+    const second = new FastResponse("y", { headers: preset });
+
+    expect(second.headers.getSetCookie()).toEqual([]);
+    expect(first.headers.getSetCookie()).toEqual(["session=abc"]);
+  });
+
+  test("the copy preserves multiple set-cookie values", () => {
+    const shared = new Headers();
+    shared.append("set-cookie", "a=1");
+    shared.append("set-cookie", "b=2");
+
+    const res = new FastResponse("x", { headers: shared });
+
+    expect(res.headers.getSetCookie()).toEqual(["a=1", "b=2"]);
+  });
+
+  test("mutations via res.headers reach the wire", () => {
+    const res = new FastResponse("x", { headers: new Headers({ a: "1" }) });
+    res.headers.set("b", "2");
+
+    const { headers } = res._toNodeResponse();
+
+    expect(headerPairs(headers)).toContainEqual(["a", "1"]);
+    expect(headerPairs(headers)).toContainEqual(["b", "2"]);
+  });
+
+  test("an untouched Headers init still reaches the wire", () => {
+    const { headers } = new FastResponse("x", {
+      headers: new Headers({ a: "1" }),
+    })._toNodeResponse();
+
+    expect(headerPairs(headers)).toContainEqual(["a", "1"]);
+  });
+});
+
 // v1 stabilization: Node-adapter crash/corruption regressions.
 describe("node body crash regressions", () => {
   // F1: the non-middleware branch of callNodeHandler had no `.catch`, so an async


### PR DESCRIPTION
Fixes #250.

`NodeResponse` (exported as `FastResponse`) adopted a caller-provided `Headers` init **by reference**, so mutating `res.headers` wrote back into the caller's object. Native `Response` copies.

## The fix

One branch in the `headers` getter (`src/adapters/_node/response.ts`):

```diff
-const initHeaders = this.#init?.headers;
-return (this.#headers =
-  initHeaders instanceof Headers ? initHeaders : new Headers(initHeaders));
+return (this.#headers = new Headers(this.#init?.headers));
```

The copy is **lazy**, as suggested in the issue: it only happens if someone reaches for `.headers`. `_toNodeResponse()` iterates `#init.headers` directly, so the read-only fast path stays zero-copy and the common case pays nothing.

`new Headers(x)` is a faithful copy — verified it preserves multiple `set-cookie` values separately rather than comma-joining them.

## Impact

The issue's Impact section understates this. Driving a real server that reuses one preset `Headers` across requests while appending a per-request cookie:

```
before:  /one → [req=one]   /two → [req=one, req=two]   /three → [req=one, req=two, req=three]
after:   /one → [req=one]   /two → [req=two]            /three → [req=three]
```

One request's `set-cookie` shipped to every subsequent response.

## Tests

Five tests in `test/node-adapters.test.ts` covering the leak, template reuse across responses, `set-cookie` fidelity through the copy, and that mutations still reach the wire. The two leak tests fail on `main` and pass here.

## Known divergence (unchanged by this PR)

The copy snapshots at first `.headers` access rather than at construction, so a mutation to the caller's object in between still shows through:

```js
const res = new FastResponse("x", { headers: shared });
shared.set("b", "2");
res.headers.get("b"); // srvx: "2"   native: null
```

This already applied to the `_toNodeResponse()` path (which reads `#init.headers` live at write time) and is inherent to the lazy approach — closing it needs an eager constructor copy, i.e. the cost this design avoids. It's also the far safer direction: it requires a deliberate mutation in a narrow window, where the reported bug poisoned the shared object permanently. Happy to document it as a divergence if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented response header changes from unintentionally modifying the original headers provided during response creation.
  * Ensured reusable header templates remain unchanged across multiple responses.
  * Preserved multiple `set-cookie` values when copying response headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->