### PR TITLE
perf(middleware): precompose the middleware chain at construction time

### DIFF
--- a/src/_middleware.ts
+++ b/src/_middleware.ts
@@ -1,23 +1,17 @@
-import type { Server, ServerRequest, ServerHandler, ServerMiddleware } from "./types.ts";
+import type { Server, ServerHandler } from "./types.ts";
 
 export function wrapFetch(server: Server): ServerHandler {
-  const fetchHandler = server.options.fetch;
-  const middleware = server.options.middleware || [];
-  return middleware.length === 0
-    ? fetchHandler
-    : (request) => callMiddleware(request, fetchHandler, middleware, 0);
-}
-
-function callMiddleware(
-  request: ServerRequest,
-  fetchHandler: ServerHandler,
-  middleware: ServerMiddleware[],
-  index: number,
-): Response | Promise<Response> {
-  if (index === middleware.length) {
-    return fetchHandler(request);
+  // Fold the middleware into a composed handler once at construction time —
+  // per-request cost is one `next` closure per layer, nothing else. Middleware
+  // added to `server.options.middleware` after this point has no effect.
+  let composed = server.options.fetch;
+  const middleware = server.options.middleware;
+  if (middleware) {
+    for (let i = middleware.length - 1; i >= 0; i--) {
+      const mw = middleware[i];
+      const next = composed;
+      composed = (request) => mw(request, () => next(request));
+    }
   }
-  return middleware[index](request, () =>
-    callMiddleware(request, fetchHandler, middleware, index + 1),
-  );
+  return composed;
 }


### PR DESCRIPTION
## What

`wrapFetch` now folds the middleware array into a single composed handler once at construction time, instead of recursively dispatching through `callMiddleware` on every request.

## Why

Per request, the recursive dispatch paid one call frame with 4 arguments, a `middleware.length` read, an index comparison, an array access, and a closure allocation per layer. After the fold, only the per-layer `next` closure remains — that one is inherent to the `next: () => Response` API since it must capture per-request state.

Micro-benchmark (Node, passthrough middleware, sentinel response to isolate dispatch cost): ~18–25% faster dispatch at 1–5 middleware (~10–20 ns/request), neutral at 10. srvx's own plugins add 0–3 middleware, which is the range where the fold wins. End-to-end this is small relative to total request cost, but it's free.

## Behavior note

Middleware added to `server.options.middleware` **after** construction now consistently has no effect. This was never a coherent contract: the old code honored late additions only when the array was non-empty at construction, because the empty case already returned the raw fetch handler. All in-tree mutators (`_plugins.ts`, `_trust-proxy.ts`, `mtls.ts`, `tracing.ts`) run inside plugins, which every adapter applies before calling `wrapFetch`, so nothing observable changes.

## Testing

- 1030 tests passed (35 skipped), typecheck and formatting clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved request middleware handling by composing the middleware chain once during server setup.
  * Preserved existing request behavior, including direct handling when no middleware is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->