### PR TITLE
refactor!: rename subpath exports to `*Middleware` / `*Plugin`

### DIFF
--- a/docs/1.guide/2.handler.md
+++ b/docs/1.guide/2.handler.md
@@ -45,7 +45,7 @@ serve({
 
 ### `request.tls?`
 
-TLS connection state, including the client (peer) certificate, negotiated protocol and cipher. Added by the opt-in [`mtls()` plugin](/guide/tls#mutual-tls-mtls) (`srvx/mtls`); `undefined` for plain HTTP requests or when the plugin is not enabled.
+TLS connection state, including the client (peer) certificate, negotiated protocol and cipher. Added by the opt-in [`mtlsPlugin()`](/guide/tls#mutual-tls-mtls) (`srvx/mtls`); `undefined` for plain HTTP requests or when the plugin is not enabled.
 
 :read-more{to="/guide/tls" title="TLS & mutual TLS"}
 

--- a/docs/1.guide/4.middleware.md
+++ b/docs/1.guide/4.middleware.md
@@ -47,25 +47,25 @@ Plugins are applied in `plugins` array order, before the server starts listening
 
 srvx ships several optional extensions as separate subpath imports. All of them are opt-in — importing `srvx` alone pulls in none of them.
 
-| Import         | Export            | Kind       | Runtimes        |
-| -------------- | ----------------- | ---------- | --------------- |
-| `srvx/log`     | `log()`           | Middleware | All             |
-| `srvx/static`  | `serveStatic()`   | Middleware | Node, Deno, Bun |
-| `srvx/mtls`    | `mtls()`          | Plugin     | Node            |
-| `srvx/tracing` | `tracingPlugin()` | Plugin     | Node, Deno, Bun |
+| Import         | Export               | Kind       | Runtimes        |
+| -------------- | -------------------- | ---------- | --------------- |
+| `srvx/log`     | `loggerMiddleware()` | Middleware | All             |
+| `srvx/static`  | `staticMiddleware()` | Middleware | Node, Deno, Bun |
+| `srvx/mtls`    | `mtlsPlugin()`       | Plugin     | Node            |
+| `srvx/tracing` | `tracingPlugin()`    | Plugin     | Node, Deno, Bun |
 
 ### Request logging
 
-`log()` from `srvx/log` prints one line per request with the method, URL, status, and duration.
+`loggerMiddleware()` from `srvx/log` prints one line per request with the method, URL, status, and duration.
 
 Colors are disabled when `NODE_ENV` is `production`, as well as when [`NO_COLOR`](https://no-color.org/) is set or output is not a TTY. Set `FORCE_COLOR` to keep them in any of those cases.
 
 ```ts [server.ts]
 import { serve } from "srvx";
-import { log } from "srvx/log";
+import { loggerMiddleware } from "srvx/log";
 
 serve({
-  middleware: [log()],
+  middleware: [loggerMiddleware()],
   fetch: () => new Response("👋 Hello there."),
 });
 ```
@@ -74,15 +74,15 @@ serve({
 [10:32:03 AM] GET http://localhost:3000/ [200] (1.42ms)
 ```
 
-The duration is measured around `next()`, so place `log()` first in the array for it to cover the whole chain. The [CLI](/guide/cli) enables this middleware automatically.
+The duration is measured around `next()`, so place `loggerMiddleware()` first in the array for it to cover the whole chain. The [CLI](/guide/cli) enables this middleware automatically.
 
-**`log()` options:**
+**`loggerMiddleware()` options:**
 
 - `batch`: Coalesce lines and write once per event-loop turn (default: `true`). Set to `false` to hand each line to stdout as its request completes — slower under concurrency, but a line never waits for a flush turn.
 
 ```ts
 serve({
-  middleware: [log({ batch: false })],
+  middleware: [loggerMiddleware({ batch: false })],
   fetch: () => new Response("👋 Hello there."),
 });
 ```
@@ -91,21 +91,21 @@ serve({
 
 ### Static files
 
-`serveStatic()` from `srvx/static` serves files from a directory, with `index.html` resolution, `.html` extension fallback (`/about` → `about.html`), common MIME types, gzip/Brotli compression, and path-traversal protection.
+`staticMiddleware()` from `srvx/static` serves files from a directory, with `index.html` resolution, `.html` extension fallback (`/about` → `about.html`), common MIME types, gzip/Brotli compression, and path-traversal protection.
 
 ```ts [server.ts]
 import { serve } from "srvx";
-import { serveStatic } from "srvx/static";
+import { staticMiddleware } from "srvx/static";
 
 serve({
-  middleware: [serveStatic({ dir: "public" })],
+  middleware: [staticMiddleware({ dir: "public" })],
   fetch: () => new Response("Not found", { status: 404 }),
 });
 ```
 
 When no file matches the request, it calls `next()` — so your handler acts as the fallback for unmatched paths.
 
-**`serveStatic()` options:**
+**`staticMiddleware()` options:**
 
 - `dir`: The directory to serve files from (required).
 - `methods`: HTTP methods to serve (default `["GET", "HEAD"]`). Other methods fall through to `next()`.
@@ -144,7 +144,7 @@ See [Serving static files](/guide/cli#serving-static-files) for the equivalent C
 
 ### Mutual TLS
 
-[`mtls()`](/guide/tls#mutual-tls-mtls) from `srvx/mtls` requests a client certificate during the TLS handshake and exposes it on [`request.tls`](/guide/handler#requesttls). It requires the [Node.js adapter](/guide/node).
+[`mtlsPlugin()`](/guide/tls#mutual-tls-mtls) from `srvx/mtls` requests a client certificate during the TLS handshake and exposes it on [`request.tls`](/guide/handler#requesttls). It requires the [Node.js adapter](/guide/node).
 
 ### Tracing
 

--- a/docs/1.guide/5.options.md
+++ b/docs/1.guide/5.options.md
@@ -151,7 +151,7 @@ serve({
 > [!TIP]
 > You can pass inline `cert` and `key` values in PEM format starting with `-----BEGIN `.
 
-Client certificates (mutual TLS) are available through the [`mtls()` plugin](/guide/tls#mutual-tls-mtls).
+Client certificates (mutual TLS) are available through the [`mtlsPlugin()` plugin](/guide/tls#mutual-tls-mtls).
 
 :read-more{to="/guide/tls" title="TLS & mutual TLS"}
 

--- a/docs/1.guide/6.tls.md
+++ b/docs/1.guide/6.tls.md
@@ -39,7 +39,7 @@ Server TLS works on **Node.js**, **Deno** and **Bun**.
 
 ## Mutual TLS (mTLS)
 
-Mutual TLS is provided by the opt-in `mtls()` plugin from `srvx/mtls`. It requests a client certificate during the handshake and exposes it — with the negotiated protocol and cipher — on [`request.tls`](#requesttls).
+Mutual TLS is provided by the opt-in `mtlsPlugin()` from `srvx/mtls`. It requests a client certificate during the handshake and exposes it — with the negotiated protocol and cipher — on [`request.tls`](#requesttls).
 
 There are two places an unauthenticated client can be turned away, depending on `rejectUnauthorized`:
 
@@ -48,12 +48,12 @@ There are two places an unauthenticated client can be turned away, depending on 
 
 ```js
 import { serve } from "srvx/node";
-import { mtls } from "srvx/mtls";
+import { mtlsPlugin } from "srvx/mtls";
 
 serve({
   tls: { cert: "./server.crt", key: "./server.key" },
   plugins: [
-    mtls({
+    mtlsPlugin({
       ca: "./ca.crt",
       requestCert: true,
       // Accept the handshake even for untrusted/missing certs so the
@@ -73,7 +73,7 @@ serve({
 > [!IMPORTANT]
 > With the default `rejectUnauthorized: true`, the `if (!request.tls?.authorized)` check above is unreachable — unauthenticated clients are already rejected at the TLS layer. Only set `rejectUnauthorized: false` if you intend to enforce authorization yourself in the handler, as shown here.
 
-**`mtls()` options:**
+**`mtlsPlugin()` options:**
 
 - `ca`: Trusted CA certificate(s) in PEM format — file path(s) or inline content (optional). When set, replaces the well-known Mozilla CAs.
 - `requestCert`: Request a certificate from connecting clients (default `true`).
@@ -92,7 +92,7 @@ While the plugin is active, [`request.tls`](/guide/handler#requesttls) provides:
 ### Runtime support
 
 > [!NOTE]
-> `mtls()` requires an HTTPS server (`tls.cert` + `tls.key`) and srvx's **Node.js adapter** (`import { serve } from "srvx/node"`); it throws otherwise.
+> `mtlsPlugin()` requires an HTTPS server (`tls.cert` + `tls.key`) and srvx's **Node.js adapter** (`import { serve } from "srvx/node"`); it throws otherwise.
 >
 > - **Node.js** — works natively.
 > - **Deno** (2.8+) — works through the Node adapter, which runs on Deno via `node:https`. (Native `Deno.serve` cannot request client certificates.)

--- a/docs/1.guide/9.aws-lambda.md
+++ b/docs/1.guide/9.aws-lambda.md
@@ -14,10 +14,10 @@ To use the AWS Lambda adapter, import the `toLambdaHandler` function from `"srvx
 
 ```ts [server.ts]
 import { toLambdaHandler } from "srvx/aws-lambda";
-import { serveStatic } from "srvx/static";
+import { staticMiddleware } from "srvx/static";
 
 export const handler = toLambdaHandler({
-  middleware: [serveStatic({ dir: "public" })],
+  middleware: [staticMiddleware({ dir: "public" })],
   fetch(req: Request) {
     return Response.json({ hello: "world!" });
   },
@@ -32,7 +32,7 @@ You can find a complete example of AWS Lambda in the [examples/aws-lambda](https
 
 ## Serving Static Assets
 
-The example above uses `serveStatic` middleware to serve static files directly from the Lambda function. While this works for simple use cases, it comes with limitations:
+The example above uses `staticMiddleware` to serve static files directly from the Lambda function. While this works for simple use cases, it comes with limitations:
 
 - Lambda has a deployment package size limit (50MB zipped, 250MB unzipped)
 - Each static file request incurs Lambda invocation costs

--- a/examples/aws-lambda/server.ts
+++ b/examples/aws-lambda/server.ts
@@ -1,8 +1,8 @@
 import { toLambdaHandler } from "srvx/aws-lambda";
-import { serveStatic } from "srvx/static";
+import { staticMiddleware } from "srvx/static";
 
 export const handler = toLambdaHandler({
-  middleware: [serveStatic({ dir: "public" })],
+  middleware: [staticMiddleware({ dir: "public" })],
   fetch(req: Request) {
     return Response.json({ hello: "world!" });
   },

--- a/src/cli/serve.ts
+++ b/src/cli/serve.ts
@@ -29,8 +29,8 @@ export async function cliServe(cliOpts: CLIOptions): Promise<void> {
     const { serve: srvxServe } = loaded.nodeCompat
       ? await import("srvx/node")
       : await import("srvx");
-    const { serveStatic } = await import("srvx/static");
-    const { log } = await import("srvx/log");
+    const { staticMiddleware } = await import("srvx/static");
+    const { loggerMiddleware } = await import("srvx/log");
 
     // F43: an explicit `--static` pointing at a missing dir must error; the
     // implicit `public` default may stay silent.
@@ -88,9 +88,9 @@ export async function cliServe(cliOpts: CLIOptions): Promise<void> {
             501,
           )),
       middleware: [
-        log(),
+        loggerMiddleware(),
         cliOpts.static
-          ? serveStatic({
+          ? staticMiddleware({
               dir: cliOpts.static,
             })
           : undefined,

--- a/src/log.ts
+++ b/src/log.ts
@@ -1,7 +1,7 @@
 import * as c from "./cli/_utils.ts";
 import type { ServerMiddleware } from "./types.ts";
 
-export interface LogOptions {
+export interface LoggerMiddlewareOptions {
   /**
    * Batch lines and write once per event-loop turn (default: `true`). Set to
    * `false` to hand each line to stdout in the request's own turn: slower
@@ -23,7 +23,7 @@ const paintForStatus = (code: number): Paint =>
  * which is the norm in production. `FORCE_COLOR` still wins, and `cli/_utils.ts`
  * covers the `NO_COLOR` and non-TTY cases on top of this.
  *
- * Resolved per `log()` call rather than at module scope: the CLI assigns
+ * Resolved per `loggerMiddleware()` call rather than at module scope: the CLI assigns
  * `NODE_ENV` while booting, after this module has already been imported.
  */
 function colorsEnabled(): boolean {
@@ -203,7 +203,9 @@ function hookExit(): void {
   }
 }
 
-export const log: (options?: LogOptions) => ServerMiddleware = (options = {}) => {
+export const loggerMiddleware: (options?: LoggerMiddlewareOptions) => ServerMiddleware = (
+  options = {},
+) => {
   const emit = options.batch === false ? writeNow : enqueue;
   const colors = colorsEnabled();
   const paint = (fn: Paint): Paint => (colors ? fn : plain);

--- a/src/mtls.ts
+++ b/src/mtls.ts
@@ -49,7 +49,7 @@ declare module "srvx" {
     /**
      * TLS connection state, including the client (peer) certificate for mutual TLS.
      *
-     * Populated by the {@link mtls} plugin. `undefined` when the request was not served over TLS.
+     * Populated by the {@link mtlsPlugin}. `undefined` when the request was not served over TLS.
      */
     tls?: ServerRequestTLS | undefined;
   }
@@ -61,9 +61,9 @@ declare module "./types.ts" {
 }
 
 /**
- * Options for the {@link mtls} plugin.
+ * Options for the {@link mtlsPlugin}.
  */
-export interface MTLSOptions {
+export interface MTLSPluginOptions {
   /**
    * File path(s) or inlined CA certificate(s) in PEM format used to verify client certificates.
    *
@@ -113,11 +113,11 @@ export interface MTLSOptions {
  * @example
  * ```js
  * import { serve } from "srvx/node";
- * import { mtls } from "srvx/mtls";
+ * import { mtlsPlugin } from "srvx/mtls";
  *
  * serve({
  *   tls: { cert, key },
- *   plugins: [mtls({ ca, requestCert: true, rejectUnauthorized: false })],
+ *   plugins: [mtlsPlugin({ ca, requestCert: true, rejectUnauthorized: false })],
  *   fetch: (request) => {
  *     if (!request.tls?.authorized) {
  *       return new Response("client certificate required", { status: 401 });
@@ -127,18 +127,18 @@ export interface MTLSOptions {
  * });
  * ```
  */
-export function mtls(options: MTLSOptions = {}): ServerPlugin {
+export function mtlsPlugin(options: MTLSPluginOptions = {}): ServerPlugin {
   return (server) => {
     // Only the Node.js adapter exposes the peer certificate. Fail loudly on anything
     // else instead of silently leaving `request.tls` empty in production.
     if (server.runtime !== "node") {
       throw new Error(
-        `[srvx] mtls() requires srvx's Node.js adapter (import { serve } from "srvx/node"). The "${server.runtime}" server cannot request or expose client certificates.`,
+        `[srvx] mtlsPlugin() requires srvx's Node.js adapter (import { serve } from "srvx/node"). The "${server.runtime}" server cannot request or expose client certificates.`,
       );
     }
     if ("Bun" in globalThis) {
       throw new Error(
-        "[srvx] mtls() is not available on Bun: Bun does not expose the peer certificate to node:http(s) request handlers. See https://github.com/oven-sh/bun/issues/16254",
+        "[srvx] mtlsPlugin() is not available on Bun: Bun does not expose the peer certificate to node:http(s) request handlers. See https://github.com/oven-sh/bun/issues/16254",
       );
     }
     // Mutual TLS is meaningless without TLS. The node adapter accepts cert/key
@@ -149,7 +149,7 @@ export function mtls(options: MTLSOptions = {}): ServerPlugin {
     const key = server.options.tls?.key ?? nodeOptions?.key;
     if (server.options.protocol === "http" || !cert || !key) {
       throw new Error(
-        "[srvx] mtls() requires an HTTPS server: set `tls.cert` and `tls.key`. Mutual TLS cannot run over plain HTTP.",
+        "[srvx] mtlsPlugin() requires an HTTPS server: set `tls.cert` and `tls.key`. Mutual TLS cannot run over plain HTTP.",
       );
     }
 
@@ -160,7 +160,9 @@ export function mtls(options: MTLSOptions = {}): ServerPlugin {
       ca = entries.map((entry) => {
         const resolved = resolveCertOrKey(entry);
         if (!resolved) {
-          throw new TypeError("mtls() `ca` entries must be non-empty PEM strings or file paths.");
+          throw new TypeError(
+            "mtlsPlugin() `ca` entries must be non-empty PEM strings or file paths.",
+          );
         }
         return resolved;
       });

--- a/src/static.ts
+++ b/src/static.ts
@@ -11,7 +11,7 @@ import { constants as zlibConstants, createBrotliCompress, createGzip } from "no
 import { FastResponse } from "srvx";
 import { FastURL } from "./_url.ts";
 
-export interface ServeStaticOptions {
+export interface StaticMiddlewareOptions {
   /**
    * The directory to serve static files from.
    */
@@ -212,7 +212,7 @@ type EncodingSpec = {
   compressor?: (sizeHint: number) => Transform;
 };
 
-export const serveStatic = (options: ServeStaticOptions): ServerMiddleware => {
+export const staticMiddleware = (options: StaticMiddlewareOptions): ServerMiddleware => {
   // `resolve()` also converts separators (`C:/assets` -> `C:\assets`), and
   // `join()`/`realpath()` only emit native ones, so every path a `sep`-based
   // check sees is already in platform form.

--- a/test/fixtures/log-crash.mjs
+++ b/test/fixtures/log-crash.mjs
@@ -1,7 +1,7 @@
-// Emits three lines through the real `log()` middleware, then dies according to
+// Emits three lines through the real `loggerMiddleware()` middleware, then dies according to
 // process.argv[2]. `log.test.ts` spawns this and asserts on what reaches the
 // pipe: crash-flush behavior only shows in a process that actually terminates.
-import { log } from "../../src/log.ts";
+import { loggerMiddleware } from "../../src/log.ts";
 
 const scenario = process.argv[2];
 
@@ -17,7 +17,7 @@ if (scenario === "once-cleanup") {
   });
 }
 
-const middleware = log();
+const middleware = loggerMiddleware();
 for (let i = 0; i < 3; i++) {
   await middleware(new Request(`http://localhost/${i}`), () => new Response(""));
 }

--- a/test/log.test.ts
+++ b/test/log.test.ts
@@ -35,7 +35,7 @@ const ESC = /\[\d+m/;
  */
 async function withLog(
   env: Record<string, string>,
-  run: (log: (options?: any) => ServerMiddleware) => Promise<void>,
+  run: (loggerMiddleware: (options?: any) => ServerMiddleware) => Promise<void>,
   { tty = false }: { tty?: boolean } = {},
 ): Promise<string[]> {
   for (const [key, value] of Object.entries(env)) {
@@ -52,14 +52,14 @@ async function withLog(
   try {
     process.stdout.isTTY = tty;
     vi.resetModules();
-    const { log } = await import("../src/log.ts");
+    const { loggerMiddleware } = await import("../src/log.ts");
 
     process.stdout.write = ((chunk: any) => {
       chunks.push(String(chunk));
       return true;
     }) as typeof write;
 
-    await run(log);
+    await run(loggerMiddleware);
     // Lines are flushed on the next check phase; give it two turns to land.
     await new Promise((resolve) => setImmediate(resolve));
     await new Promise((resolve) => setImmediate(resolve));
@@ -84,10 +84,10 @@ afterEach(() => {
   vi.unstubAllEnvs();
 });
 
-describe("log", () => {
+describe("loggerMiddleware", () => {
   it("logs method, url, status and duration", async () => {
-    const chunks = await withLog({ NODE_ENV: "production" }, async (log) => {
-      const middleware = log();
+    const chunks = await withLog({ NODE_ENV: "production" }, async (loggerMiddleware) => {
+      const middleware = loggerMiddleware();
       await middleware(request("http://localhost/hello"), respond(200));
     });
 
@@ -98,9 +98,9 @@ describe("log", () => {
 
   it("passes the response through untouched", async () => {
     let response: Response | undefined;
-    await withLog({ NODE_ENV: "production" }, async (log) => {
+    await withLog({ NODE_ENV: "production" }, async (loggerMiddleware) => {
       const original = new Response("body", { status: 201 });
-      response = (await log()(request(), () => original)) as Response;
+      response = (await loggerMiddleware()(request(), () => original)) as Response;
       expect(response).toBe(original);
     });
     expect(await response!.text()).toBe("body");
@@ -109,8 +109,8 @@ describe("log", () => {
   it("emits no colors in production, even on a color-capable stdout", async () => {
     const chunks = await withLog(
       { NODE_ENV: "production" },
-      async (log) => {
-        const middleware = log();
+      async (loggerMiddleware) => {
+        const middleware = loggerMiddleware();
         await middleware(request(), respond(200));
         await middleware(request(), respond(500));
       },
@@ -127,8 +127,8 @@ describe("log", () => {
   it("emits colors outside production", async () => {
     const chunks = await withLog(
       { NODE_ENV: "development" },
-      async (log) => {
-        await log()(request(), respond(200));
+      async (loggerMiddleware) => {
+        await loggerMiddleware()(request(), respond(200));
       },
       { tty: true },
     );
@@ -137,20 +137,26 @@ describe("log", () => {
   });
 
   it("lets FORCE_COLOR override the production default", async () => {
-    const chunks = await withLog({ NODE_ENV: "production", FORCE_COLOR: "1" }, async (log) => {
-      await log()(request(), respond(200));
-    });
+    const chunks = await withLog(
+      { NODE_ENV: "production", FORCE_COLOR: "1" },
+      async (loggerMiddleware) => {
+        await loggerMiddleware()(request(), respond(200));
+      },
+    );
 
     expect(chunks.join("")).toMatch(ESC);
   });
 
   it("colors the status by its leading digit", async () => {
-    const chunks = await withLog({ NODE_ENV: "development", FORCE_COLOR: "1" }, async (log) => {
-      const middleware = log();
-      for (const status of [101, 200, 302, 404, 500]) {
-        await middleware(request(), respondWith(status));
-      }
-    });
+    const chunks = await withLog(
+      { NODE_ENV: "development", FORCE_COLOR: "1" },
+      async (loggerMiddleware) => {
+        const middleware = loggerMiddleware();
+        for (const status of [101, 200, 302, 404, 500]) {
+          await middleware(request(), respondWith(status));
+        }
+      },
+    );
     const lines = chunks.join("").trimEnd().split("\n");
 
     expect(lines[0]).toContain("[[34m101[39m]"); // 1xx blue
@@ -161,8 +167,8 @@ describe("log", () => {
   });
 
   it("coalesces lines logged in the same turn into a single write", async () => {
-    const chunks = await withLog({ NODE_ENV: "production" }, async (log) => {
-      const middleware = log();
+    const chunks = await withLog({ NODE_ENV: "production" }, async (loggerMiddleware) => {
+      const middleware = loggerMiddleware();
       await Promise.all(
         Array.from({ length: 20 }, (_, i) =>
           middleware(request(`http://localhost/${i}`), respond(200)),
@@ -175,8 +181,8 @@ describe("log", () => {
   });
 
   it("preserves order across writes", async () => {
-    const chunks = await withLog({ NODE_ENV: "production" }, async (log) => {
-      const middleware = log();
+    const chunks = await withLog({ NODE_ENV: "production" }, async (loggerMiddleware) => {
+      const middleware = loggerMiddleware();
       for (const i of [0, 1, 2]) {
         await middleware(request(`http://localhost/${i}`), respond(200));
         await new Promise((resolve) => setImmediate(resolve));
@@ -203,14 +209,14 @@ describe("log", () => {
     try {
       process.stdout.isTTY = false;
       vi.resetModules();
-      const { log } = await import("../src/log.ts");
+      const { loggerMiddleware } = await import("../src/log.ts");
 
       process.stdout.write = ((chunk: any) => {
         writes.push(String(chunk));
         return accepting;
       }) as typeof write;
 
-      const middleware = log();
+      const middleware = loggerMiddleware();
       const flushed = () => new Promise((resolve) => setImmediate(resolve));
 
       await middleware(request("http://localhost/a"), respond(200));
@@ -249,14 +255,14 @@ describe("log", () => {
     try {
       process.stdout.isTTY = false;
       vi.resetModules();
-      const { log } = await import("../src/log.ts");
+      const { loggerMiddleware } = await import("../src/log.ts");
 
       process.stdout.write = ((chunk: any) => {
         writes.push(String(chunk));
         return true;
       }) as typeof write;
 
-      const middleware = log({ batch: false });
+      const middleware = loggerMiddleware({ batch: false });
       // No setImmediate turn in between: the line must already be with stdout.
       await middleware(request("http://localhost/a"), respond(200));
       expect(writes).toHaveLength(1);
@@ -283,15 +289,15 @@ describe("log", () => {
     try {
       process.stdout.isTTY = false;
       vi.resetModules();
-      const { log } = await import("../src/log.ts");
+      const { loggerMiddleware } = await import("../src/log.ts");
 
       process.stdout.write = ((chunk: any) => {
         writes.push(String(chunk));
         return accepting;
       }) as typeof write;
 
-      const batched = log();
-      const unbatched = log({ batch: false });
+      const batched = loggerMiddleware();
+      const unbatched = loggerMiddleware({ batch: false });
 
       // The batched line schedules a flush; the unbatched one then writes both
       // and starts a drain wait before that scheduled flush has fired.
@@ -329,14 +335,14 @@ describe("log", () => {
     try {
       process.stdout.isTTY = false;
       vi.resetModules();
-      const { log } = await import("../src/log.ts");
+      const { loggerMiddleware } = await import("../src/log.ts");
 
       process.stdout.write = ((chunk: any) => {
         writes.push(String(chunk));
         return accepting;
       }) as typeof write;
 
-      const middleware = log({ batch: false });
+      const middleware = loggerMiddleware({ batch: false });
       await middleware(request("http://localhost/a"), respond(200));
       // The write returned false: subsequent lines must wait for `drain`
       // instead of being forced onto a full stream.

--- a/test/static-nonblock.test.ts
+++ b/test/static-nonblock.test.ts
@@ -5,7 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ServerRequest } from "../src/types.ts";
 
-// `serveStatic` reads a candidate's mode with `stat()` and opens it a syscall
+// `staticMiddleware` reads a candidate's mode with `stat()` and opens it a syscall
 // later, so an attacker who can write into the root can swap a regular file for
 // a FIFO in between and `open()` will wait for a writer that never comes. That
 // window is too narrow to hit deterministically, so it is reproduced here by
@@ -25,7 +25,7 @@ vi.mock("node:fs/promises", async (importOriginal) => {
   };
 });
 
-const { serveStatic } = await import("../src/static.ts");
+const { staticMiddleware } = await import("../src/static.ts");
 
 let tmp: string;
 let dir: string;
@@ -42,7 +42,7 @@ afterAll(async () => {
 });
 
 const fetchStatic = (path: string) =>
-  serveStatic({ dir })(
+  staticMiddleware({ dir })(
     new Request(`http://localhost${path}`) as unknown as ServerRequest,
     () => new Response("next()", { status: 404 }),
   ) as Promise<Response>;

--- a/test/static.test.ts
+++ b/test/static.test.ts
@@ -4,7 +4,7 @@ import { execFileSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import { join, parse, relative, sep } from "node:path";
 import { brotliDecompressSync, gunzipSync } from "node:zlib";
-import { serveStatic, type ServeStaticOptions } from "../src/static.ts";
+import { staticMiddleware, type StaticMiddlewareOptions } from "../src/static.ts";
 import { FastURL } from "../src/_url.ts";
 import type { ServerRequest } from "../src/types.ts";
 
@@ -177,13 +177,16 @@ afterEach(async () => {
   }
 });
 
-const fetchStatic = (path: string, opts: Partial<ServeStaticOptions> = {}, init?: RequestInit) =>
-  track(serveStatic({ dir, ...opts })(req(path, init), notFound) as Promise<Response>);
+const fetchStatic = (
+  path: string,
+  opts: Partial<StaticMiddlewareOptions> = {},
+  init?: RequestInit,
+) => track(staticMiddleware({ dir, ...opts })(req(path, init), notFound) as Promise<Response>);
 
 const fetchEncoded = (
   path: string,
   acceptEncoding: string,
-  opts: Partial<ServeStaticOptions> = {},
+  opts: Partial<StaticMiddlewareOptions> = {},
 ) => fetchStatic(path, opts, { headers: { "accept-encoding": acceptEncoding } });
 
 // The precompressed-variant lookup is opt-in (off by default), so any test that
@@ -191,7 +194,7 @@ const fetchEncoded = (
 const fetchVariant = (
   path: string,
   acceptEncoding: string,
-  opts: Partial<ServeStaticOptions> = {},
+  opts: Partial<StaticMiddlewareOptions> = {},
 ) => fetchEncoded(path, acceptEncoding, { encodings: true, ...opts });
 
 // Every denial falls through to the app rather than being answered here, so the
@@ -215,9 +218,9 @@ const rawReq = (path: string) => {
 };
 
 const fetchRaw = (path: string) =>
-  track(serveStatic({ dir })(rawReq(path), notFound) as Promise<Response>);
+  track(staticMiddleware({ dir })(rawReq(path), notFound) as Promise<Response>);
 
-describe("serveStatic", () => {
+describe("staticMiddleware", () => {
   test("serves a file", async () => {
     const res = await fetchStatic("/sub/inside.txt");
     expect(res.status).toBe(200);
@@ -1140,7 +1143,7 @@ describe("serveStatic", () => {
   });
 
   describe("byte ranges", () => {
-    const fetchRange = (path: string, range: string, opts: Partial<ServeStaticOptions> = {}) =>
+    const fetchRange = (path: string, range: string, opts: Partial<StaticMiddlewareOptions> = {}) =>
       fetchStatic(path, opts, { headers: { range } });
 
     test("serves a leading slice as 206", async () => {
@@ -1346,7 +1349,7 @@ describe("serveStatic", () => {
   describe("unresolved pathname", () => {
     // Every request here bypasses `new Request()` — see `rawReq`. Without that,
     // the pathname arrives already collapsed and these assert nothing: they pass
-    // against a `serveStatic` with both containment checks deleted.
+    // against a `staticMiddleware` with both containment checks deleted.
     test.each([
       "/../outside/secret.txt",
       "/sub/../../outside/secret.txt",

--- a/test/tls-peer-cert.test.ts
+++ b/test/tls-peer-cert.test.ts
@@ -4,7 +4,7 @@ import { getTLSCert } from "./_utils.ts";
 import { fixture } from "./_fixture.ts";
 import { serve as nodeServe } from "../src/adapters/node.ts";
 import { serve as denoServe } from "../src/adapters/deno.ts";
-import { mtls } from "../src/mtls.ts";
+import { mtlsPlugin } from "../src/mtls.ts";
 
 const tls = await getTLSCert();
 
@@ -18,10 +18,10 @@ function clientAgent(opts: { withClientCert: boolean }) {
   });
 }
 
-// Skipped under a real Bun runtime: mtls() unconditionally refuses to start
+// Skipped under a real Bun runtime: mtlsPlugin() unconditionally refuses to start
 // on Bun (see the throw test below), so `beforeAll` would fail before any of
 // these sub-tests could run.
-describe.skipIf(typeof Bun !== "undefined")("mtls() plugin (Node adapter)", () => {
+describe.skipIf(typeof Bun !== "undefined")("mtlsPlugin() plugin (Node adapter)", () => {
   let server: Awaited<ReturnType<typeof nodeServe>> | undefined;
 
   beforeAll(async () => {
@@ -30,7 +30,7 @@ describe.skipIf(typeof Bun !== "undefined")("mtls() plugin (Node adapter)", () =
         port: 0,
         tls: { cert: tls.cert, key: tls.key },
         plugins: [
-          mtls({
+          mtlsPlugin({
             ca: tls.ca,
             // Inspect the certificate even when self-presented/unauthorized.
             rejectUnauthorized: false,
@@ -85,7 +85,7 @@ describe.skipIf(typeof Bun !== "undefined")("mtls() plugin (Node adapter)", () =
   });
 });
 
-test("request.tls is absent without the mtls() plugin", async () => {
+test("request.tls is absent without the mtlsPlugin() plugin", async () => {
   const server = nodeServe(fixture({ port: 0 }));
   await server.ready();
   try {
@@ -96,16 +96,16 @@ test("request.tls is absent without the mtls() plugin", async () => {
   }
 });
 
-test("mtls() throws when TLS is not configured", () => {
+test("mtlsPlugin() throws when TLS is not configured", () => {
   // On a real Bun runtime, the Bun-support guard fires unconditionally before
   // the TLS-config check (see below), so the thrown message differs there.
   const expected = typeof Bun !== "undefined" ? /not available on Bun/ : /HTTPS server/;
   expect(() =>
-    nodeServe(fixture({ manual: true, port: 0, plugins: [mtls({ ca: tls.ca })] })),
+    nodeServe(fixture({ manual: true, port: 0, plugins: [mtlsPlugin({ ca: tls.ca })] })),
   ).toThrow(expected);
 });
 
-test("mtls() accepts TLS configured via node server options", () => {
+test("mtlsPlugin() accepts TLS configured via node server options", () => {
   // The node adapter also reads cert/key straight from `options.node`, so the
   // plugin must recognize that path as a valid HTTPS server (not throw).
   expect(() =>
@@ -114,13 +114,13 @@ test("mtls() accepts TLS configured via node server options", () => {
         manual: true,
         port: 0,
         node: { cert: tls.cert, key: tls.key },
-        plugins: [mtls({ ca: tls.ca })],
+        plugins: [mtlsPlugin({ ca: tls.ca })],
       }),
     ),
   ).not.toThrow();
 });
 
-test("mtls() throws on the native Deno adapter and points to srvx/node", () => {
+test("mtlsPlugin() throws on the native Deno adapter and points to srvx/node", () => {
   // The native `Deno.serve` cannot expose client certificates, so the plugin must
   // fail loudly instead of silently leaving `request.tls` empty.
   expect(() =>
@@ -129,13 +129,13 @@ test("mtls() throws on the native Deno adapter and points to srvx/node", () => {
         manual: true,
         port: 0,
         tls: { cert: tls.cert, key: tls.key },
-        plugins: [mtls({ ca: tls.ca })],
+        plugins: [mtlsPlugin({ ca: tls.ca })],
       }),
     ),
   ).toThrow(/srvx\/node/);
 });
 
-test("mtls() throws when running under Bun, even with TLS configured", () => {
+test("mtlsPlugin() throws when running under Bun, even with TLS configured", () => {
   // Verified against the real Bun runtime separately (`bun --bun vitest`):
   // Bun's node:http(s) compat does not expose the peer certificate to the
   // handler (https://github.com/oven-sh/bun/issues/16254), so this guard must
@@ -152,7 +152,7 @@ test("mtls() throws when running under Bun, even with TLS configured", () => {
           manual: true,
           port: 0,
           tls: { cert: tls.cert, key: tls.key },
-          plugins: [mtls({ ca: tls.ca })],
+          plugins: [mtlsPlugin({ ca: tls.ca })],
         }),
       ),
     ).toThrow(/not available on Bun/);

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -1,7 +1,7 @@
 import { describe, test, expectTypeOf } from "vitest";
 import type { PeerCertificate } from "node:tls";
 import type { ServerRequest } from "../src/types.ts";
-import type { MTLSOptions } from "../src/mtls.ts";
+import type { MTLSPluginOptions } from "../src/mtls.ts";
 
 describe("types", () => {
   describe("ServerRequest", () => {
@@ -13,7 +13,7 @@ describe("types", () => {
         >();
       });
     });
-    // `request.tls` is contributed by the `srvx/mtls` mtls() module augmentation.
+    // `request.tls` is contributed by the `srvx/mtls` mtlsPlugin() module augmentation.
     describe("tls", () => {
       test("peerCertificate", () => {
         expectTypeOf(request.tls?.peerCertificate).toEqualTypeOf<undefined | PeerCertificate>();
@@ -24,9 +24,12 @@ describe("types", () => {
     });
   });
 
-  describe("MTLSOptions", () => {
+  describe("MTLSPluginOptions", () => {
     test("requestCert / ca", () => {
-      expectTypeOf<MTLSOptions>().toExtend<{ requestCert?: boolean; ca?: string | string[] }>();
+      expectTypeOf<MTLSPluginOptions>().toExtend<{
+        requestCert?: boolean;
+        ca?: string | string[];
+      }>();
     });
   });
 });


### PR DESCRIPTION
`log()` read as a value rather than as a middleware factory at the call site — `middleware: [log()]` gives no hint that the export *is* the middleware. This renames it and aligns the rest of the subpath surface on one scheme, so every export name states what it produces.

## Renames

| Import | Before | After | Kind |
| --- | --- | --- | --- |
| `srvx/log` | `log()` | `loggerMiddleware()` | Middleware |
| `srvx/static` | `serveStatic()` | `staticMiddleware()` | Middleware |
| `srvx/mtls` | `mtls()` | `mtlsPlugin()` | Plugin |
| `srvx/tracing` | `tracingPlugin()` | *(unchanged)* | Plugin |

Option interfaces follow their functions:

- `LogOptions` → `LoggerMiddlewareOptions`
- `ServeStaticOptions` → `StaticMiddlewareOptions`
- `MTLSOptions` → `MTLSPluginOptions`

Subpath specifiers are untouched — only the exported names move, so migration is a named-import edit:

```diff
-import { log } from "srvx/log";
+import { loggerMiddleware } from "srvx/log";

 serve({
-  middleware: [log()],
+  middleware: [loggerMiddleware()],
 });
```

## Notes

- `tracingPlugin()` already conformed and is left alone.
- Error messages in `src/mtls.ts` that name the function (`"mtls() requires an HTTPS server…"`) were updated so they keep matching the public API.
- Docs, the aws-lambda example, and the CLI's internal dynamic imports (`src/cli/serve.ts`) all follow.

## Verification

`pnpm typecheck`, `pnpm lint`, and `vitest run` all clean — 1236 passed, 35 skipped, no type errors. `grep` confirms no occurrence of the old names remains outside `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Renamed middleware APIs for logging and static file serving to `loggerMiddleware()` and `staticMiddleware()`.
  * Renamed the mutual TLS plugin to `mtlsPlugin()`.

* **Documentation**
  * Updated guides (handler, middleware, options, TLS) and AWS Lambda example to use the new API names and revised guidance.

* **Tests**
  * Updated logging, static file, TLS, and type tests (and fixtures) to cover the renamed APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->