### PR TITLE
fix(node/web): stream bridged responses instead of buffering until end() (#248)

### DIFF
--- a/src/adapters/_node/web/response.ts
+++ b/src/adapters/_node/web/response.ts
@@ -41,6 +41,10 @@ const HOP_BY_HOP_HEADERS = new Set([
 export class WebServerResponse extends ServerResponse {
   #socket: WebRequestSocket;
   #socketError?: Error;
+  // Resolves the pending `waitForResponseHead()` promise the moment the header
+  // block is flushed (see `writeHead()` below). `undefined` when nothing is
+  // waiting yet.
+  #onHeadersSent?: () => void;
 
   constructor(req: WebIncomingMessage, socket: WebRequestSocket) {
     super(req);
@@ -91,17 +95,27 @@ export class WebServerResponse extends ServerResponse {
 
     // Express can override prototype so we have to bind methods
     this.waitToFinish = this.waitToFinish.bind(this);
+    this.waitForResponseHead = this.waitForResponseHead.bind(this);
     this.toWebResponse = this.toWebResponse.bind(this);
   }
 
   // `writeHead()` bypasses `setHeader()`, storing headers straight into the raw
   // header block, so an explicit `Transfer-Encoding` here would re-enable chunk
   // framing. Strip it from every accepted headers form before delegating.
+  //
+  // This is also the single choke point where the header block is flushed: both
+  // an explicit `writeHead()` and the implicit flush on the first `write()`/
+  // `end()` (Node's `_implicitHeader()` calls `this.writeHead(statusCode)`) pass
+  // through here. Once `super.writeHead()` returns, `this._header` is populated,
+  // so this is where `waitForResponseHead()` is released and streaming/SSE
+  // responses can be handed back before `end()`. See issue #248.
   override writeHead(statusCode: number, statusMessage?: any, headers?: any): this {
-    if (typeof statusMessage === "string") {
-      return super.writeHead(statusCode, statusMessage, stripTransferEncoding(headers));
-    }
-    return super.writeHead(statusCode, stripTransferEncoding(statusMessage));
+    const result =
+      typeof statusMessage === "string"
+        ? super.writeHead(statusCode, statusMessage, stripTransferEncoding(headers))
+        : super.writeHead(statusCode, stripTransferEncoding(statusMessage));
+    this.#onHeadersSent?.();
+    return result;
   }
 
   override setHeader(name: string, value: number | string | readonly string[]): this {
@@ -156,8 +170,52 @@ export class WebServerResponse extends ServerResponse {
     });
   }
 
+  // Settle as soon as the response head (status + headers) is known, WITHOUT
+  // waiting for `res.end()`. Unlike `waitToFinish()`, this lets `toWebResponse()`
+  // return while the handler keeps writing, so streaming and SSE bodies flow
+  // through the `_webResBody` stream instead of buffering until finish (which,
+  // for a never-ending SSE handler, is never). See issue #248.
+  waitForResponseHead(): Promise<void> {
+    // Headers already flushed (the common case: a handler calls writeHead/write
+    // then returns), or the response already finished/ended synchronously.
+    if (this.headersSent || this.writableEnded || this.writableFinished) {
+      return Promise.resolve();
+    }
+    // Socket already torn down (e.g. an already-aborted request): no head is
+    // coming. Mirror waitToFinish()'s rejection so the caller surfaces the abort.
+    if (this.#socketError || this.#socket.destroyed) {
+      return Promise.reject(this.#socketError ?? prematureCloseError());
+    }
+    return new Promise<void>((resolve, reject) => {
+      const socket = this.#socket;
+      const settle = (err?: Error) => {
+        this.#onHeadersSent = undefined;
+        this.removeListener("finish", onFinish);
+        this.removeListener("error", onError);
+        socket.removeListener("error", onError);
+        socket.removeListener("close", onClose);
+        if (err) reject(err);
+        else resolve();
+      };
+      // The header flush releases us (see `writeHead()`); `finish` covers a
+      // response that ends without ever flushing a distinct head first.
+      this.#onHeadersSent = () => settle();
+      const onFinish = () => settle();
+      const onError = (err: Error) => settle(err);
+      const onClose = () => {
+        if (!this.headersSent && !this.writableFinished) {
+          settle(this.#socketError ?? prematureCloseError());
+        }
+      };
+      this.on("finish", onFinish);
+      this.on("error", onError);
+      socket.on("error", onError);
+      socket.on("close", onClose);
+    });
+  }
+
   async toWebResponse(): Promise<Response> {
-    await this.waitToFinish();
+    await this.waitForResponseHead();
 
     const headers: [string, string][] = [];
 

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -256,6 +256,48 @@ describe("adapters", () => {
   });
 
   // https://github.com/h3js/srvx/issues/248
+  // A streaming/SSE handler that writes the head + a chunk but never calls
+  // res.end() must NOT block the returned Response: toWebResponse() has to settle
+  // once the head is known so the body streams incrementally instead of buffering
+  // until finish (which, for open-ended SSE, never happens).
+  test("streaming response is returned before res.end()", async () => {
+    let pushChunk!: () => void;
+    let endStream!: () => void;
+    const sseHandler: NodeHttp1Handler = (_req, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write("data: 1\n\n");
+      let n = 2;
+      pushChunk = () => res.write(`data: ${n++}\n\n`);
+      endStream = () => res.end();
+      // Intentionally never returns end(); the response stays open.
+    };
+    const webHandler = toFetchHandler(sseHandler);
+
+    // The Response must resolve without the handler ever calling res.end().
+    const res = await Promise.race([
+      Promise.resolve(webHandler(new Request("http://localhost/"))),
+      new Promise<Response>((_, reject) =>
+        setTimeout(() => reject(new Error("streaming response hung until finish")), 3000),
+      ),
+    ]);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("text/event-stream");
+
+    // And the body must flow chunk-by-chunk while the handler keeps writing.
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    const read = async () => decoder.decode((await reader.read()).value);
+
+    expect(await read()).toBe("data: 1\n\n");
+    pushChunk();
+    expect(await read()).toBe("data: 2\n\n");
+    pushChunk();
+    expect(await read()).toBe("data: 3\n\n");
+    endStream();
+    expect((await reader.read()).done).toBe(true);
+  });
+
+  // https://github.com/h3js/srvx/issues/248
   // An explicit `Transfer-Encoding: chunked` must not chunk-frame the bridged
   // body. The synthetic response is close-delimited (its raw bytes are captured
   // and re-wrapped in a web Response), so framing would surface as literal chunk


### PR DESCRIPTION
Addresses point **3. Bridged responses are fully buffered; streaming/SSE hangs forever** from #248.

## Problem

`toWebResponse()` awaited `waitToFinish()`, so the web `Response` was only returned after the Node handler called `res.end()`. For an open-ended SSE/streaming handler this means:

```js
const handler = toFetchHandler((req, res) => {
  res.writeHead(200, { "content-type": "text/event-stream" });
  res.write("data: 1\n\n");
  // typical SSE: never ends
});
await handler(new Request("http://localhost/")); // never resolves
```

Beyond the hang, every response buffered its full body in the `_webResBody` queue (nothing consumes the stream until the `Response` is returned), causing memory bloat for large payloads.

## Fix

The streaming machinery already exists — `_write` enqueues each chunk into the `_webResBody` `ReadableStream` as it's written, and the stream closes on `finish`. The only missing piece was returning the `Response` **before** `end()`.

- Add `waitForResponseHead()` — settles as soon as the response head (status + headers) is known, without waiting for `res.end()`. It resolves on the header flush or on `finish`, and rejects on socket error / premature close, mirroring `waitToFinish()`'s abort handling.
- Release it from the existing `writeHead()` override — the single choke point every header flush routes through (both explicit `writeHead()` and the implicit flush on first `write()`/`end()`, since Node's `_implicitHeader()` calls `this.writeHead(statusCode)`).
- `toWebResponse()` now awaits the head instead of finish, so the body streams through `_webResBody` while the handler keeps writing.

## Verification

- New regression test `streaming response is returned before res.end()`: asserts the `Response` resolves without the handler ever calling `end()`, and that the body flows chunk-by-chunk.
- Manual repro: response returns in ~5ms (was: hung forever); chunks arrive at the handler's real write cadence.
- Node suites pass (203 passed / 6 skipped), typecheck + lint + format clean.

## Scope note

This fixes the 2-arg handler path from the issue's example. The connect-style middleware path (`handler.length > 2`) still awaits `finish`/`close` before building the response — it has no way to signal head-ready separately from completion, and that pattern isn't in the issue.

Points 1 (explicit `Transfer-Encoding` corruption) and 2 (hop-by-hop header leak) from #248 were already fixed in #268 and #270.

🤖 Generated with [Claude Code](https://claude.com/claude-code)