### PR TITLE
feat(log): flush on default-handled SIGTERM/SIGINT and add `batch` option

### DIFF
--- a/docs/1.guide/4.middleware.md
+++ b/docs/1.guide/4.middleware.md
@@ -76,6 +76,12 @@ serve({
 
 The duration is measured around `next()`, so place `log()` first in the array for it to cover the whole chain. The [CLI](/guide/cli) enables this middleware automatically.
 
+**`log()` options:**
+
+- `batch`: Coalesce lines and write once per event-loop turn (default: `true`). Set to `false` to hand each line to stdout synchronously — slower under concurrency, but a line is never buffered in the process when it dies.
+
+Buffered lines are flushed on process exit, including uncaught exceptions and `SIGTERM`/`SIGINT`. Only a hard kill (`SIGKILL`, the OOM killer) can drop the lines of the final event-loop turn — set `batch: false` where that window matters more than throughput.
+
 ### Static files
 
 `serveStatic()` from `srvx/static` serves files from a directory, with `index.html` resolution, `.html` extension fallback (`/about` → `about.html`), common MIME types, gzip/Brotli compression, and path-traversal protection.

--- a/docs/1.guide/4.middleware.md
+++ b/docs/1.guide/4.middleware.md
@@ -78,9 +78,16 @@ The duration is measured around `next()`, so place `log()` first in the array fo
 
 **`log()` options:**
 
-- `batch`: Coalesce lines and write once per event-loop turn (default: `true`). Set to `false` to hand each line to stdout as its request completes — slower under concurrency, but nothing waits for a flush turn when the process is killed.
+- `batch`: Coalesce lines and write once per event-loop turn (default: `true`). Set to `false` to hand each line to stdout as its request completes — slower under concurrency, but a line never waits for a flush turn.
 
-Buffered lines are flushed on process exit, including uncaught exceptions and `SIGHUP`/`SIGTERM`/`SIGINT`. A hard kill (`SIGKILL`, the OOM killer) can still drop the lines of the final event-loop turn — `batch: false` narrows that window to the write in flight.
+```ts
+serve({
+  middleware: [log({ batch: false })],
+  fetch: () => new Response("👋 Hello there."),
+});
+```
+
+**Crash safety:** buffered lines are flushed when the process ends — on normal exit, `process.exit()`, uncaught exceptions, and `SIGHUP`/`SIGTERM`/`SIGINT`, whether a shutdown handler (such as srvx's graceful shutdown) is installed or the signal is default-handled. Only a hard kill (`SIGKILL`, the OOM killer) can drop the lines of the final event-loop turn; `batch: false` narrows that window to the single write in flight.
 
 ### Static files
 

--- a/docs/1.guide/4.middleware.md
+++ b/docs/1.guide/4.middleware.md
@@ -78,9 +78,9 @@ The duration is measured around `next()`, so place `log()` first in the array fo
 
 **`log()` options:**
 
-- `batch`: Coalesce lines and write once per event-loop turn (default: `true`). Set to `false` to hand each line to stdout synchronously — slower under concurrency, but a line is never buffered in the process when it dies.
+- `batch`: Coalesce lines and write once per event-loop turn (default: `true`). Set to `false` to hand each line to stdout as its request completes — slower under concurrency, but nothing waits for a flush turn when the process is killed.
 
-Buffered lines are flushed on process exit, including uncaught exceptions and `SIGTERM`/`SIGINT`. Only a hard kill (`SIGKILL`, the OOM killer) can drop the lines of the final event-loop turn — set `batch: false` where that window matters more than throughput.
+Buffered lines are flushed on process exit, including uncaught exceptions and `SIGHUP`/`SIGTERM`/`SIGINT`. A hard kill (`SIGKILL`, the OOM killer) can still drop the lines of the final event-loop turn — `batch: false` narrows that window to the write in flight.
 
 ### Static files
 

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,14 @@
 import * as c from "./cli/_utils.ts";
 import type { ServerMiddleware } from "./types.ts";
 
-export interface LogOptions {}
+export interface LogOptions {
+  /**
+   * Batch lines and write once per event-loop turn (default: `true`). Set to
+   * `false` to hand each line to stdout synchronously: slower under load, but
+   * nothing is buffered in the process if it dies before a flush.
+   */
+  batch?: boolean;
+}
 
 type Paint = (text: string) => string;
 
@@ -66,10 +73,23 @@ function enqueue(line: string): void {
   }
 }
 
+/**
+ * Unbatched mode (`batch: false`): append and flush in the same call, so the
+ * line is handed to stdout before the request completes. It still goes through
+ * `pending` + `flush` rather than `write` directly, so it can never overtake
+ * lines a batched logger or a drain wait is still holding.
+ */
+function writeNow(line: string): void {
+  pending += line;
+  if (!draining) {
+    flush();
+  }
+}
+
 function flush(): void {
   scheduled = false;
-  // `draining` is never true here: `enqueue` won't schedule a flush while
-  // draining, and `onDrain` clears it before rescheduling.
+  // `draining` is never true here: `enqueue` won't schedule a flush and
+  // `writeNow` won't call one while draining; `onDrain` clears it first.
   if (!pending) {
     return;
   }
@@ -102,6 +122,36 @@ function onDrain(): void {
  * directly because `process.stdout.write` is asynchronous for pipes and would
  * not land in time.
  */
+function flushSync(): void {
+  if (!pending) {
+    return;
+  }
+  const proc = globalThis.process;
+  const chunk = pending;
+  pending = "";
+  try {
+    const fs = proc?.getBuiltinModule?.("node:fs");
+    if (fs) {
+      // Encode with the web-standard `TextEncoder` so this stays runtime
+      // agnostic (`Buffer` is Node-only); `writeSync` takes any typed array.
+      // A `writeSync` may accept only part of the bytes, so advance by the
+      // returned count until the whole chunk lands.
+      const bytes = encoder.encode(chunk);
+      for (let offset = 0; offset < bytes.length;) {
+        const written = fs.writeSync(1, bytes, offset, bytes.length - offset);
+        if (written <= 0) {
+          break;
+        }
+        offset += written;
+      }
+    } else {
+      proc?.stdout?.write(chunk);
+    }
+  } catch {
+    // stdout is already gone.
+  }
+}
+
 let exitHooked = false;
 function hookExit(): void {
   const proc = globalThis.process;
@@ -109,37 +159,41 @@ function hookExit(): void {
     return;
   }
   exitHooked = true;
-  proc.on("exit", () => {
-    if (!pending) {
-      return;
-    }
-    const chunk = pending;
-    pending = "";
-    try {
-      const fs = proc.getBuiltinModule?.("node:fs");
-      if (fs) {
-        // Encode with the web-standard `TextEncoder` so this stays runtime
-        // agnostic (`Buffer` is Node-only); `writeSync` takes any typed array.
-        // A `writeSync` may accept only part of the bytes, so advance by the
-        // returned count until the whole chunk lands.
-        const bytes = encoder.encode(chunk);
-        for (let offset = 0; offset < bytes.length;) {
-          const written = fs.writeSync(1, bytes, offset, bytes.length - offset);
-          if (written <= 0) {
-            break;
-          }
-          offset += written;
-        }
-      } else {
-        proc.stdout?.write(chunk);
+  proc.on("exit", flushSync);
+
+  // A default-handled SIGTERM/SIGINT terminates the process without emitting
+  // `exit`, silently dropping whatever is buffered. That only happens when no
+  // listener exists at all — srvx's graceful shutdown normally registers one —
+  // so a listener is installed per signal that, when it turns out to be the
+  // only one, flushes and re-raises with the default disposition restored:
+  // the process still dies by the signal, with `exit` semantics untouched.
+  if (!proc.listenerCount || !proc.kill) {
+    return;
+  }
+  for (const sig of ["SIGTERM", "SIGINT"] as const) {
+    const onSignal = (): void => {
+      // Another listener owns the shutdown (e.g. graceful shutdown): the
+      // process keeps running and the regular flush path delivers `pending`.
+      // Flushing here would jump ahead of anything the stream has queued.
+      if (proc.listenerCount(sig) > 1) {
+        return;
       }
-    } catch {
-      // stdout is already gone.
-    }
-  });
+      flushSync();
+      proc.removeListener(sig, onSignal);
+      try {
+        proc.kill(proc.pid, sig);
+      } catch {
+        // Re-raising is unsupported (e.g. Windows edge cases): exit with the
+        // conventional 128 + signal number code instead of hanging alive.
+        proc.exit(sig === "SIGINT" ? 130 : 143);
+      }
+    };
+    proc.on(sig, onSignal);
+  }
 }
 
-export const log: (options?: LogOptions) => ServerMiddleware = (_options = {}) => {
+export const log: (options?: LogOptions) => ServerMiddleware = (options = {}) => {
+  const emit = options.batch === false ? writeNow : enqueue;
   const colors = colorsEnabled();
   const paint = (fn: Paint): Paint => (colors ? fn : plain);
   const gray = paint(c.gray);
@@ -169,7 +223,7 @@ export const log: (options?: LogOptions) => ServerMiddleware = (_options = {}) =
     const start = performance.now();
     const res = await next();
     const duration = performance.now() - start;
-    enqueue(
+    emit(
       `${time()} ${bold(req.method)} ${blue(req.url)} ${status(res.status)} ${gray(`(${duration.toFixed(2)}ms)`)}\n`,
     );
     return res;

--- a/src/log.ts
+++ b/src/log.ts
@@ -4,8 +4,9 @@ import type { ServerMiddleware } from "./types.ts";
 export interface LogOptions {
   /**
    * Batch lines and write once per event-loop turn (default: `true`). Set to
-   * `false` to hand each line to stdout synchronously: slower under load, but
-   * nothing is buffered in the process if it dies before a flush.
+   * `false` to hand each line to stdout in the request's own turn: slower
+   * under load, but a hard kill can only drop the write still in flight,
+   * never a batch waiting for its flush turn.
    */
   batch?: boolean;
 }
@@ -81,16 +82,14 @@ function enqueue(line: string): void {
  */
 function writeNow(line: string): void {
   pending += line;
-  if (!draining) {
-    flush();
-  }
+  flush();
 }
 
 function flush(): void {
   scheduled = false;
-  // `draining` is never true here: `enqueue` won't schedule a flush and
-  // `writeNow` won't call one while draining; `onDrain` clears it first.
-  if (!pending) {
+  // A flush scheduled by `enqueue` can still fire mid-drain when a `writeNow`
+  // hit backpressure after it was queued; only buffer until `onDrain` resumes.
+  if (draining || !pending) {
     return;
   }
   const chunk = pending;
@@ -161,16 +160,20 @@ function hookExit(): void {
   exitHooked = true;
   proc.on("exit", flushSync);
 
-  // A default-handled SIGTERM/SIGINT terminates the process without emitting
-  // `exit`, silently dropping whatever is buffered. That only happens when no
-  // listener exists at all — srvx's graceful shutdown normally registers one —
+  // A default-handled SIGHUP/SIGTERM/SIGINT terminates the process without
+  // emitting `exit`, silently dropping whatever is buffered. That only happens
+  // when no listener exists at all — srvx's graceful shutdown registers one —
   // so a listener is installed per signal that, when it turns out to be the
   // only one, flushes and re-raises with the default disposition restored:
   // the process still dies by the signal, with `exit` semantics untouched.
   if (!proc.listenerCount || !proc.kill) {
     return;
   }
-  for (const sig of ["SIGTERM", "SIGINT"] as const) {
+  for (const [sig, signum] of [
+    ["SIGHUP", 1],
+    ["SIGINT", 2],
+    ["SIGTERM", 15],
+  ] as const) {
     const onSignal = (): void => {
       // Another listener owns the shutdown (e.g. graceful shutdown): the
       // process keeps running and the regular flush path delivers `pending`.
@@ -185,10 +188,18 @@ function hookExit(): void {
       } catch {
         // Re-raising is unsupported (e.g. Windows edge cases): exit with the
         // conventional 128 + signal number code instead of hanging alive.
-        proc.exit(sig === "SIGINT" ? 130 : 143);
+        proc.exit(128 + signum);
       }
     };
-    proc.on(sig, onSignal);
+    // Prepended so this runs before any `once` wrapper removes itself: a
+    // `process.once(sig, cleanup)` registered earlier would otherwise already
+    // be gone from the count when appended-last `onSignal` runs, and the
+    // sole-listener check would re-raise mid-cleanup.
+    if (proc.prependListener) {
+      proc.prependListener(sig, onSignal);
+    } else {
+      proc.on(sig, onSignal);
+    }
   }
 }
 

--- a/test/fixtures/log-crash.mjs
+++ b/test/fixtures/log-crash.mjs
@@ -1,0 +1,34 @@
+// Emits three lines through the real `log()` middleware, then dies according to
+// process.argv[2]. `log.test.ts` spawns this and asserts on what reaches the
+// pipe: crash-flush behavior only shows in a process that actually terminates.
+import { log } from "../../src/log.ts";
+
+const scenario = process.argv[2];
+const middleware = log();
+for (let i = 0; i < 3; i++) {
+  await middleware(new Request(`http://localhost/${i}`), () => new Response(""));
+}
+
+// The batched flush runs a check phase later, so everything above is still
+// buffered at this point.
+switch (scenario) {
+  case "sigterm":
+  case "sigint": {
+    // No other listener: the signal hook must flush and re-raise.
+    process.kill(process.pid, scenario === "sigint" ? "SIGINT" : "SIGTERM");
+    break;
+  }
+  case "handled-sigterm": {
+    // Another listener owns the shutdown; the logger must not force-kill and
+    // the regular flush delivers the lines once the loop drains.
+    process.on("SIGTERM", () => {});
+    process.kill(process.pid, "SIGTERM");
+    break;
+  }
+  case "exit": {
+    // Same-tick `process.exit()`: the `exit` hook flushes synchronously.
+    process.exit(0);
+  }
+  // "natural": fall through and let the event loop drain. Guards against the
+  // signal listeners keeping the process alive.
+}

--- a/test/fixtures/log-crash.mjs
+++ b/test/fixtures/log-crash.mjs
@@ -4,6 +4,19 @@
 import { log } from "../../src/log.ts";
 
 const scenario = process.argv[2];
+
+if (scenario === "once-cleanup") {
+  // Registered BEFORE the logger's hook exists: a `once` wrapper removes
+  // itself before running, so if the logger's sole-listener check saw the
+  // count after that, it would re-raise and kill this cleanup mid-flight.
+  process.once("SIGTERM", () => {
+    setTimeout(() => {
+      process.stdout.write("cleanup done\n");
+      process.exit(0);
+    }, 50);
+  });
+}
+
 const middleware = log();
 for (let i = 0; i < 3; i++) {
   await middleware(new Request(`http://localhost/${i}`), () => new Response(""));
@@ -12,10 +25,11 @@ for (let i = 0; i < 3; i++) {
 // The batched flush runs a check phase later, so everything above is still
 // buffered at this point.
 switch (scenario) {
+  case "sighup":
   case "sigterm":
-  case "sigint": {
-    // No other listener: the signal hook must flush and re-raise.
-    process.kill(process.pid, scenario === "sigint" ? "SIGINT" : "SIGTERM");
+  case "sigint":
+  case "once-cleanup": {
+    process.kill(process.pid, scenario === "once-cleanup" ? "SIGTERM" : scenario.toUpperCase());
     break;
   }
   case "handled-sigterm": {

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -271,6 +271,52 @@ describe("log", () => {
     }
   });
 
+  it("keeps a scheduled batched flush from writing mid-drain", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const isTTY = process.stdout.isTTY;
+    const write = process.stdout.write;
+    const restoreListeners = snapshotProcessListeners();
+    const writes: string[] = [];
+    let accepting = false;
+
+    try {
+      process.stdout.isTTY = false;
+      vi.resetModules();
+      const { log } = await import("../src/log.ts");
+
+      process.stdout.write = ((chunk: any) => {
+        writes.push(String(chunk));
+        return accepting;
+      }) as typeof write;
+
+      const batched = log();
+      const unbatched = log({ batch: false });
+
+      // The batched line schedules a flush; the unbatched one then writes both
+      // and starts a drain wait before that scheduled flush has fired.
+      await batched(request("http://localhost/a"), respond(200));
+      await unbatched(request("http://localhost/b"), respond(200));
+      expect(writes).toHaveLength(1);
+
+      // The stale scheduled flush fires now — it must not feed the full stream.
+      await batched(request("http://localhost/c"), respond(200));
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(writes).toHaveLength(1);
+
+      accepting = true;
+      process.stdout.emit("drain");
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(writes).toHaveLength(2);
+      expect(writes[1]).toContain("http://localhost/c");
+    } finally {
+      process.stdout.write = write;
+      process.stdout.isTTY = isTTY;
+      restoreListeners();
+    }
+  });
+
   it("buffers unbatched lines while the stream drains", async () => {
     vi.stubEnv("NODE_ENV", "production");
 
@@ -321,7 +367,7 @@ describe.skipIf(process.platform === "win32")("log crash flush", () => {
 
   const run = (
     scenario: string,
-  ): Promise<{ urls: string[]; code: number | null; signal: NodeJS.Signals | null }> =>
+  ): Promise<{ urls: string[]; out: string; code: number | null; signal: NodeJS.Signals | null }> =>
     new Promise((resolve, reject) => {
       const child = spawn(
         process.execPath,
@@ -344,7 +390,7 @@ describe.skipIf(process.platform === "win32")("log crash flush", () => {
           reject(new Error(`fixture stderr: ${err}`));
           return;
         }
-        resolve({ urls: [...out.matchAll(/GET (\S+)/g)].map((m) => m[1]!), code, signal });
+        resolve({ urls: [...out.matchAll(/GET (\S+)/g)].map((m) => m[1]!), out, code, signal });
       });
     });
 
@@ -361,6 +407,21 @@ describe.skipIf(process.platform === "win32")("log crash flush", () => {
     const result = await run("sigint");
     expect(result.urls).toEqual(allThree);
     expect(result.signal).toBe("SIGINT");
+  });
+
+  it("flushes buffered lines when a default-handled SIGHUP terminates the process", async () => {
+    const result = await run("sighup");
+    expect(result.urls).toEqual(allThree);
+    expect(result.signal).toBe("SIGHUP");
+  });
+
+  it("defers to a once-listener registered before the logger", async () => {
+    // `once` wrappers self-remove before running; the logger's handler must
+    // still count them (it runs first) instead of re-raising mid-cleanup.
+    const result = await run("once-cleanup");
+    expect(result.urls).toEqual(allThree);
+    expect(result.out).toContain("cleanup done");
+    expect(result.code).toBe(0);
   });
 
   it("defers to other signal listeners instead of killing the process", async () => {

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -1,5 +1,26 @@
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import type { ServerMiddleware, ServerRequest } from "../src/types.ts";
+
+/**
+ * Every fresh import of `log.ts` registers its own `exit`/`SIGTERM`/`SIGINT`
+ * hooks on the shared process; without cleanup the suite accumulates them past
+ * the max-listeners warning threshold.
+ */
+function snapshotProcessListeners(): () => void {
+  const events = ["exit", "SIGTERM", "SIGINT"] as const;
+  const before = new Map(events.map((event) => [event, new Set(process.listeners(event))]));
+  return () => {
+    for (const event of events) {
+      for (const listener of process.listeners(event)) {
+        if (!before.get(event)!.has(listener)) {
+          process.removeListener(event, listener);
+        }
+      }
+    }
+  };
+}
 
 const ESC = /\[\d+m/;
 
@@ -26,6 +47,7 @@ async function withLog(
 
   const isTTY = process.stdout.isTTY;
   const write = process.stdout.write;
+  const restoreListeners = snapshotProcessListeners();
   const chunks: string[] = [];
   try {
     process.stdout.isTTY = tty;
@@ -44,6 +66,7 @@ async function withLog(
   } finally {
     process.stdout.write = write;
     process.stdout.isTTY = isTTY;
+    restoreListeners();
   }
   return chunks;
 }
@@ -173,6 +196,7 @@ describe("log", () => {
 
     const isTTY = process.stdout.isTTY;
     const write = process.stdout.write;
+    const restoreListeners = snapshotProcessListeners();
     const writes: string[] = [];
     let accepting = false; // false => stream buffer is full
 
@@ -210,6 +234,150 @@ describe("log", () => {
     } finally {
       process.stdout.write = write;
       process.stdout.isTTY = isTTY;
+      restoreListeners();
     }
+  });
+
+  it("writes each line without waiting for a flush turn when batch is disabled", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const isTTY = process.stdout.isTTY;
+    const write = process.stdout.write;
+    const restoreListeners = snapshotProcessListeners();
+    const writes: string[] = [];
+
+    try {
+      process.stdout.isTTY = false;
+      vi.resetModules();
+      const { log } = await import("../src/log.ts");
+
+      process.stdout.write = ((chunk: any) => {
+        writes.push(String(chunk));
+        return true;
+      }) as typeof write;
+
+      const middleware = log({ batch: false });
+      // No setImmediate turn in between: the line must already be with stdout.
+      await middleware(request("http://localhost/a"), respond(200));
+      expect(writes).toHaveLength(1);
+      expect(writes[0]).toContain("http://localhost/a");
+      await middleware(request("http://localhost/b"), respond(200));
+      expect(writes).toHaveLength(2);
+      expect(writes[1]).toContain("http://localhost/b");
+    } finally {
+      process.stdout.write = write;
+      process.stdout.isTTY = isTTY;
+      restoreListeners();
+    }
+  });
+
+  it("buffers unbatched lines while the stream drains", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+
+    const isTTY = process.stdout.isTTY;
+    const write = process.stdout.write;
+    const restoreListeners = snapshotProcessListeners();
+    const writes: string[] = [];
+    let accepting = false;
+
+    try {
+      process.stdout.isTTY = false;
+      vi.resetModules();
+      const { log } = await import("../src/log.ts");
+
+      process.stdout.write = ((chunk: any) => {
+        writes.push(String(chunk));
+        return accepting;
+      }) as typeof write;
+
+      const middleware = log({ batch: false });
+      await middleware(request("http://localhost/a"), respond(200));
+      // The write returned false: subsequent lines must wait for `drain`
+      // instead of being forced onto a full stream.
+      await middleware(request("http://localhost/b"), respond(200));
+      expect(writes).toHaveLength(1);
+
+      accepting = true;
+      process.stdout.emit("drain");
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(writes).toHaveLength(2);
+      expect(writes[1]).toContain("http://localhost/b");
+    } finally {
+      process.stdout.write = write;
+      process.stdout.isTTY = isTTY;
+      restoreListeners();
+    }
+  });
+});
+
+/**
+ * Crash-flush behavior only shows in a process that actually terminates, so
+ * these spawn `fixtures/log-crash.mjs` and assert on what reaches the pipe.
+ * Self-delivered signals don't exist on Windows.
+ */
+describe.skipIf(process.platform === "win32")("log crash flush", () => {
+  const fixture = fileURLToPath(new URL("fixtures/log-crash.mjs", import.meta.url));
+
+  const run = (
+    scenario: string,
+  ): Promise<{ urls: string[]; code: number | null; signal: NodeJS.Signals | null }> =>
+    new Promise((resolve, reject) => {
+      const child = spawn(
+        process.execPath,
+        // Node 22 needs the flag to import the `.ts` source; on newer versions
+        // stripping is on by default and the flag only emits the warning.
+        ["--experimental-strip-types", "--disable-warning=ExperimentalWarning", fixture, scenario],
+        // Production disables colors, keeping the output assertions plain.
+        {
+          env: { ...process.env, NODE_ENV: "production", FORCE_COLOR: "" },
+          stdio: ["ignore", "pipe", "pipe"],
+        },
+      );
+      let out = "";
+      let err = "";
+      child.stdout.on("data", (chunk) => (out += chunk));
+      child.stderr.on("data", (chunk) => (err += chunk));
+      child.on("error", reject);
+      child.on("close", (code, signal) => {
+        if (err.trim()) {
+          reject(new Error(`fixture stderr: ${err}`));
+          return;
+        }
+        resolve({ urls: [...out.matchAll(/GET (\S+)/g)].map((m) => m[1]!), code, signal });
+      });
+    });
+
+  const allThree = ["http://localhost/0", "http://localhost/1", "http://localhost/2"];
+
+  it("flushes buffered lines when a default-handled SIGTERM terminates the process", async () => {
+    const result = await run("sigterm");
+    expect(result.urls).toEqual(allThree);
+    // The re-raise preserves death-by-signal semantics.
+    expect(result.signal).toBe("SIGTERM");
+  });
+
+  it("flushes buffered lines when a default-handled SIGINT terminates the process", async () => {
+    const result = await run("sigint");
+    expect(result.urls).toEqual(allThree);
+    expect(result.signal).toBe("SIGINT");
+  });
+
+  it("defers to other signal listeners instead of killing the process", async () => {
+    const result = await run("handled-sigterm");
+    expect(result.urls).toEqual(allThree);
+    expect(result.code).toBe(0);
+  });
+
+  it("flushes buffered lines on a same-tick process.exit()", async () => {
+    const result = await run("exit");
+    expect(result.urls).toEqual(allThree);
+    expect(result.code).toBe(0);
+  });
+
+  it("does not keep an idle process alive", async () => {
+    const result = await run("natural");
+    expect(result.urls).toEqual(allThree);
+    expect(result.code).toBe(0);
   });
 });

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -9,7 +9,7 @@ import type { ServerMiddleware, ServerRequest } from "../src/types.ts";
  * the max-listeners warning threshold.
  */
 function snapshotProcessListeners(): () => void {
-  const events = ["exit", "SIGTERM", "SIGINT"] as const;
+  const events = ["exit", "SIGHUP", "SIGTERM", "SIGINT"] as const;
   const before = new Map(events.map((event) => [event, new Set(process.listeners(event))]));
   return () => {
     for (const event of events) {


### PR DESCRIPTION
Follows up on the crash-safety concern raised on #266 ("missed logs prior to a crash"). I stress-tested the batched logger against real process deaths (child processes on Node 22/24, Deno, Bun) and closed the gaps that are actually closable.

## What the stress test showed

Scenarios where every buffered line already arrived before this PR: clean exit, same-tick `process.exit()`, uncaught exception, unhandled rejection (Node runs `exit` hooks on its default crash path), and SIGTERM/SIGINT with srvx graceful shutdown active.

Scenarios that lost the final event-loop turn of lines:

- **SIGHUP/SIGTERM/SIGINT with *default* handling** — no listener anywhere, so the runtime terminates without emitting `exit`. Happens when graceful shutdown is off (explicit `false`, the CI/TEST env carve-out, or `log()` used standalone with a non-srvx server). **Fixable — fixed here.**
- **SIGKILL / OOM killer / V8 heap OOM (SIGABRT)** — no userland code runs. Not fixable by hooks, but the pre-#266 unbatched logger *did* survive these for already-logged lines (each write lands in the kernel pipe buffer synchronously). **Addressed via an opt-out.**

## Changes

- **Signal flush hooks.** `hookExit()` now also registers a SIGHUP/SIGTERM/SIGINT listener (signal-exit style): if it turns out to be the *only* listener at delivery time, it flushes synchronously, removes itself and re-raises — the process still dies by the signal with exit semantics untouched (verified: parent observes `signal: SIGTERM`, not an exit code). When any other listener exists (e.g. srvx graceful shutdown), it defers entirely and the regular flush path delivers the lines. Registration uses `prependListener` so a `process.once(sig, cleanup)` registered earlier is still counted at delivery time — `once` wrappers self-remove before dispatch, and an appended handler would miscount them as absent and re-raise mid-cleanup. The listeners are unref'd on all three runtimes, so an idle process still exits naturally (covered by a test).
- **`batch: false` option.** Writes each line in the request's own turn instead of coalescing per event-loop turn — narrows a hard kill's loss window to the write in flight, matching the pre-#266 logger (verified: lines survive a same-tick SIGKILL on Node, Deno and Bun). It funnels through the shared buffer + drain logic, so it respects backpressure and can never overtake lines a batched logger is still holding; `flush()` gained a mid-drain guard so a stale scheduled flush can't feed a full stream when both modes are mixed.

## Verification

All child-process scenarios re-run after the change — buffered lines delivered in every runnable path:

| scenario | before | after |
| --- | --- | --- |
| default-handled SIGHUP / SIGTERM / SIGINT | ❌ lost | ✅ flushed, dies by signal |
| SIGTERM with graceful shutdown / other listener (incl. `once`) | ✅ | ✅ (hook defers) |
| same-tick `process.exit()`, uncaught exception, natural end | ✅ | ✅ |
| same-tick SIGKILL, `batch: false` | ❌ lost | ✅ in kernel buffer |
| same-tick SIGKILL, batched | ❌ | ❌ (≤ 1 turn, inherent) |

Tests spawn `test/fixtures/log-crash.mjs` and assert on what actually reaches the pipe plus how the process died — crash-flush behavior only shows in a process that really terminates. Suite also gained `batch: false` write/backpressure/mixed-mode cases and listener cleanup so repeated `log.ts` imports don't trip the max-listeners warning.

An independent clean-context review validated the design and surfaced the `once` race, the missing SIGHUP, the mid-drain guard and a doc overclaim — all addressed in the second commit (details in the comment below).

`pnpm test` green (1215 passed), lint and types clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a `batch` option for request logging.
  - Logging is batched by default; setting `batch: false` writes each request log immediately.
  - Added crash-safe flushing for buffered logs during normal exits, signals, and uncaught exceptions.

- **Documentation**
  - Expanded middleware logging guidance with batching examples and shutdown behavior.

- **Bug Fixes**
  - Improved reliability of log output during process termination and stdout backpressure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->