### PR TITLE
fix(node/web): strip hop-by-hop headers from toWebResponse()

### DIFF
--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -19,6 +19,25 @@ function getNeedDrainSymbol(res: ServerResponse): symbol | undefined {
 // Statuses that must not carry a response body per the Fetch/HTTP spec.
 const NULL_BODY_STATUSES = new Set([101, 204, 205, 304]);
 
+// Hop-by-hop headers (RFC 9110 §7.6.1). They describe a single transport hop,
+// not the message, so they must never be carried into the web `Response` the
+// bridge synthesizes. Node auto-generates `Connection` (and `Keep-Alive`) on the
+// synthetic wire, and a handler may set any of these explicitly — all of them
+// would otherwise leak out of `toWebResponse()`. `Transfer-Encoding` is also
+// stripped earlier at the write choke points because it changes body framing;
+// here it is covered again as a header-output defense.
+// See https://github.com/h3js/srvx/issues/248
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
   #socketError?: Error;
@@ -144,13 +163,31 @@ export class WebServerResponse extends ServerResponse {
 
     // this.getHeaders() is unreliable because it misses direct writeHead() calls
     const httpHeader = (this as any)._header?.split("\r\n");
+    // Any field-name listed in the `Connection` header is itself hop-by-hop
+    // (RFC 9110 §7.6.1), so collect those from a first pass and drop them too.
+    const connectionTokens = new Set<string>();
     for (let i = 1; httpHeader && i < httpHeader.length; i++) {
       const sepIndex = httpHeader[i].indexOf(": ");
       if (sepIndex === -1) continue;
       const key = httpHeader[i].slice(0, Math.max(0, sepIndex));
       const value = httpHeader[i].slice(Math.max(0, sepIndex + 2));
       if (!key) continue;
+      const lowerKey = key.toLowerCase();
+      if (lowerKey === "connection") {
+        for (const token of value.split(",")) {
+          const t = token.trim().toLowerCase();
+          if (t) connectionTokens.add(t);
+        }
+      }
+      if (HOP_BY_HOP_HEADERS.has(lowerKey)) continue;
       headers.push([key, value]);
+    }
+    if (connectionTokens.size > 0) {
+      for (let i = headers.length - 1; i >= 0; i--) {
+        if (connectionTokens.has(headers[i][0].toLowerCase())) {
+          headers.splice(i, 1);
+        }
+      }
     }
 
     // Null-body statuses (101, 204, 205, 304) cannot have a body; passing a

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -302,6 +302,66 @@ describe("adapters", () => {
     }
   });
 
+  // https://github.com/h3js/srvx/issues/248
+  // Hop-by-hop headers (RFC 9110 §7.6.1) describe a single transport hop, not
+  // the message. Node auto-generates `Connection` on the synthetic wire and a
+  // handler may set any of them explicitly; none may leak into the web Response
+  // that `toWebResponse()` synthesizes.
+  describe("hop-by-hop headers do not leak into the web Response", () => {
+    test("auto-generated Connection: close is stripped", async () => {
+      const handler: NodeHttp1Handler = (_req, res) => {
+        res.writeHead(200, { "content-type": "text/plain" });
+        res.end("hello");
+      };
+      const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+      expect(res.status).toBe(200);
+      expect(await res.text()).toBe("hello");
+      expect(res.headers.get("connection")).toBe(null);
+      // End-to-end headers are untouched.
+      expect(res.headers.get("content-type")).toBe("text/plain");
+    });
+
+    const hopByHop: [string, string][] = [
+      ["connection", "keep-alive"],
+      ["keep-alive", "timeout=5"],
+      ["proxy-authenticate", "Basic"],
+      ["proxy-authorization", "Basic abc"],
+      ["te", "trailers"],
+      ["transfer-encoding", "chunked"],
+      ["upgrade", "h2c"],
+    ];
+    for (const [name, value] of hopByHop) {
+      test(`explicit ${name} is stripped`, async () => {
+        const handler: NodeHttp1Handler = (_req, res) => {
+          res.writeHead(200, { [name]: value, "content-type": "text/plain" });
+          res.end("hello");
+        };
+        const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe("hello");
+        expect(res.headers.get(name)).toBe(null);
+        expect(res.headers.get("content-type")).toBe("text/plain");
+      });
+    }
+
+    // Any field-name listed in `Connection` is itself hop-by-hop and must go too.
+    test("field-names listed in Connection are stripped", async () => {
+      const handler: NodeHttp1Handler = (_req, res) => {
+        res.writeHead(200, {
+          connection: "close, x-secret",
+          "x-secret": "leak",
+          "content-type": "text/plain",
+        });
+        res.end("hello");
+      };
+      const res = await toFetchHandler(handler)(new Request("http://localhost/"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("connection")).toBe(null);
+      expect(res.headers.get("x-secret")).toBe(null);
+      expect(res.headers.get("content-type")).toBe("text/plain");
+    });
+  });
+
   // F14: null-body statuses (204/304/...) must not throw when constructing the
   // web Response (which would surface as a 500).
   test("null-body status 204 does not become a 500", async () => {


### PR DESCRIPTION
## Problem

`toWebResponse()` rebuilds the web `Response` headers by parsing the synthetic `ServerResponse`'s raw `_header` block. That block carries **hop-by-hop headers** (RFC 9110 §7.6.1) — which describe a single transport hop, not the message, and must never cross the bridge:

- Node auto-generates `Connection: close` (and `Keep-Alive`) on the synthetic wire → it leaked into every bridged response.
- A handler setting `Connection`, `Keep-Alive`, `Upgrade`, `TE`, etc. had them passed straight through.
- Field-names *listed* in `Connection` (e.g. `Connection: close, x-secret`) are themselves hop-by-hop, so `x-secret` leaked too.

The prior fix (#268) only handled `Transfer-Encoding`, and only because it corrupts body framing — the broader header leak remained.

## Fix

Added a `HOP_BY_HOP_HEADERS` set (`connection`, `keep-alive`, `proxy-authenticate`, `proxy-authorization`, `te`, `trailer`, `transfer-encoding`, `upgrade`) and filter them out while building the header list in `toWebResponse()`. In the same pass, tokens named in the `Connection` header are collected and their headers dropped too. The existing `Transfer-Encoding` write-time choke points stay (they prevent chunk-framing of the captured body, a separate concern).

Before → after for a plain `text/plain` handler:
- `[["connection","close"],["content-type","text/plain"],["date",…]]`
- `[["content-type","text/plain"],["date",…]]`

## Tests

New `describe("hop-by-hop headers do not leak into the web Response")` block in `test/node-adapters.test.ts`: the auto-generated `Connection: close`, each explicitly-set hop-by-hop header, and the `Connection`-listed-token case — each asserting the header is gone while end-to-end headers and the body survive. `test/node-adapters.test.ts`: 74 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented internal hop-by-hop HTTP headers from appearing in web responses.
  * Improved response header handling for connection-specific and transfer-related headers.
  * Preserved valid end-to-end headers, such as content type, while removing headers that should not be exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->