### PR TITLE
fix(node/web): strip explicit Transfer-Encoding to avoid corrupting the bridged body

### DIFF
--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -19,8 +19,6 @@ function getNeedDrainSymbol(res: ServerResponse): symbol | undefined {
 // Statuses that must not carry a response body per the Fetch/HTTP spec.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
-
-
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
   #socketError?: Error;
@@ -167,7 +165,6 @@ export class WebServerResponse extends ServerResponse {
     });
   }
 }
-
 
 // --- internal ---
 

--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -19,44 +19,7 @@ function getNeedDrainSymbol(res: ServerResponse): symbol | undefined {
 // Statuses that must not carry a response body per the Fetch/HTTP spec.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
-// Drop any `transfer-encoding` entry from a `writeHead()` headers argument
-// (object, flat `[k, v, ...]`, or nested `[[k, v], ...]` form). An explicit
-// `Transfer-Encoding: chunked` makes Node chunk-frame the body it writes to the
-// bridging socket, corrupting the captured body (`5\r\nhello\r\n...`), and the
-// header itself is a hop-by-hop framing artifact that must not reach the web
-// `Response`. See https://github.com/h3js/srvx/issues/248
-function stripTransferEncoding<T>(headers: T): T {
-  if (!headers || typeof headers !== "object") {
-    return headers;
-  }
-  if (Array.isArray(headers)) {
-    if (headers.length > 0 && Array.isArray(headers[0])) {
-      return headers.filter(([key]) => String(key).toLowerCase() !== "transfer-encoding") as T;
-    }
-    const out: unknown[] = [];
-    for (let i = 0; i < headers.length; i += 2) {
-      if (String(headers[i]).toLowerCase() === "transfer-encoding") continue;
-      out.push(headers[i], headers[i + 1]);
-    }
-    return out as T;
-  }
-  let hasTransferEncoding = false;
-  for (const key in headers) {
-    if (key.toLowerCase() === "transfer-encoding") {
-      hasTransferEncoding = true;
-      break;
-    }
-  }
-  if (!hasTransferEncoding) {
-    return headers;
-  }
-  const out: Record<string, unknown> = {};
-  for (const key in headers) {
-    if (key.toLowerCase() === "transfer-encoding") continue;
-    out[key] = (headers as Record<string, unknown>)[key];
-  }
-  return out as T;
-}
+
 
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
@@ -203,4 +166,46 @@ export class WebServerResponse extends ServerResponse {
       headers: headers,
     });
   }
+}
+
+
+// --- internal ---
+
+// Drop any `transfer-encoding` entry from a `writeHead()` headers argument
+// (object, flat `[k, v, ...]`, or nested `[[k, v], ...]` form). An explicit
+// `Transfer-Encoding: chunked` makes Node chunk-frame the body it writes to the
+// bridging socket, corrupting the captured body (`5\r\nhello\r\n...`), and the
+// header itself is a hop-by-hop framing artifact that must not reach the web
+// `Response`. See https://github.com/h3js/srvx/issues/248
+function stripTransferEncoding<T>(headers: T): T {
+  if (!headers || typeof headers !== "object") {
+    return headers;
+  }
+  if (Array.isArray(headers)) {
+    if (headers.length > 0 && Array.isArray(headers[0])) {
+      return headers.filter(([key]) => String(key).toLowerCase() !== "transfer-encoding") as T;
+    }
+    const out: unknown[] = [];
+    for (let i = 0; i < headers.length; i += 2) {
+      if (String(headers[i]).toLowerCase() === "transfer-encoding") continue;
+      out.push(headers[i], headers[i + 1]);
+    }
+    return out as T;
+  }
+  let hasTransferEncoding = false;
+  for (const key in headers) {
+    if (key.toLowerCase() === "transfer-encoding") {
+      hasTransferEncoding = true;
+      break;
+    }
+  }
+  if (!hasTransferEncoding) {
+    return headers;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key in headers) {
+    if (key.toLowerCase() === "transfer-encoding") continue;
+    out[key] = (headers as Record<string, unknown>)[key];
+  }
+  return out as T;
 }

