### PR TITLE
fix(node): keep `req.headers` live and consistent across `_request` materialization

### DIFF
--- a/src/adapters/_node/headers.ts
+++ b/src/adapters/_node/headers.ts
@@ -51,7 +51,10 @@ function _isRepeated(rawHeaders: string[], lowerName: string): boolean {
 export type NodeRequestHeaders = InstanceType<typeof NodeRequestHeaders>;
 
 export const NodeRequestHeaders: {
-  new (req: NodeServerRequest): globalThis.Headers;
+  new (req: NodeServerRequest): globalThis.Headers & {
+    /** @internal See `_adopt` in the class body. */
+    _adopt(headers: globalThis.Headers): void;
+  };
 } = /* @__PURE__ */ (() => {
   const NativeHeaders = globalThis.Headers;
 
@@ -65,6 +68,17 @@ export const NodeRequestHeaders: {
 
     static [Symbol.hasInstance](val: unknown) {
       return val instanceof NativeHeaders;
+    }
+
+    /**
+     * Swap the backing store for the materialized native request's Headers so
+     * this wrapper becomes a pure facade over it: previously-taken references
+     * stay live and mutations through either view land in the single remaining
+     * store. Called by `NodeRequest`'s `_request` getter.
+     * @internal
+     */
+    _adopt(headers: globalThis.Headers) {
+      this.#headers = headers;
     }
 
     get _headers() {

--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -147,10 +147,10 @@ export const NodeRequest: {
       return this._url.href;
     }
 
+    // Always the same `NodeRequestHeaders` wrapper, even after `_request`
+    // materializes (the wrapper then fronts the native request's Headers — see
+    // `_request`), so references taken at any point stay live and identical.
     get headers(): Headers {
-      if (this.#request) {
-        return this.#request.headers;
-      }
       return (this.#headers ||= new NodeRequestHeaders(this.#req));
     }
 
@@ -355,7 +355,13 @@ export const NodeRequest: {
           // @ts-expect-error Undici specific
           duplex: body ? "half" : undefined,
         });
-        this.#headers = undefined;
+        // From here on the native request's Headers is the single mutable
+        // store; the wrapper (created by the `this.headers` init above if it
+        // didn't already exist) becomes a facade over it. Both views —
+        // `req.headers` and `_request.headers` / `clone()` / `formData()` —
+        // observe the same mutations, and header references taken before
+        // materialization stay live.
+        this.#headers!._adopt(this.#request.headers);
         this.#bodyStream = undefined;
       }
 

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -1209,6 +1209,89 @@ describe("node fetch-spec correctness regressions", () => {
     await server.close(true);
   });
 
+  // A headers reference taken before `_request` materialization must stay live:
+  // `req.headers` keeps its identity and mutations through the old reference
+  // remain visible (https://github.com/h3js/srvx/issues/245).
+  test("headers reference stays live across _request materialization", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const h = req.headers;
+        // Force materialization of the underlying native Request.
+        void req._request;
+        h.set("x-added-after", "1");
+        return Response.json({
+          sameIdentity: req.headers === h,
+          viaGetter: req.headers.get("x-added-after"),
+          viaRef: h.get("x-added-after"),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!);
+    expect(await res.json()).toEqual({
+      sameIdentity: true,
+      viaGetter: "1",
+      viaRef: "1",
+    });
+    await server.close(true);
+  });
+
+  // The dual of the identity test — the case that sank the #243 approach:
+  // after materialization there is a single header store, so mutations through
+  // `req.headers` must be visible to the native views (`_request.headers`,
+  // `clone()`, and `formData()`'s content-type sniff), and vice versa.
+  test("headers mutations after _request materialization reach both views", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        const native = req._request!; // materialize first
+        req.headers.set("x-via-wrapper", "1");
+        native.headers.set("x-via-native", "1");
+        return Response.json({
+          nativeSeesWrapperSet: native.headers.get("x-via-wrapper"),
+          cloneSeesWrapperSet: req.clone().headers.get("x-via-wrapper"),
+          wrapperSeesNativeSet: req.headers.get("x-via-native"),
+          preMaterializationHeader: native.headers.get("x-early"),
+        });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, { headers: { "x-early": "yes" } });
+    expect(await res.json()).toEqual({
+      nativeSeesWrapperSet: "1",
+      cloneSeesWrapperSet: "1",
+      wrapperSeesNativeSet: "1",
+      preMaterializationHeader: "yes",
+    });
+    await server.close(true);
+  });
+
+  // formData() sniffs content-type off the native request; a content-type set
+  // via `req.headers` before the native Request exists must be honored.
+  test("formData() sees content-type set through req.headers", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(req) {
+        // Overwrite the incoming content-type before materialization.
+        req.headers.set("content-type", "application/x-www-form-urlencoded");
+        const form = await req.formData();
+        return Response.json({ value: form.get("a") });
+      },
+    });
+    await server.ready();
+
+    const res = await fetch(server.url!, {
+      method: "POST",
+      headers: { "content-type": "text/plain" },
+      body: "a=1",
+    });
+    expect(await res.json()).toEqual({ value: "1" });
+    await server.close(true);
+  });
+
   // A synchronous send failure (e.g. an invalid header value hitting writeHead)
   // must be logged for diagnostics (unless silenced) and returned as a bare 500
   // without leaking details to the client.


### PR DESCRIPTION
Resolves #245

## Problem

On the Node adapter, once the native (undici) `Request` materializes — via `req._request`, `clone()`, `formData()`/`blob()`/`bytes()`/`arrayBuffer()`, or any lazily-inherited native property — `get headers()` switched from the `NodeRequestHeaders` wrapper to `#request.headers`. A reference taken earlier became detached: `req.headers !== h`, and mutations through `h` were silently lost. The approach tried in #243 (keep the wrapper canonical forever) fixed identity but froze `_request.headers` / `clone()` at a materialization-time snapshot, so it was reverted (1754b02).

## Fix

Instead of swapping which object the getter returns, swap the wrapper's **backing store**. `NodeRequestHeaders` already fronts a lazily-built native `Headers`; at materialization it now `_adopt`s the native request's `Headers` and becomes a pure facade over it. From then on there is a single mutable header store, so with no dual-write bookkeeping:

- header references taken at any point stay live, and `req.headers` identity is stable forever,
- mutations through `req.headers` are visible in `_request.headers`, `clone()`, and `formData()`'s content-type sniff,
- mutations made directly on `_request.headers` are visible through `req.headers` (which one-way write-through could never give).

The untouched-headers hot path is unchanged; requests whose headers were accessed pay one extra branch + delegated call per header op after materialization.

## Semantics note

After materialization the single store is the native request's `Headers`, which carries the fetch spec's `"request"` guard: forbidden-header mutations (e.g. `set("host", …)`) are silently filtered where the pre-materialization wrapper allowed them. This moves toward spec behavior and only applies once a native view exists.

## Tests

- revives the reverted `headers reference stays live across _request materialization` test from #243,
- its dual (the case that sank #243): mutations after materialization reach `_request.headers` and `clone()`, in both directions,
- `formData()` honors a `content-type` set through `req.headers` before materialization.

Full suite: 1041 passed, lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)