### PR TITLE
fix(types): declare runtime type packages as optional peer dependencies

### DIFF
--- a/docs/1.guide/01.index.md
+++ b/docs/1.guide/01.index.md
@@ -83,6 +83,25 @@ bun run server.mjs
 
 ::
 
+## TypeScript
+
+srvx ships one shared set of type definitions covering every supported runtime. The runtime types they reference come from ambient type packages, declared as optional `peerDependencies` so that nothing is installed unless you ask for it:
+
+| Runtime            | Types package               |
+| ------------------ | --------------------------- |
+| Node.js            | `@types/node`               |
+| Deno               | `@types/deno`               |
+| Bun                | `@types/bun`                |
+| Cloudflare Workers | `@cloudflare/workers-types` |
+| AWS Lambda         | `@types/aws-lambda`         |
+| Service Worker     | `@types/serviceworker`      |
+
+> [!NOTE]
+> `@types/deno` references DOM types, so pair it with `lib: ["esnext", "dom"]`.
+
+> [!NOTE]
+> Because the definitions are shared, `tsc` with `skipLibCheck: false` also resolves the references of runtimes you do not target and reports the missing ones. Installing all of them is not a way out — `@types/serviceworker` redeclares globals (`Blob`, `Request`, `GPU*`, …) that `@types/bun` and `@types/deno` declare too, and TypeScript's own `lib: ["webworker"]` collides with `@types/bun` the same way — so keep `skipLibCheck: true` (what `tsc --init` generates).
+
 ## Starter Examples
 
 <!-- automd:examples -->

--- a/package.json
+++ b/package.json
@@ -95,6 +95,34 @@
     "undici": "8.4.0",
     "vitest": "^4.1.10"
   },
+  "peerDependencies": {
+    "@cloudflare/workers-types": "*",
+    "@types/aws-lambda": "*",
+    "@types/bun": "*",
+    "@types/deno": "*",
+    "@types/node": "*",
+    "@types/serviceworker": "*"
+  },
+  "peerDependenciesMeta": {
+    "@cloudflare/workers-types": {
+      "optional": true
+    },
+    "@types/aws-lambda": {
+      "optional": true
+    },
+    "@types/bun": {
+      "optional": true
+    },
+    "@types/deno": {
+      "optional": true
+    },
+    "@types/node": {
+      "optional": true
+    },
+    "@types/serviceworker": {
+      "optional": true
+    }
+  },
   "resolutions": {
     "srvx": "link:."
   },


### PR DESCRIPTION
Refs #284 (option 2 of the three listed there).

`dist/_chunks/types.d.mts` is shared by every entrypoint and references `bun`, `aws-lambda`, `@cloudflare/workers-types`, the `Deno` namespace and `FetchEvent`. All of those were only `devDependencies`, so consumers had no declared way to know which packages the published types expect.

This declares them — plus `@types/node` — as `peerDependencies` with `peerDependenciesMeta.optional: true`, and adds a TypeScript section to the getting-started guide listing the package per runtime. Ranges are `*` because these are ambient type packages: any version supplies the namespaces, and pinning would only produce spurious peer warnings.

Nothing is installed automatically — npm does not auto-install optional peers (verified) — so this is purely declarative for existing users.

### What this does and does not fix

Measured on the issue's reproduction (`srvx@0.12.4`, `module: NodeNext`, no `skipLibCheck`), from 12 errors in the shared chunk:

- **Fixed** once the packages are installed: `Cannot find module 'aws-lambda' | 'bun' | '@cloudflare/workers-types'`.
- **Not fixed:** `Cannot find namespace 'Deno'` (5x) and `Cannot find name 'FetchEvent'` need `@types/deno` / `@types/serviceworker` to be globally included, and those two cannot be loaded in the same program: `@types/serviceworker` redeclares globals (`Blob`, `Request`, `GPU*`, …) that `@types/deno` declares too (13 errors), and that `@types/bun` declares too (49). Substituting TypeScript's own `lib: ["webworker"]` for `FetchEvent` collides with `@types/bun` all the same (54). Pairwise they are fine — `@types/node` with any single one of them type checks at 0 errors — so the shared chunk needing all of them at once is the actual blocker.
- **Not fixed:** `Cannot find module 'cloudflare:workers'` (2x). `@cloudflare/workers-types` does declare that module, but only as an ambient declaration in a global script file, so importing the package as a module does not bring it in.
- `dist/adapters/node.d.mts:43` `BodyInit` is untouched — `@types/node` genuinely does not provide that global.

So this is a documentation/declaration improvement, not a complete fix: a Node-only consumer still cannot type check srvx's declarations with `skipLibCheck: false`. #286 is the root fix — it splits the type chunk so each entry references only its own runtime, which is what makes these packages installable one at a time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added TypeScript guidance explaining that `srvx` provides a shared set of types across supported runtimes.
  * Included recommendations for pairing runtime type packages and compiler settings (including `skipLibCheck`) to avoid missing-type and global redeclaration issues.
  * Clarified `@types/deno` DOM type reference and suggested `lib` configuration.

* **Improvements**
  * Declared `@cloudflare/workers-types` and `@types/*` packages as optional peer dependencies for supported runtimes (e.g., Node.js, Deno, Bun, AWS Lambda, Service Worker).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->