--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -19,6 +19,45 @@ function getNeedDrainSymbol(res: ServerResponse): symbol | undefined {
 // Statuses that must not carry a response body per the Fetch/HTTP spec.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
+// Drop any `transfer-encoding` entry from a `writeHead()` headers argument
+// (object, flat `[k, v, ...]`, or nested `[[k, v], ...]` form). An explicit
+// `Transfer-Encoding: chunked` makes Node chunk-frame the body it writes to the
+// bridging socket, corrupting the captured body (`5\r\nhello\r\n...`), and the
+// header itself is a hop-by-hop framing artifact that must not reach the web
+// `Response`. See https://github.com/h3js/srvx/issues/248
+function stripTransferEncoding<T>(headers: T): T {
+  if (!headers || typeof headers !== "object") {
+    return headers;
+  }
+  if (Array.isArray(headers)) {
+    if (headers.length > 0 && Array.isArray(headers[0])) {
+      return headers.filter(([key]) => String(key).toLowerCase() !== "transfer-encoding") as T;
+    }
+    const out: unknown[] = [];
+    for (let i = 0; i < headers.length; i += 2) {
+      if (String(headers[i]).toLowerCase() === "transfer-encoding") continue;
+      out.push(headers[i], headers[i + 1]);
+    }
+    return out as T;
+  }
+  let hasTransferEncoding = false;
+  for (const key in headers) {
+    if (key.toLowerCase() === "transfer-encoding") {
+      hasTransferEncoding = true;
+      break;
+    }
+  }
+  if (!hasTransferEncoding) {
+    return headers;
+  }
+  const out: Record<string, unknown> = {};
+  for (const key in headers) {
+    if (key.toLowerCase() === "transfer-encoding") continue;
+    out[key] = (headers as Record<string, unknown>)[key];
+  }
+  return out as T;
+}
+
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
   #socketError?: Error;
@@ -32,6 +71,9 @@ export class WebServerResponse extends ServerResponse {
     // a real wire: `toWebResponse()` captures the raw body buffer from the
     // bridging socket and re-wraps it in a web `Response`. Chunk framing would
     // corrupt that captured body, so keep the output un-chunked (close-delimited).
+    // A handler setting `Transfer-Encoding` explicitly would re-enable framing
+    // regardless of this flag, so those headers are also stripped at the
+    // `writeHead`/`setHeader`/`appendHeader` choke points below.
     this.useChunkedEncodingByDefault = false;
 
     this.once("finish", () => {
@@ -70,6 +112,30 @@ export class WebServerResponse extends ServerResponse {
     // Express can override prototype so we have to bind methods
     this.waitToFinish = this.waitToFinish.bind(this);
     this.toWebResponse = this.toWebResponse.bind(this);
+  }
+
+  // `writeHead()` bypasses `setHeader()`, storing headers straight into the raw
+  // header block, so an explicit `Transfer-Encoding` here would re-enable chunk
+  // framing. Strip it from every accepted headers form before delegating.
+  override writeHead(statusCode: number, statusMessage?: any, headers?: any): this {
+    if (typeof statusMessage === "string") {
+      return super.writeHead(statusCode, statusMessage, stripTransferEncoding(headers));
+    }
+    return super.writeHead(statusCode, stripTransferEncoding(statusMessage));
+  }
+
+  override setHeader(name: string, value: number | string | readonly string[]): this {
+    if (typeof name === "string" && name.toLowerCase() === "transfer-encoding") {
+      return this;
+    }
+    return super.setHeader(name, value);
+  }
+
+  override appendHeader(name: string, value: string | readonly string[]): this {
+    if (typeof name === "string" && name.toLowerCase() === "transfer-encoding") {
+      return this;
+    }
+    return super.appendHeader(name, value);
   }
 
   waitToFinish(): Promise<void> {

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -255,6 +255,53 @@ describe("adapters", () => {
     expect(await res.text()).toBe(payload);
   });
 
+  // https://github.com/h3js/srvx/issues/248
+  // An explicit `Transfer-Encoding: chunked` must not chunk-frame the bridged
+  // body. The synthetic response is close-delimited (its raw bytes are captured
+  // and re-wrapped in a web Response), so framing would surface as literal chunk
+  // metadata in the body ("5\r\nhello\r\n...") and leak a hop-by-hop header.
+  describe("explicit Transfer-Encoding: chunked does not corrupt the body", () => {
+    const cases: { name: string; setHeaders: (res: any) => void }[] = [
+      {
+        name: "writeHead object form",
+        setHeaders: (res) => res.writeHead(200, { "transfer-encoding": "chunked" }),
+      },
+      {
+        name: "writeHead with statusMessage",
+        setHeaders: (res) => res.writeHead(200, "OK", { "Transfer-Encoding": "chunked" }),
+      },
+      {
+        name: "writeHead flat array form",
+        setHeaders: (res) => res.writeHead(200, ["transfer-encoding", "chunked"] as any),
+      },
+      {
+        name: "writeHead nested array form",
+        setHeaders: (res) => res.writeHead(200, [["transfer-encoding", "chunked"]] as any),
+      },
+      {
+        name: "setHeader",
+        setHeaders: (res) => res.setHeader("Transfer-Encoding", "chunked"),
+      },
+    ];
+
+    for (const { name, setHeaders } of cases) {
+      test(name, async () => {
+        const handler: NodeHttp1Handler = (_req, res) => {
+          setHeaders(res as any);
+          res.write("hello");
+          res.end("world");
+        };
+        const webHandler = toFetchHandler(handler);
+        const res = await webHandler(new Request("http://localhost/"));
+        expect(res.status).toBe(200);
+        // Body arrives verbatim, without chunk framing.
+        expect(await res.text()).toBe("helloworld");
+        // The hop-by-hop framing header does not leak into the web Response.
+        expect(res.headers.get("transfer-encoding")).toBe(null);
+      });
+    }
+  });
+
   // F14: null-body statuses (204/304/...) must not throw when constructing the
   // web Response (which would surface as a 500).
   test("null-body status 204 does not become a 500", async () => {


### PR DESCRIPTION
## Summary

Fixes issue 1 of #248 — **explicit `Transfer-Encoding: chunked` corrupts the bridged body**.

`WebServerResponse` sets `useChunkedEncodingByDefault = false` because the synthetic response isn't written to a real wire — `toWebResponse()` captures the raw body bytes from the bridging socket and re-wraps them in a web `Response`. But an explicit `Transfer-Encoding: chunked` set by the handler **re-enables chunk framing regardless of that flag**, so the captured bytes end up chunk-framed instead of the actual body, and the hop-by-hop header leaks into the web `Response`.

```js
const handler = toFetchHandler((req, res) => {
  res.writeHead(200, { "transfer-encoding": "chunked" });
  res.write("hello");
  res.end("world");
});
```

Before → body `"5\r\nhello\r\n5\r\nworld\r\n0\r\n\r\n"`, `transfer-encoding: chunked` on the response.
After → body `"helloworld"`, no `transfer-encoding` header.

## Fix

Strip `transfer-encoding` at every header-setting choke point so the synthetic response stays un-chunked (close-delimited) and the header never reaches the web `Response`:

- `writeHead()` — object, flat `[k, v, ...]`, and nested `[[k, v], ...]` forms (it bypasses `setHeader`, storing straight into the raw header block).
- `setHeader()` / `appendHeader()`.

## Tests

Adds a parameterized regression suite in `test/node-adapters.test.ts` covering all five vectors, asserting the body arrives verbatim and the header does not leak.

- [x] `vitest run` (node suites) — all pass
- [x] `pnpm typecheck` — clean (after `pnpm build`)
- [x] `pnpm lint` — clean

> Scope note: issues 2 (hop-by-hop header filtering) and 3 (streaming) from #248 are intentionally left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed cases where explicitly setting `Transfer-Encoding: chunked` caused clients to receive chunk-framing metadata.
  * Prevented hop-by-hop `Transfer-Encoding` headers from being forwarded into captured web responses.
  * Improved header handling so filtering applies consistently across supported `writeHead`/`setHeader`/`appendHeader` input styles.
* **Tests**
  * Added regression coverage for explicitly set `Transfer-Encoding: chunked`, including multiple header-setting and `writeHead` argument shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->