### PR TITLE
fix(url): keep `searchParams` identity and reflect mutations across deopt

### DIFF
--- a/src/_url.ts
+++ b/src/_url.ts
@@ -48,11 +48,86 @@ const _searchNeedsNormRE = /[#"'<>\x00-\x20\x7f-\uffff]/;
  *
  * - It is assumed that the input URL is **already encoded** and formatted from an HTTP request. A fragment (`#`), while not valid in an origin-form request target, is handled via full URL parsing.
  * - Triggering the setters or getters on other props will deoptimize to full URL parsing.
- * - Changes to `searchParams` will be discarded as we don't track them.
+ * - Mutating `searchParams` deoptimizes to full URL parsing; changes are reflected in `search`/`href` and the same `searchParams` object is kept across deopts (native `URL` semantics).
  */
 export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
   /* @__PURE__ */ (() => {
     const NativeURL = globalThis.URL;
+    const NativeSearchParams = globalThis.URLSearchParams;
+
+    /**
+     * Facade handed out by `FastURL`'s `searchParams` getter on the fast path so
+     * the spec's "same object for the lifetime of the URL" identity holds across
+     * a later deopt. Reads are served from a params object lazily parsed off the
+     * owner's search string; mutations materialize the owner's native URL first
+     * (the owner then swaps this facade's backing store to that URL's
+     * `searchParams` via `_adopt`) so the write lands in the single store
+     * `search`/`href` serialize from — matching native `URL` semantics.
+     */
+    const FastURLSearchParams: {
+      new (owner: { search: string; _url: globalThis.URL }): globalThis.URLSearchParams & {
+        /** @internal See `_adopt` in the class body. */
+        _adopt(params: globalThis.URLSearchParams): void;
+      };
+    } = class URLSearchParams implements Partial<globalThis.URLSearchParams> {
+      #owner: { search: string; _url: globalThis.URL };
+      #params?: globalThis.URLSearchParams;
+
+      constructor(owner: { search: string; _url: globalThis.URL }) {
+        this.#owner = owner;
+      }
+
+      static [Symbol.hasInstance](val: unknown) {
+        return val instanceof NativeSearchParams;
+      }
+
+      /**
+       * Swap the backing store for the materialized native URL's `searchParams`
+       * so this facade becomes a pure view over it: previously-taken references
+       * stay live and mutations through either view land in the single remaining
+       * store (mirrors `NodeRequestHeaders`'s `_adopt`). Called by `FastURL`'s
+       * `_url` getter.
+       * @internal
+       */
+      _adopt(params: globalThis.URLSearchParams) {
+        this.#params = params;
+      }
+
+      get _params(): globalThis.URLSearchParams {
+        return (this.#params ??= new NativeSearchParams(this.#owner.search));
+      }
+
+      // Writes must be reflected by the owner URL (`search`/`href`) like
+      // native. Materializing `_url` makes the owner adopt its native
+      // `searchParams` as this facade's store (a pre-adoption `#params` parsed
+      // from the same search string is safely discarded — it cannot have been
+      // mutated), so the write below lands in the linked store.
+      #mutable(): globalThis.URLSearchParams {
+        void this.#owner._url;
+        return this.#params!;
+      }
+
+      append(name: string, value: string): void {
+        this.#mutable().append(name, value);
+      }
+
+      set(name: string, value: string): void {
+        this.#mutable().set(name, value);
+      }
+
+      delete(name: string, value?: string): void {
+        this.#mutable().delete(name, value);
+      }
+
+      sort(): void {
+        this.#mutable().sort();
+      }
+    } as any;
+
+    lazyInherit(FastURLSearchParams.prototype, NativeSearchParams.prototype, "_params");
+
+    Object.setPrototypeOf(FastURLSearchParams.prototype, NativeSearchParams.prototype);
+    Object.setPrototypeOf(FastURLSearchParams, NativeSearchParams);
 
     const FastURL = class URL implements Partial<globalThis.URL> {
       #url?: globalThis.URL;
@@ -61,7 +136,7 @@ export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
       #host?: string;
       #pathname?: string;
       #search?: string;
-      #searchParams?: URLSearchParams;
+      #searchParams?: InstanceType<typeof FastURLSearchParams>;
       #pos?: [protocol: number, pathname: number, query: number];
 
       constructor(url: string | URLInit) {
@@ -106,8 +181,12 @@ export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
         this.#host = undefined;
         this.#pathname = undefined;
         this.#search = undefined;
-        this.#searchParams = undefined;
         this.#pos = undefined;
+        // Keep #searchParams: the handed-out facade stays this URL's
+        // `searchParams` identity; it now fronts the native URL's params so
+        // previously-taken references stay live and mutations through either
+        // view land in the single remaining store.
+        this.#searchParams?._adopt(this.#url.searchParams);
         return this.#url;
       }
 
@@ -167,13 +246,15 @@ export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
       }
 
       get searchParams() {
+        // The facade (created on the fast path) stays the answer even after a
+        // deopt — it fronts the native URL's params from then on (see `_url`).
+        if (this.#searchParams) {
+          return this.#searchParams;
+        }
         if (this.#url) {
           return this.#url.searchParams;
         }
-        if (!this.#searchParams) {
-          this.#searchParams = new URLSearchParams(this.search);
-        }
-        return this.#searchParams;
+        return (this.#searchParams = new FastURLSearchParams(this));
       }
 
       get protocol() {

--- a/src/_url.ts
+++ b/src/_url.ts
@@ -94,7 +94,18 @@ export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
       }
 
       get _params(): globalThis.URLSearchParams {
-        return (this.#params ??= new NativeSearchParams(this.#owner.search));
+        if (!this.#params) {
+          // Read the owner's search BEFORE the `??=` check below: if this read
+          // ever deopted the owner, its `_url` getter would `_adopt` into
+          // `#params`, and a blind assignment here would overwrite the adopted
+          // (URL-linked) store with a detached copy — silently re-detaching the
+          // facade. Unreachable today (a facade only exists on the fast path,
+          // whose href always contains a `/` so `search` never deopts), but
+          // don't rely on that invariant.
+          const search = this.#owner.search;
+          this.#params ??= new NativeSearchParams(search);
+        }
+        return this.#params;
       }
 
       // Writes must be reflected by the owner URL (`search`/`href`) like

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -54,6 +54,85 @@ describe("FastURL", () => {
     expect(url.searchParams).toEqual(new URLSearchParams("?search"));
   });
 
+  describe("searchParams identity & mutation", () => {
+    // Native URL hands out the SAME `searchParams` object for the lifetime of
+    // the URL, and mutations are reflected in `search`/`href`. The fast path
+    // used to hand out a detached URLSearchParams whose identity broke on any
+    // deopt (even a read-only `url.host` access) and whose mutations were
+    // silently discarded. The facade (with `_adopt`, mirroring
+    // NodeRequestHeaders) must close both gaps.
+
+    test("same object across a read-only deopt", () => {
+      const url = new FastURL("/p?a=1");
+      const params = url.searchParams;
+      void url.hostname; // deopt to native URL
+      expect(url.searchParams).toBe(params);
+      expect(params.get("a")).toBe("1");
+    });
+
+    test("instanceof URLSearchParams, iterable, and copyable", () => {
+      const url = new FastURL("/p?a=1&b=2");
+      const params = url.searchParams;
+      expect(params instanceof URLSearchParams).toBe(true);
+      expect([...params]).toEqual([
+        ["a", "1"],
+        ["b", "2"],
+      ]);
+      expect(new URLSearchParams(params as any).toString()).toBe("a=1&b=2");
+      expect(params.size).toBe(2);
+      expect(params.getAll("a")).toEqual(["1"]);
+      expect(params.toString()).toBe("a=1&b=2");
+    });
+
+    test("set/append/delete/sort are reflected in search & href (like native)", () => {
+      const std = new URL("http://localhost/p?b=2&a=1");
+      const url = new FastURL("/p?b=2&a=1");
+      for (const u of [std, url]) {
+        u.searchParams.set("c", "3");
+        u.searchParams.append("a", "x");
+        u.searchParams.delete("b");
+        u.searchParams.sort();
+      }
+      expect(url.search, ".search").toBe(std.search);
+      expect(url.href, ".href").toBe(std.href);
+      expect(url.searchParams.toString()).toBe(std.searchParams.toString());
+    });
+
+    test("reference taken before deopt observes later URL mutations", () => {
+      const url = new FastURL("/p?a=1");
+      const params = url.searchParams;
+      url.search = "?z=9"; // setter deopts and mutates the native URL
+      expect(params.get("z")).toBe("9");
+      expect(params.get("a")).toBe(null);
+      expect(url.searchParams).toBe(params);
+    });
+
+    test("mutation on the fast path deopts and drops cached search", () => {
+      const url = new FastURL("/p?a=1");
+      expect(url.search).toBe("?a=1"); // populate fast-path cache first
+      url.searchParams.delete("a");
+      expect(url.search).toBe("");
+      expect(url.href).toBe("http://localhost/p");
+    });
+
+    test("constructor slow path keeps stable native searchParams", () => {
+      const url = new FastURL("http://example.com/p?a=1");
+      const params = url.searchParams;
+      expect(url.searchParams).toBe(params);
+      params.set("b", "2");
+      expect(url.search).toBe("?a=1&b=2");
+    });
+
+    test("NodeRequestURL: mutation reflected, raw req.url untouched", () => {
+      const req = { url: "/p?a=1", headers: { host: "localhost" } } as any;
+      const url = new NodeRequestURL({ req });
+      url.searchParams.set("b", "2");
+      expect(url.href).toBe("http://localhost/p?a=1&b=2");
+      expect(url.searchParams).toBe(url.searchParams);
+      expect(req.url).toBe("/p?a=1");
+    });
+  });
+
   describe("origin-form string (bare path)", () => {
     // Regression (F12): `new FastURL("/foo?x=1")` is a documented fast path.
     // It must resolve against `http://localhost` semantics (like the adapter's

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -123,6 +123,59 @@ describe("FastURL", () => {
       expect(url.search).toBe("?a=1&b=2");
     });
 
+    test("read-then-mutate: detached read cache is discarded on adoption", () => {
+      const url = new FastURL("/p?a=1");
+      const params = url.searchParams;
+      expect(params.get("a")).toBe("1"); // populate the lazily-parsed read store
+      params.set("b", "2"); // adopts the native URL's params; read store discarded
+      expect(url.search).toBe("?a=1&b=2");
+      expect(url.href).toBe("http://localhost/p?a=1&b=2");
+      expect(params.get("b")).toBe("2");
+    });
+
+    test("encoding round-trip matches native (%2B, +, %20)", () => {
+      const input = "/p?a=%2B&b=+&c=%20";
+      const std = new URL(`http://localhost${input}`);
+      const url = new FastURL(input);
+      expect(url.searchParams.get("a")).toBe(std.searchParams.get("a")); // "+"
+      expect(url.searchParams.get("b")).toBe(std.searchParams.get("b")); // " "
+      expect(url.searchParams.get("c")).toBe(std.searchParams.get("c")); // " "
+      for (const u of [std, url]) {
+        u.searchParams.set("d", "+ &=");
+      }
+      expect(url.search).toBe(std.search);
+      expect(url.href).toBe(std.href);
+    });
+
+    test("forEach forwards thisArg", () => {
+      const url = new FastURL("/p?a=1&b=2");
+      const thisArg = { tag: "ctx" };
+      const seen: [string, string, unknown][] = [];
+      url.searchParams.forEach(function (this: unknown, value, key) {
+        seen.push([key, value, this]);
+      }, thisArg);
+      expect(seen).toEqual([
+        ["a", "1", thisArg],
+        ["b", "2", thisArg],
+      ]);
+    });
+
+    test("delete/has with value argument match native", () => {
+      const std = new URL("http://localhost/p?a=1&a=2&b=3");
+      const url = new FastURL("/p?a=1&a=2&b=3");
+      expect(url.searchParams.has("a", "2")).toBe(true);
+      expect(url.searchParams.has("a", "9")).toBe(false);
+      for (const u of [std, url]) {
+        u.searchParams.delete("a", "1");
+      }
+      expect(url.search).toBe(std.search);
+      for (const u of [std, url]) {
+        u.searchParams.delete("b");
+      }
+      expect(url.search).toBe(std.search);
+      expect(url.href).toBe(std.href);
+    });
+
     test("NodeRequestURL: mutation reflected, raw req.url untouched", () => {
       const req = { url: "/p?a=1", headers: { host: "localhost" } } as any;
       const url = new NodeRequestURL({ req });


### PR DESCRIPTION
## Problem

`FastURL`'s fast path hands out a **detached** `URLSearchParams` built from the search string. That breaks native `URL` semantics in two observable ways:

1. **Identity break on deopt.** Any access to a non-fast-path prop — even a read-only one like `url.host` / `url.hostname` / `url.origin` / `url.port` — deopts to the native URL and cleared `#searchParams`, so the next `url.searchParams` read returned a *different* object. Native `URL` guarantees the same object for the lifetime of the URL.

   ```js
   const p = url.searchParams;
   url.host;                  // read-only access, silently deopts
   url.searchParams === p;    // was false
   ```

2. **Dropped mutations.** Writes to the detached object were never reflected in `search`/`href` and were discarded entirely at deopt (previously a documented caveat).

## Fix

Hand out a small facade instead, using the same `_adopt` pattern as `NodeRequestHeaders` (and the same `lazyInherit` machinery):

- Reads are served from a params object lazily parsed off the owner's search string — the fast path stays allocation-light and never parses the full URL.
- The four mutators (`append`/`set`/`delete`/`sort`) materialize the owner's native URL first; the owner's `_url` getter then calls `facade._adopt(nativeURL.searchParams)`, swapping the facade's backing store to the native URL's linked params. The write lands in the single store `search`/`href` serialize from.
- On any other deopt, `_url` likewise adopts instead of clearing, so the handed-out object stays identical and previously-taken references stay live.

Net effect: `searchParams` identity is stable for the lifetime of the URL and mutations behave exactly like native `URL` — the "changes will be discarded" caveat is gone. This also means a `searchParams` mutation made before `NodeRequest._request` materializes is now reflected in the native `Request`'s URL.

## Tests

New `searchParams identity & mutation` suite: identity across read-only deopt, liveness of pre-deopt references after URL mutation, set/append/delete/sort parity with native (`search`/`href`/serialization), iteration/copy-construct/`instanceof`/`size`, constructor slow path, and `NodeRequestURL` (raw `req.url` stays untouched). Full suite green (typecheck, lint, 1243 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL query-parameter (`searchParams`) behavior to align with native WHATWG `URL`, including stable object identity across optimized/native transitions.
  * Ensured `searchParams` mutations (add/set/delete/sort) stay synchronized with both `search` and `href`, including correct encoding round-trips.
  * Matched `NodeRequestURL` behavior so updates reflect in the computed URL while leaving the original request URL string unchanged.
* **Tests**
  * Expanded coverage for identity preservation, iteration/constructibility, mutation semantics (including value-aware `has`/`delete`), and `NodeRequestURL` synchronization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->