### PR TITLE
types: inline minimal runtime types

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -3,5 +3,18 @@
   "plugins": ["unicorn", "typescript", "oxc"],
   "rules": {
     "eslint/no-unused-vars": "off"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["src/**"],
+      "rules": {
+        "eslint/no-restricted-imports": [
+          "error",
+          {
+            "paths": ["bun", "aws-lambda", "@cloudflare/workers-types", "cloudflare:workers"]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/build.config.mjs
+++ b/build.config.mjs
@@ -28,7 +28,6 @@ export default defineBuildConfig({
         ].map((adapter) => `src/adapters/${adapter}.ts`),
       ],
       rolldown: {
-        external: ["bun", "@cloudflare/workers-types", "aws-lambda"],
         plugins: [
           pkg.name === "srvx-nightly" && {
             name: "nightly-alias",

--- a/docs/1.guide/01.index.md
+++ b/docs/1.guide/01.index.md
@@ -98,7 +98,11 @@ bunServer?.publish("channel", "hello");
 
 To type Cloudflare Workers bindings, augment `CloudflareEnv`:
 
+The `declare module` block only augments `CloudflareEnv` in a file that is a module. In a standalone `.d.ts` with no imports or exports it would declare a whole new `srvx` module instead, so add `export {}` there.
+
 ```ts
+import { serve } from "srvx";
+
 declare module "srvx" {
   interface CloudflareEnv {
     MY_KV: KVNamespace;

--- a/docs/1.guide/01.index.md
+++ b/docs/1.guide/01.index.md
@@ -83,6 +83,36 @@ bun run server.mjs
 
 ::
 
+## TypeScript
+
+srvx ships self-contained types: they reference no runtime type packages, so `tsc` passes with only `@types/node` (or none at all) and without `skipLibCheck`, whichever runtime you target.
+
+Runtime objects such as `server.bun?.server`, `server.deno?.server`, `request.runtime?.cloudflare?.context` or `request.runtime?.awsLambda?.event` are described by minimal interfaces covering what srvx itself uses. They accept the official types, so passing a real `Bun.Server` or Lambda event still type checks. To reach the full surface of a runtime object, install that runtime's type package and cast:
+
+```ts
+import type { Server } from "bun";
+
+const bunServer = server.bun?.server as Server | undefined;
+bunServer?.publish("channel", "hello");
+```
+
+To type Cloudflare Workers bindings, augment `CloudflareEnv`:
+
+```ts
+declare module "srvx" {
+  interface CloudflareEnv {
+    MY_KV: KVNamespace;
+  }
+}
+
+serve({
+  fetch: (request) => {
+    const kv = request.runtime?.cloudflare?.env.MY_KV;
+    // ...
+  },
+});
+```
+
 ## Starter Examples
 
 <!-- automd:examples -->

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -1,11 +1,14 @@
 import type { ServerRequest } from "../../types.ts";
 import type { TrustProxyOption } from "../../_trust-proxy.ts";
 import { resolveClientIP, trustedHops, forwardedHopValue } from "../../_trust-proxy.ts";
+import type { ResponseBody } from "../../types.ts";
 import type {
-  APIGatewayProxyEvent,
-  Context as AWSContext,
-  APIGatewayProxyEventV2,
-} from "aws-lambda";
+  AWSLambdaContext,
+  AWSLambdaProxyEvent,
+  AWSLambdaProxyEventV2,
+  AWSLambdaProxyResult,
+  AWSLambdaProxyResultV2,
+} from "../../types/aws-lambda.ts";
 
 // -- Streaming types --
 
@@ -30,8 +33,8 @@ export interface AWSResponseHeaders {
 // Incoming (AWS => Web)
 
 export function awsRequest(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
-  context: AWSContext,
+  event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2,
+  context: AWSLambdaContext,
   trustProxy?: TrustProxyOption,
 ): ServerRequest {
   // The gateway-verified `sourceIp` is the nearest hop. Resolve the trusted hop
@@ -57,27 +60,27 @@ export function awsRequest(
   return req;
 }
 
-function awsForwardedFor(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): string | undefined {
+function awsForwardedFor(event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2): string | undefined {
   return event.headers["X-Forwarded-For"] || event.headers["x-forwarded-for"];
 }
 
-function awsEventMethod(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): string {
+function awsEventMethod(event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2): string {
   return (
-    (event as APIGatewayProxyEvent).httpMethod ||
-    (event as APIGatewayProxyEventV2).requestContext?.http?.method ||
+    (event as AWSLambdaProxyEvent).httpMethod ||
+    (event as AWSLambdaProxyEventV2).requestContext?.http?.method ||
     "GET"
   );
 }
 
-function awsEventIP(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): string | undefined {
+function awsEventIP(event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2): string | undefined {
   return (
-    (event as APIGatewayProxyEventV2).requestContext?.http?.sourceIp || // v2 (HTTP API)
-    (event as APIGatewayProxyEvent).requestContext?.identity?.sourceIp // v1 (REST API)
+    (event as AWSLambdaProxyEventV2).requestContext?.http?.sourceIp || // v2 (HTTP API)
+    (event as AWSLambdaProxyEvent).requestContext?.identity?.sourceIp // v1 (REST API)
   );
 }
 
-function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2, hops: number): URL {
-  const path = (event as APIGatewayProxyEvent).path || (event as APIGatewayProxyEventV2).rawPath;
+function awsEventURL(event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2, hops: number): URL {
+  const path = (event as AWSLambdaProxyEvent).path || (event as AWSLambdaProxyEventV2).rawPath;
 
   const query = awsEventQuery(event);
 
@@ -105,18 +108,18 @@ function awsEventURL(event: APIGatewayProxyEvent | APIGatewayProxyEventV2, hops:
   return new URL(`${path}${query ? `?${query}` : ""}`, `${protocol}://${hostname}`);
 }
 
-function awsEventQuery(event: APIGatewayProxyEvent | APIGatewayProxyEventV2) {
-  if (typeof (event as APIGatewayProxyEventV2).rawQueryString === "string") {
-    return (event as APIGatewayProxyEventV2).rawQueryString;
+function awsEventQuery(event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2) {
+  if (typeof (event as AWSLambdaProxyEventV2).rawQueryString === "string") {
+    return (event as AWSLambdaProxyEventV2).rawQueryString;
   }
   const queryObj = {
     ...event.queryStringParameters,
-    ...(event as APIGatewayProxyEvent).multiValueQueryStringParameters,
+    ...(event as AWSLambdaProxyEvent).multiValueQueryStringParameters,
   };
   return stringifyQuery(queryObj);
 }
 
-function awsEventHeaders(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): Headers {
+function awsEventHeaders(event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2): Headers {
   const headers = new Headers();
   for (const [key, value] of Object.entries(event.headers)) {
     if (value) {
@@ -132,8 +135,8 @@ function awsEventHeaders(event: APIGatewayProxyEvent | APIGatewayProxyEventV2): 
 }
 
 export function awsEventBody(
-  event: APIGatewayProxyEvent | APIGatewayProxyEventV2,
-): BodyInit | undefined {
+  event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2,
+): ResponseBody | undefined {
   if (!event.body) {
     return undefined;
   }
@@ -147,7 +150,7 @@ export function awsEventBody(
 
 export function awsResponseHeaders(
   response: Response,
-  event?: APIGatewayProxyEvent | APIGatewayProxyEventV2,
+  event?: AWSLambdaProxyEvent | AWSLambdaProxyEventV2,
 ): AWSResponseHeaders {
   const headers = Object.create(null);
   for (const [key, value] of response.headers) {
@@ -163,8 +166,8 @@ export function awsResponseHeaders(
   }
 
   const isV2 =
-    (event as APIGatewayProxyEventV2)?.version === "2.0" ||
-    !!(event as APIGatewayProxyEventV2)?.requestContext?.http;
+    (event as AWSLambdaProxyEventV2)?.version === "2.0" ||
+    !!(event as AWSLambdaProxyEventV2)?.requestContext?.http;
 
   return isV2
     ? { headers, cookies }
@@ -192,7 +195,7 @@ export async function awsResponseBody(
 export async function awsStreamResponse(
   response: Response,
   responseStream: AWSLambdaResponseStream,
-  event?: APIGatewayProxyEvent | APIGatewayProxyEventV2,
+  event?: AWSLambdaProxyEvent | AWSLambdaProxyEventV2,
 ): Promise<void> {
   const metadata: AWSLambdaStreamResponseMetadata = {
     statusCode: response.status,
@@ -282,7 +285,7 @@ function stringifyQuery(obj: Record<string, unknown>) {
 
 // Reverse: Web Request => AWS Event (v1/v2 compatible)
 
-export type AwsLambdaEvent = APIGatewayProxyEvent & APIGatewayProxyEventV2;
+export type AwsLambdaEvent = AWSLambdaProxyEvent & AWSLambdaProxyEventV2;
 
 export async function requestToAwsEvent(request: Request): Promise<AwsLambdaEvent> {
   const url = new URL(request.url);
@@ -395,9 +398,7 @@ function parseMultiValueQuery(params: URLSearchParams): Record<string, string[]>
 
 // Reverse: AWS Result => Web Response
 
-export type AwsLambdaResult =
-  | import("aws-lambda").APIGatewayProxyResult
-  | import("aws-lambda").APIGatewayProxyResultV2;
+export type AwsLambdaResult = AWSLambdaProxyResult | AWSLambdaProxyResultV2;
 
 export function awsResultToResponse(result: AwsLambdaResult): Response {
   // APIGatewayProxyResultV2 can be a plain string for simple responses
@@ -435,7 +436,7 @@ export function awsResultToResponse(result: AwsLambdaResult): Response {
   }
 
   // Handle body
-  let body: BodyInit | undefined;
+  let body: ResponseBody | undefined;
   if (typeof result.body === "string") {
     if (result.isBase64Encoded) {
       body = Buffer.from(result.body, "base64");
@@ -452,7 +453,7 @@ export function awsResultToResponse(result: AwsLambdaResult): Response {
   });
 }
 
-export function createMockContext(): AWSContext {
+export function createMockContext(): AWSLambdaContext {
   const id = crypto.randomUUID();
   return {
     callbackWaitsForEmptyEventLoop: true,

--- a/src/adapters/_node/response.ts
+++ b/src/adapters/_node/response.ts
@@ -1,6 +1,7 @@
 import { PassThrough, Readable as NodeReadable, Writable as NodeWritable } from "node:stream";
 
 import { lazyInherit } from "../../_inherit.ts";
+import type { ResponseBody } from "../../types.ts";
 
 // prettier-ignore
 export type PreparedNodeResponseBody = string | Buffer | Uint8Array | DataView | ReadableStream | NodeReadable | undefined | null
@@ -20,7 +21,7 @@ export interface PreparedNodeResponse {
  */
 export const NodeResponse: {
   new (
-    body?: BodyInit | null,
+    body?: ResponseBody | null,
     init?: ResponseInit,
   ): globalThis.Response & {
     _toNodeResponse: () => PreparedNodeResponse;
@@ -33,12 +34,12 @@ export const NodeResponse: {
   const NativeResponse = globalThis.Response;
 
   class NodeResponse implements Partial<Response> {
-    #body?: BodyInit | null;
+    #body?: ResponseBody | null;
     #init?: ResponseInit;
     #headers?: Headers;
     #response?: globalThis.Response;
 
-    constructor(body?: BodyInit | null, init?: ResponseInit) {
+    constructor(body?: ResponseBody | null, init?: ResponseInit) {
       this.#body = body;
       this.#init = init;
     }
@@ -108,7 +109,7 @@ export const NodeResponse: {
 
       // Undici accepts standard Response body or async iterators (which Node Readable implements too).
       // Pipeable objects, like React's renderToPipeableStream, do not implement async iterators.
-      let body: BodyInit | null | undefined = this.#body;
+      let body: ResponseBody | null | undefined = this.#body;
       if (
         body &&
         typeof (body as unknown as NodeReadable).pipe === "function" &&
@@ -120,7 +121,7 @@ export const NodeResponse: {
         if (abort) {
           stream.once("close", () => abort());
         }
-        body = stream as unknown as BodyInit;
+        body = stream as unknown as ResponseBody;
       }
 
       this.#response = new NativeResponse(

--- a/src/adapters/aws-lambda.ts
+++ b/src/adapters/aws-lambda.ts
@@ -1,5 +1,11 @@
-import type * as AWS from "aws-lambda";
 import type { FetchHandler, Server, ServerOptions } from "../types.ts";
+import type {
+  AWSLambdaContext,
+  AWSLambdaProxyEvent,
+  AWSLambdaProxyEventV2,
+  AWSLambdaProxyResult,
+  AWSLambdaProxyResultV2,
+} from "../types/aws-lambda.ts";
 import type { TrustProxyOption } from "../_trust-proxy.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
@@ -16,19 +22,19 @@ import {
 
 type MaybePromise<T> = T | Promise<T>;
 
-export type AwsLambdaEvent = AWS.APIGatewayProxyEvent | AWS.APIGatewayProxyEventV2;
+export type AwsLambdaEvent = AWSLambdaProxyEvent | AWSLambdaProxyEventV2;
 
 export type { AWSLambdaResponseStream };
 
 export type AWSLambdaHandler = (
   event: AwsLambdaEvent,
-  context: AWS.Context,
-) => MaybePromise<AWS.APIGatewayProxyResult | AWS.APIGatewayProxyResultV2>;
+  context: AWSLambdaContext,
+) => MaybePromise<AWSLambdaProxyResult | AWSLambdaProxyResultV2>;
 
 export type AWSLambdaStreamingHandler = (
   event: AwsLambdaEvent,
   responseStream: AWSLambdaResponseStream,
-  context: AWS.Context,
+  context: AWSLambdaContext,
 ) => MaybePromise<void>;
 
 export function toLambdaHandler(options: ServerOptions): AWSLambdaHandler {
@@ -39,9 +45,9 @@ export function toLambdaHandler(options: ServerOptions): AWSLambdaHandler {
 export async function handleLambdaEvent(
   fetchHandler: FetchHandler,
   event: AwsLambdaEvent,
-  context: AWS.Context,
+  context: AWSLambdaContext,
   trustProxy?: TrustProxyOption,
-): Promise<AWS.APIGatewayProxyResult | AWS.APIGatewayProxyResultV2> {
+): Promise<AWSLambdaProxyResult | AWSLambdaProxyResultV2> {
   const request = awsRequest(event, context, trustProxy);
   const response = await fetchHandler(request);
   return {
@@ -55,7 +61,7 @@ export async function handleLambdaEventWithStream(
   fetchHandler: FetchHandler,
   event: AwsLambdaEvent,
   responseStream: AWSLambdaResponseStream,
-  context: AWS.Context,
+  context: AWSLambdaContext,
   trustProxy?: TrustProxyOption,
 ): Promise<void> {
   const request = awsRequest(event, context, trustProxy);
@@ -85,7 +91,7 @@ class AWSLambdaServer implements Server<AWSLambdaHandler> {
 
     const fetchHandler = wrapFetch(this as unknown as Server);
 
-    this.fetch = (event: AwsLambdaEvent, context: AWS.Context) =>
+    this.fetch = (event: AwsLambdaEvent, context: AWSLambdaContext) =>
       handleLambdaEvent(fetchHandler, event, context, this.options.trustProxy);
   }
 

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -1,5 +1,5 @@
 import type { BunFetchHandler, Server, ServerHandler, ServerOptions } from "../types.ts";
-import type * as bun from "bun";
+import type { BunServeOptions } from "../types/bun.ts";
 import {
   fmtURL,
   printListening,
@@ -25,7 +25,7 @@ class BunServer implements Server<BunFetchHandler> {
   readonly runtime = "bun";
   readonly options: Server["options"];
   readonly bun: Server["bun"] = {};
-  readonly serveOptions: bun.Serve.Options<any> | undefined;
+  readonly serveOptions: BunServeOptions | undefined;
   readonly fetch: BunFetchHandler;
   readonly waitUntil?: Server["waitUntil"];
 
@@ -87,12 +87,12 @@ class BunServer implements Server<BunFetchHandler> {
       ...(this.options.maxRequestBodySize !== undefined
         ? { maxRequestBodySize: this.options.maxRequestBodySize }
         : {}),
-      ...(this.options.bun as any),
+      ...this.options.bun,
       tls: {
         cert: tls?.cert,
         key: tls?.key,
         passphrase: tls?.passphrase,
-        ...(this.options.bun as bun.Serve.Options<any>)?.tls,
+        ...this.options.bun?.tls,
       },
       fetch: this.fetch,
     };
@@ -104,7 +104,10 @@ class BunServer implements Server<BunFetchHandler> {
 
   serve(): Promise<this> {
     if (!this.bun!.server) {
-      this.bun!.server = Bun.serve(this.serveOptions!);
+      // `BunServeOptions` is the open shape srvx accepts (see
+      // `src/types/README.md`); `Bun.serve` overloads on mutually exclusive
+      // tcp/unix variants that no single object type satisfies.
+      this.bun!.server = Bun.serve(this.serveOptions as Bun.Serve.Options<any>);
     }
     printListening(this.options, this.url);
     return Promise.resolve(this);

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -1,12 +1,12 @@
 import type { CloudflareFetchHandler, Server, ServerOptions } from "../types.ts";
-import type * as CF from "@cloudflare/workers-types";
+import type { ServiceWorkerFetchEvent } from "../types/service-worker.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
 
 export const FastURL: typeof globalThis.URL = URL;
 export const FastResponse: typeof globalThis.Response = Response;
 
-export function serve(options: ServerOptions): Server<CF.ExportedHandlerFetchHandler> {
+export function serve(options: ServerOptions): Server<CloudflareFetchHandler> {
   return new CloudflareServer(options);
 }
 
@@ -26,13 +26,13 @@ export function serve(options: ServerOptions): Server<CF.ExportedHandlerFetchHan
 class CloudflareServer implements Server<CloudflareFetchHandler> {
   readonly runtime = "cloudflare";
   readonly options: Server["options"];
-  readonly serveOptions: CF.ExportedHandler;
-  readonly fetch: CF.ExportedHandlerFetchHandler;
+  readonly serveOptions: { fetch: CloudflareFetchHandler };
+  readonly fetch: CloudflareFetchHandler;
 
   // Retained so `close()` can remove exactly the listener `serve()` added and
   // repeated `serve()` calls do not stack duplicate listeners (which would
   // trigger a double `respondWith()` error on Cloudflare).
-  #fetchListener?: (event: FetchEvent) => void;
+  #fetchListener?: (event: ServiceWorkerFetchEvent) => void;
 
   constructor(options: ServerOptions) {
     this.options = { ...options, middleware: [...(options.middleware || [])] };
@@ -59,9 +59,7 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
           },
         },
       });
-      return fetchHandler(request as unknown as Request) as unknown as
-        | CF.Response
-        | Promise<CF.Response>;
+      return fetchHandler(request);
     };
 
     this.serveOptions = {
@@ -84,19 +82,18 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
     this.#fetchListener = (event) => {
       // Service-worker events carry no `env`; bindings are only reachable in
       // module-worker syntax (see the class doc comment).
-      // @ts-expect-error `respondWith` is FetchEvent-only.
       event.respondWith(this.fetch(event.request, (event as any).env || {}, event));
     };
-    addEventListener("fetch", this.#fetchListener as EventListener);
+    addEventListener("fetch", this.#fetchListener as unknown as EventListener);
   }
 
-  ready(): Promise<Server<CF.ExportedHandlerFetchHandler>> {
+  ready(): Promise<Server<CloudflareFetchHandler>> {
     return Promise.resolve().then(() => this);
   }
 
   close() {
     if (this.#fetchListener) {
-      removeEventListener("fetch", this.#fetchListener as EventListener);
+      removeEventListener("fetch", this.#fetchListener as unknown as EventListener);
       this.#fetchListener = undefined;
     }
     return Promise.resolve();

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -1,4 +1,5 @@
 import type { CloudflareFetchHandler, Server, ServerOptions } from "../types.ts";
+import type { CloudflareExecutionContext } from "../types/cloudflare.ts";
 import type { ServiceWorkerFetchEvent } from "../types/service-worker.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
@@ -82,7 +83,17 @@ class CloudflareServer implements Server<CloudflareFetchHandler> {
     this.#fetchListener = (event) => {
       // Service-worker events carry no `env`; bindings are only reachable in
       // module-worker syntax (see the class doc comment).
-      event.respondWith(this.fetch(event.request, (event as any).env || {}, event));
+      //
+      // Cloudflare's `FetchEvent` doubles as the execution context: it adds
+      // `passThroughOnException()` on top of `waitUntil()`, which the generic
+      // service worker event does not have, hence the cast.
+      event.respondWith(
+        this.fetch(
+          event.request,
+          (event as any).env || {},
+          event as unknown as CloudflareExecutionContext,
+        ),
+      );
     };
     addEventListener("fetch", this.#fetchListener as unknown as EventListener);
   }

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -1,4 +1,5 @@
 import type { DenoFetchHandler, Server, ServerHandler, ServerOptions } from "../types.ts";
+import type { DenoServeOptions } from "../types/deno.ts";
 import {
   createWaitUntil,
   fmtURL,
@@ -25,10 +26,7 @@ class DenoServer implements Server<DenoFetchHandler> {
   readonly runtime = "deno";
   readonly options: Server["options"];
   readonly deno: Server["deno"] = {};
-  readonly serveOptions:
-    | Deno.ServeTcpOptions
-    | (Deno.ServeTcpOptions & Deno.TlsCertifiedKeyPem)
-    | undefined;
+  readonly serveOptions: DenoServeOptions | undefined;
   readonly fetch: DenoFetchHandler;
   readonly waitUntil?: Server["waitUntil"];
 
@@ -80,7 +78,7 @@ class DenoServer implements Server<DenoFetchHandler> {
           // `X-Forwarded-For` when the peer is trusted.
           configurable: true,
           get() {
-            return (info?.remoteAddr as Deno.NetAddr)?.hostname;
+            return info?.remoteAddr?.hostname;
           },
         },
       });
@@ -112,7 +110,7 @@ class DenoServer implements Server<DenoFetchHandler> {
     this.deno!.server = Deno.serve(
       {
         ...this.serveOptions,
-        onListen: (info) => {
+        onListen: (info: { hostname: string; port: number }) => {
           this.#listeningInfo = info;
           if (this.options.deno?.onListen) {
             this.options.deno.onListen(info);

--- a/src/adapters/service-worker.ts
+++ b/src/adapters/service-worker.ts
@@ -1,5 +1,6 @@
 /* eslint-disable unicorn/prefer-global-this */
 import type { Server, ServerOptions, ServerRequest } from "../types.ts";
+import type { ServiceWorkerFetchEvent } from "../types/service-worker.ts";
 import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin } from "../_plugins.ts";
 
@@ -8,7 +9,7 @@ export const FastResponse: typeof globalThis.Response = Response;
 
 export type ServiceWorkerHandler = (
   request: ServerRequest,
-  event: FetchEvent,
+  event: ServiceWorkerFetchEvent,
 ) => Response | Promise<Response>;
 
 const isBrowserWindow = typeof window !== "undefined" && typeof navigator !== "undefined";
@@ -25,7 +26,7 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
   readonly options: Server["options"];
   readonly fetch: ServiceWorkerHandler;
 
-  #fetchListener?: (event: FetchEvent) => void | Promise<void>;
+  #fetchListener?: (event: ServiceWorkerFetchEvent) => void | Promise<void>;
   #listeningPromise?: Promise<any>;
   // The registration `serve()` created (browser-window mode), so `close()`
   // unregisters only our own worker instead of every worker on the origin.
@@ -39,7 +40,7 @@ class ServiceWorkerServer implements Server<ServiceWorkerHandler> {
 
     const fetchHandler = wrapFetch(this as unknown as Server);
 
-    this.fetch = (request: Request, event: FetchEvent) => {
+    this.fetch = (request: Request, event: ServiceWorkerFetchEvent) => {
       Object.defineProperties(request, {
         runtime: {
           enumerable: true,

--- a/src/cli/fetch.ts
+++ b/src/cli/fetch.ts
@@ -4,7 +4,7 @@ import { createReadStream } from "node:fs";
 
 import { loadServerEntry, type LoadOptions } from "../loader.ts";
 import type { CLIOptions } from "./types.ts";
-import type { ServerHandler } from "../types.ts";
+import type { ResponseBody, ServerHandler } from "../types.ts";
 import { resolve } from "node:path";
 
 export async function cliFetch(
@@ -87,7 +87,7 @@ export async function cliFetch(
   }
 
   // Build body
-  let body: BodyInit | undefined;
+  let body: ResponseBody | undefined;
   let isStream = false;
   if (cliOpts.data !== undefined) {
     if (cliOpts.data === "@-") {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,18 +2,21 @@ import type * as NodeHttp from "node:http";
 import type * as NodeHttps from "node:https";
 import type * as NodeHttp2 from "node:http2";
 import type * as NodeNet from "node:net";
-import type * as Bun from "bun";
-import type * as CF from "@cloudflare/workers-types";
-import type * as AWS from "aws-lambda";
 import type { TrustProxyOption } from "./_trust-proxy.ts";
+import type { BunHttpServer, BunServeOptions } from "./types/bun.ts";
+import type { DenoHttpServer, DenoServeHandlerInfo, DenoServeOptions } from "./types/deno.ts";
+import type { CloudflareEnv, CloudflareExecutionContext } from "./types/cloudflare.ts";
+import type {
+  AWSLambdaContext,
+  AWSLambdaProxyEvent,
+  AWSLambdaProxyEventV2,
+} from "./types/aws-lambda.ts";
+import type { ServiceWorkerFetchEvent } from "./types/service-worker.ts";
 
 export type { TrustProxyOption } from "./_trust-proxy.ts";
 
 // Utils
 type MaybePromise<T> = T | Promise<T>;
-type IsAny<T> = Equal<T, any> extends true ? true : false;
-type Equal<X, Y> =
-  (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 
 // ----------------------------------------------------------------------------
 // srvx API
@@ -201,14 +204,14 @@ export interface ServerOptions {
    *
    * @docs https://bun.sh/docs/api/http
    */
-  bun?: Omit<Bun.Serve.Options<any>, "fetch">;
+  bun?: BunServeOptions;
 
   /**
    * Deno server options
    *
    * @docs https://docs.deno.com/api/deno/~/Deno.serve
    */
-  deno?: Deno.ServeOptions;
+  deno?: DenoServeOptions;
 
   /**
    * Service worker options
@@ -262,12 +265,12 @@ export interface Server<Handler = ServerHandler> {
   /**
    * Bun context.
    */
-  readonly bun?: { server?: Bun.Server<any> };
+  readonly bun?: { server?: BunHttpServer };
 
   /**
    * Deno context.
    */
-  readonly deno?: { server?: Deno.HttpServer };
+  readonly deno?: { server?: DenoHttpServer };
 
   /**
    * Server fetch handler
@@ -322,32 +325,30 @@ export interface ServerRuntimeContext {
    * Underlying Deno server request info.
    */
   deno?: {
-    info: Deno.ServeHandlerInfo<Deno.NetAddr>;
+    info: DenoServeHandlerInfo;
   };
 
   /**
    * Underlying Bun server request context.
    */
   bun?: {
-    server: Bun.Server<any>;
+    server: BunHttpServer;
   };
 
   /**
    * Underlying Cloudflare request context.
    */
   cloudflare?: {
-    context: CF.ExecutionContext;
-    env: IsAny<typeof import("cloudflare:workers")> extends true
-      ? Record<string, unknown>
-      : typeof import("cloudflare:workers").env;
+    context: CloudflareExecutionContext;
+    env: CloudflareEnv;
   };
 
   awsLambda?: {
-    context: AWS.Context;
-    event: AWS.APIGatewayProxyEvent | AWS.APIGatewayProxyEventV2;
+    context: AWSLambdaContext;
+    event: AWSLambdaProxyEvent | AWSLambdaProxyEventV2;
   };
 
-  serviceWorker?: { event: FetchEvent };
+  serviceWorker?: { event: ServiceWorkerFetchEvent };
 
   netlify?: { context: any };
 
@@ -404,12 +405,12 @@ export type ErrorHandler = (error: unknown) => Response | Promise<Response>;
 
 export type BunFetchHandler = (
   request: Request,
-  server?: Bun.Server<any>,
+  server?: BunHttpServer,
 ) => Response | Promise<Response>;
 
 export type DenoFetchHandler = (
   request: Request,
-  info?: Deno.ServeHandlerInfo<Deno.NetAddr>,
+  info?: DenoServeHandlerInfo,
 ) => Response | Promise<Response>;
 
 export type NodeServerRequest = NodeHttp.IncomingMessage | NodeHttp2.Http2ServerRequest;
@@ -442,4 +443,33 @@ export type NodeHTTP2Middleware = (
 
 export type NodeHTTPMiddleware = NodeHTTP1Middleware | NodeHTTP2Middleware;
 
-export type CloudflareFetchHandler = CF.ExportedHandlerFetchHandler;
+export type CloudflareFetchHandler = (
+  request: Request,
+  env: CloudflareEnv,
+  context: CloudflareExecutionContext,
+) => Response | Promise<Response>;
+
+// ----------------------------------------------------------------------------
+// Runtime types
+// ----------------------------------------------------------------------------
+
+/**
+ * Body accepted by the runtime `Response` constructor (`BodyInit`).
+ *
+ * Derived from the ambient `Response` so that it does not require `lib: ["dom"]`.
+ */
+export type ResponseBody = NonNullable<ConstructorParameters<typeof globalThis.Response>[0]>;
+
+// Minimal declarations of the objects each runtime hands to srvx, so that the
+// published types depend on no runtime type package (see `src/types/README.md`).
+export type { BunHttpServer, BunServeOptions } from "./types/bun.ts";
+export type { DenoHttpServer, DenoServeHandlerInfo, DenoServeOptions } from "./types/deno.ts";
+export type { CloudflareEnv, CloudflareExecutionContext } from "./types/cloudflare.ts";
+export type {
+  AWSLambdaContext,
+  AWSLambdaProxyEvent,
+  AWSLambdaProxyEventV2,
+  AWSLambdaProxyResult,
+  AWSLambdaProxyResultV2,
+} from "./types/aws-lambda.ts";
+export type { ServiceWorkerFetchEvent } from "./types/service-worker.ts";

--- a/src/types/README.md
+++ b/src/types/README.md
@@ -1,0 +1,21 @@
+# Runtime types
+
+Minimal type declarations for the runtime objects srvx exposes, one file per runtime.
+
+srvx does **not** import `@types/bun`, `@types/deno`, `@cloudflare/workers-types`,
+`@types/aws-lambda` or `@types/serviceworker` from its sources. Those packages are not
+shipped to consumers, and several of them redeclare the same globals so they cannot be
+installed side by side. Referencing them from the published declarations made `tsc` fail
+for anyone targeting a single runtime without `skipLibCheck`
+([#284](https://github.com/h3js/srvx/issues/284)).
+
+Each type covers only what srvx itself reads or forwards, and stays structurally
+compatible with the official one, so a real `Bun.Server`, `Deno.HttpServer` or Lambda
+event is still accepted where srvx expects one. Consumers cast to the official type when
+they need the full surface.
+
+The official packages stay as devDependencies: `types.d.ts` references the `Deno`, `Bun`
+and service worker globals so the adapter implementations are still checked against the
+real declarations, and `test/aws.test.ts` feeds real `aws-lambda` events through the
+handlers. That is what keeps these shims honest. An oxlint `no-restricted-imports`
+override on `src/**` prevents the packages from being imported again.

--- a/src/types/aws-lambda.ts
+++ b/src/types/aws-lambda.ts
@@ -1,0 +1,86 @@
+// Minimal AWS Lambda types. See `src/types/README.md` for why these are inlined.
+
+/**
+ * AWS Lambda invocation context (`aws-lambda`'s `Context`).
+ */
+export interface AWSLambdaContext {
+  callbackWaitsForEmptyEventLoop: boolean;
+  functionName: string;
+  functionVersion: string;
+  invokedFunctionArn: string;
+  memoryLimitInMB: string;
+  awsRequestId: string;
+  logGroupName: string;
+  logStreamName: string;
+  getRemainingTimeInMillis(): number;
+  done(error?: Error, result?: any): void;
+  fail(error: Error | string): void;
+  succeed(messageOrObject: any): void;
+}
+
+/**
+ * API Gateway REST API (v1) proxy event (`APIGatewayProxyEvent`).
+ */
+export interface AWSLambdaProxyEvent {
+  httpMethod: string;
+  path: string;
+  headers: Record<string, string | undefined>;
+  multiValueHeaders?: Record<string, string[] | undefined>;
+  queryStringParameters?: Record<string, string | undefined> | null;
+  multiValueQueryStringParameters?: Record<string, string[] | undefined> | null;
+  body: string | null;
+  isBase64Encoded: boolean;
+  requestContext: {
+    domainName?: string;
+    identity?: { sourceIp?: string };
+  };
+}
+
+/**
+ * API Gateway HTTP API (v2) proxy event (`APIGatewayProxyEventV2`).
+ */
+export interface AWSLambdaProxyEventV2 {
+  version: string;
+  routeKey?: string;
+  rawPath: string;
+  rawQueryString: string;
+  cookies?: string[];
+  headers: Record<string, string | undefined>;
+  queryStringParameters?: Record<string, string | undefined>;
+  body?: string;
+  isBase64Encoded: boolean;
+  requestContext: {
+    domainName?: string;
+    http?: {
+      method: string;
+      path?: string;
+      protocol?: string;
+      sourceIp?: string;
+      userAgent?: string;
+    };
+  };
+}
+
+/**
+ * API Gateway REST API (v1) proxy result (`APIGatewayProxyResult`).
+ */
+export interface AWSLambdaProxyResult {
+  statusCode: number;
+  headers?: Record<string, string | number | boolean>;
+  multiValueHeaders?: Record<string, Array<string | number | boolean>>;
+  body: string;
+  isBase64Encoded?: boolean;
+}
+
+/**
+ * API Gateway HTTP API (v2) proxy result (`APIGatewayProxyResultV2`).
+ */
+export type AWSLambdaProxyResultV2 =
+  | string
+  | {
+      statusCode?: number;
+      headers?: Record<string, string | number | boolean>;
+      body?: string;
+      isBase64Encoded?: boolean;
+      cookies?: string[];
+    };

--- a/src/types/aws-lambda.ts
+++ b/src/types/aws-lambda.ts
@@ -12,6 +12,8 @@ export interface AWSLambdaContext {
   awsRequestId: string;
   logGroupName: string;
   logStreamName: string;
+  identity?: any;
+  clientContext?: any;
   getRemainingTimeInMillis(): number;
   done(error?: Error, result?: any): void;
   fail(error: Error | string): void;
@@ -24,15 +26,28 @@ export interface AWSLambdaContext {
 export interface AWSLambdaProxyEvent {
   httpMethod: string;
   path: string;
+  resource?: string;
   headers: Record<string, string | undefined>;
   multiValueHeaders?: Record<string, string[] | undefined>;
   queryStringParameters?: Record<string, string | undefined> | null;
   multiValueQueryStringParameters?: Record<string, string[] | undefined> | null;
+  pathParameters?: Record<string, string | undefined> | null;
+  stageVariables?: Record<string, string | undefined> | null;
   body: string | null;
   isBase64Encoded: boolean;
   requestContext: {
+    accountId?: string;
+    apiId?: string;
+    authorizer?: any;
     domainName?: string;
+    httpMethod?: string;
     identity?: { sourceIp?: string };
+    path?: string;
+    protocol?: string;
+    requestId?: string;
+    requestTimeEpoch?: number;
+    resourcePath?: string;
+    stage?: string;
   };
 }
 
@@ -47,10 +62,21 @@ export interface AWSLambdaProxyEventV2 {
   cookies?: string[];
   headers: Record<string, string | undefined>;
   queryStringParameters?: Record<string, string | undefined>;
+  pathParameters?: Record<string, string | undefined>;
+  stageVariables?: Record<string, string | undefined>;
   body?: string;
   isBase64Encoded: boolean;
   requestContext: {
+    accountId?: string;
+    apiId?: string;
+    authorizer?: any;
     domainName?: string;
+    domainPrefix?: string;
+    requestId?: string;
+    routeKey?: string;
+    stage?: string;
+    time?: string;
+    timeEpoch?: number;
     http?: {
       method: string;
       path?: string;

--- a/src/types/bun.ts
+++ b/src/types/bun.ts
@@ -12,7 +12,6 @@ export interface BunServeOptions {
   reusePort?: boolean;
   idleTimeout?: number;
   maxRequestBodySize?: number;
-  development?: boolean;
   error?: (error: any) => any;
   tls?: any;
   /** Any other option supported by the running Bun version. */
@@ -28,7 +27,7 @@ export interface BunHttpServer {
   readonly hostname?: string;
   readonly development?: boolean;
   readonly pendingRequests?: number;
-  requestIP(request: Request): { address: string; family: string; port: number } | null;
+  requestIP(request: Request): { address: string; family: "IPv4" | "IPv6"; port: number } | null;
   stop(closeActiveConnections?: boolean): Promise<void>;
   ref(): void;
   unref(): void;

--- a/src/types/bun.ts
+++ b/src/types/bun.ts
@@ -1,0 +1,35 @@
+// Minimal Bun types. See `src/types/README.md` for why these are inlined.
+
+/**
+ * Options forwarded to `Bun.serve()`.
+ *
+ * @docs https://bun.sh/docs/api/http
+ */
+export interface BunServeOptions {
+  port?: string | number;
+  hostname?: string;
+  unix?: string;
+  reusePort?: boolean;
+  idleTimeout?: number;
+  maxRequestBodySize?: number;
+  development?: boolean;
+  error?: (error: any) => any;
+  tls?: any;
+  /** Any other option supported by the running Bun version. */
+  [key: string]: any;
+}
+
+/**
+ * Server instance returned by `Bun.serve()` (`Bun.Server`).
+ */
+export interface BunHttpServer {
+  readonly url: URL;
+  readonly port?: number;
+  readonly hostname?: string;
+  readonly development?: boolean;
+  readonly pendingRequests?: number;
+  requestIP(request: Request): { address: string; family: string; port: number } | null;
+  stop(closeActiveConnections?: boolean): Promise<void>;
+  ref(): void;
+  unref(): void;
+}

--- a/src/types/bun.ts
+++ b/src/types/bun.ts
@@ -33,7 +33,11 @@ export interface BunHttpServer {
   /** Upgrade an incoming request to a WebSocket connection. */
   upgrade(request: Request, options?: { headers?: HeadersInit; data?: any }): boolean;
   /** Publish a message to every client subscribed to `topic`. */
-  publish(topic: string, data: any, compress?: boolean): number;
+  publish(
+    topic: string,
+    data: string | ArrayBufferView | ArrayBuffer | SharedArrayBuffer,
+    compress?: boolean,
+  ): number;
   subscriberCount(topic: string): number;
   reload(options: any): void;
   stop(closeActiveConnections?: boolean): Promise<void>;

--- a/src/types/bun.ts
+++ b/src/types/bun.ts
@@ -27,7 +27,15 @@ export interface BunHttpServer {
   readonly hostname?: string;
   readonly development?: boolean;
   readonly pendingRequests?: number;
+  readonly pendingWebSockets?: number;
   requestIP(request: Request): { address: string; family: "IPv4" | "IPv6"; port: number } | null;
+  timeout(request: Request, seconds: number): void;
+  /** Upgrade an incoming request to a WebSocket connection. */
+  upgrade(request: Request, options?: { headers?: HeadersInit; data?: any }): boolean;
+  /** Publish a message to every client subscribed to `topic`. */
+  publish(topic: string, data: any, compress?: boolean): number;
+  subscriberCount(topic: string): number;
+  reload(options: any): void;
   stop(closeActiveConnections?: boolean): Promise<void>;
   ref(): void;
   unref(): void;

--- a/src/types/cloudflare.ts
+++ b/src/types/cloudflare.ts
@@ -5,7 +5,7 @@
  */
 export interface CloudflareExecutionContext {
   waitUntil(promise: Promise<any>): void;
-  passThroughOnException?(): void;
+  passThroughOnException(): void;
   props?: any;
 }
 

--- a/src/types/cloudflare.ts
+++ b/src/types/cloudflare.ts
@@ -1,0 +1,27 @@
+// Minimal Cloudflare Workers types. See `src/types/README.md` for why these are inlined.
+
+/**
+ * Cloudflare Workers execution context (`ExecutionContext`).
+ */
+export interface CloudflareExecutionContext {
+  waitUntil(promise: Promise<any>): void;
+  passThroughOnException?(): void;
+  props?: any;
+}
+
+/**
+ * Cloudflare Workers environment bindings.
+ *
+ * Augment this interface to type your own bindings:
+ *
+ * ```ts
+ * declare module "srvx" {
+ *   interface CloudflareEnv {
+ *     MY_KV: KVNamespace;
+ *   }
+ * }
+ * ```
+ */
+export interface CloudflareEnv {
+  [key: string]: unknown;
+}

--- a/src/types/deno.ts
+++ b/src/types/deno.ts
@@ -1,0 +1,39 @@
+// Minimal Deno types. See `src/types/README.md` for why these are inlined.
+
+/**
+ * Options forwarded to `Deno.serve()`.
+ *
+ * @docs https://docs.deno.com/api/deno/~/Deno.serve
+ */
+export interface DenoServeOptions {
+  port?: number;
+  hostname?: string;
+  reusePort?: boolean;
+  signal?: AbortSignal;
+  key?: string;
+  cert?: string;
+  passphrase?: string;
+  onError?: (error: unknown) => Response | Promise<Response>;
+  onListen?: (localAddr: { hostname: string; port: number }) => void;
+  /** Any other option supported by the running Deno version. */
+  [key: string]: any;
+}
+
+/**
+ * Server instance returned by `Deno.serve()` (`Deno.HttpServer`).
+ */
+export interface DenoHttpServer {
+  readonly finished: Promise<void>;
+  readonly addr?: { hostname?: string; port?: number; transport?: string };
+  shutdown(): Promise<void>;
+  ref(): void;
+  unref(): void;
+}
+
+/**
+ * Second argument Deno passes to the fetch handler (`Deno.ServeHandlerInfo`).
+ */
+export interface DenoServeHandlerInfo {
+  readonly remoteAddr: { hostname: string; port: number; transport?: string };
+  readonly completed?: Promise<void>;
+}

--- a/src/types/deno.ts
+++ b/src/types/deno.ts
@@ -28,6 +28,7 @@ export interface DenoHttpServer {
   shutdown(): Promise<void>;
   ref(): void;
   unref(): void;
+  [Symbol.asyncDispose](): PromiseLike<void>;
 }
 
 /**

--- a/src/types/service-worker.ts
+++ b/src/types/service-worker.ts
@@ -1,0 +1,11 @@
+// Minimal service worker types. See `src/types/README.md` for why these are inlined.
+
+/**
+ * Service worker `fetch` event (`FetchEvent`).
+ */
+export interface ServiceWorkerFetchEvent {
+  readonly request: Request;
+  readonly clientId?: string;
+  respondWith(response: Response | Promise<Response>): void;
+  waitUntil(promise: Promise<any>): void;
+}

--- a/test/types.test-d.ts
+++ b/test/types.test-d.ts
@@ -3,14 +3,19 @@ import type { PeerCertificate } from "node:tls";
 import type { ServerRequest } from "../src/types.ts";
 import type { MTLSPluginOptions } from "../src/mtls.ts";
 
+// `CloudflareEnv` is the augmentation point for Workers bindings.
+declare module "../src/types.ts" {
+  interface CloudflareEnv {
+    TEST?: string;
+  }
+}
+
 describe("types", () => {
   describe("ServerRequest", () => {
     const request = new Request("http://_") as ServerRequest;
     describe("cloudflare", () => {
       test("env", () => {
-        expectTypeOf(request.runtime?.cloudflare?.env).toEqualTypeOf<
-          undefined | { TEST: string }
-        >();
+        expectTypeOf(request.runtime?.cloudflare?.env.TEST).toEqualTypeOf<undefined | string>();
       });
     });
     // `request.tls` is contributed by the `srvx/mtls` mtlsPlugin() module augmentation.

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,8 +1,7 @@
+// Ambient runtime declarations for srvx's own sources and tests only.
+// The published types reference none of these (see `src/types/README.md`); they
+// are kept so the adapter implementations are still checked against the real
+// `Bun` / `Deno` / service worker globals.
+/// <reference types="bun" />
 /// <reference types="deno" />
 /// <reference types="serviceworker" />
-
-declare module "cloudflare:workers" {
-  export const env: {
-    TEST: string;
-  };
-}


### PR DESCRIPTION
Closes #284 — a third option, alongside #285 (declare the packages) and #286 (split the chunk): describe the runtime objects ourselves so there is nothing left to install or split.

### The problem

`dist/_chunks/types.d.mts` is pulled in by every entry and references `bun`, `aws-lambda`, `@cloudflare/workers-types`, `cloudflare:workers`, the `Deno` namespace and `FetchEvent`. All of those are devDependencies consumers never receive, so `tsc` fails without `skipLibCheck` whatever runtime you target. They also cannot all be installed at once — `@types/serviceworker`, `@types/bun` and `@types/deno` redeclare the same globals.

### The change

Minimal interfaces, one file per runtime under `src/types/`, re-exported from `src/types.ts`:

```
src/types/
├── README.md            # why these are inlined, and what keeps them honest
├── aws-lambda.ts        # AWSLambdaContext, AWSLambdaProxyEvent(V2), AWSLambdaProxyResult(V2)
├── bun.ts               # BunServeOptions, BunHttpServer
├── cloudflare.ts        # CloudflareExecutionContext, CloudflareEnv
├── deno.ts              # DenoServeOptions, DenoHttpServer, DenoServeHandlerInfo
└── service-worker.ts    # ServiceWorkerFetchEvent
```

Each covers only what srvx itself reads or forwards, and stays structurally compatible with the official types, so a real `Bun.Server`, `Deno.HttpServer` or Lambda event is still accepted where srvx expects one. Consumers cast to the official type when they want the full surface.

Also here:

- **`BodyInit` → `ResponseBody`**, derived from the ambient `Response` (`NonNullable<ConstructorParameters<typeof globalThis.Response>[0]>`), fixing `dist/adapters/node.d.mts:43` without `lib: ["dom"]` or `undici-types`.
- **Cloudflare bindings** move from `typeof import("cloudflare:workers").env` to an augmentable `CloudflareEnv` interface. `declare module "srvx" { interface CloudflareEnv { MY_KV: KVNamespace } }` — verified to merge through the re-export, from a consumer against built `dist/`. Documented in the guide.
- **The type packages stay as devDependencies.** `types.d.ts` still references the `Bun` / `Deno` / service worker globals, so the adapter implementations are still checked against the real declarations, and `test/aws.test.ts` still feeds real `aws-lambda` events through the handlers. That is what proves the shims are compatible rather than merely plausible. An oxlint `no-restricted-imports` override on `src/**` stops the packages being imported from sources again.

### Verified

Consumer project, `module: NodeNext`, `skipLibCheck: false`, only `@types/node` installed — errors reported by `tsc`:

| Import | before | after |
| --- | --- | --- |
| `srvx/static` (the issue's repro) | 12 | **0** |
| `srvx/node` | 13 | **0** |
| `srvx/service-worker` | 13 | **0** |
| `srvx/log` + `srvx/mtls` + `srvx/body-limit` | 12 | **0** |
| `srvx/bun`, `srvx/deno`, `srvx/cloudflare`, `srvx/aws-lambda` | — | **0** |
| `srvx` (universal) | 12 | **0** |

The universal entry reaching 0 is the part the other two PRs cannot do: with nothing left to resolve, covering every runtime costs nothing.

With `@types/bun` and `@types/aws-lambda` also installed it stays at 0: a real `Bun.Server<any>` assigns into `request.runtime.bun.server`, real `APIGatewayProxyEvent` / `Context` pass to `handleLambdaEvent`, and `server.bun?.server as Server` reaches `publish`. Precision holds for `server.bun?.server?.port`, `runtime?.deno?.info.remoteAddr.hostname`, `runtime?.node?.req.url` and passthrough options (`bun: { websocket }`, `node: { http2 }`); wrong types still error.

- `pnpm lint`, `pnpm typecheck`, `pnpm vitest run` (30 files, 1286 tests) green, including the existing `test/types.test-d.ts` assertions for the Cloudflare `env` and the mtls `request.tls` augmentation.
- Every emitted `.mjs` is identical to a build of `main` apart from one dropped cast's parentheses in `deno.mjs` — this is a types-only change.
- `dist/**/*.d.mts` references no external package and no ambient runtime global.

### Compatibility

Measured by running identical probes against a build of `main` and this branch. Runtime behaviour is unchanged — every emitted `.mjs` is identical apart from one dropped cast's parentheses in `deno.mjs`.

Unaffected: `serve()`, options, middleware, plugins, `ServerRequest`, `FastResponse` / `FastURL`, the whole Node adapter surface, and passing option objects (`bun: { … }` takes fresh literals, typed consts, interfaces and `Omit<Bun.Serve.Options, "fetch">` alike, since those types stay open). Two things that already failed on `main` still fail identically and are **not** regressions: assigning `toLambdaHandler()` to `APIGatewayProxyHandler` (the v2 `string` result never fit), and `ExportedHandlerFetchHandler` needing `@cloudflare/workers-types`.

The shims cover the members consumers actually read — including `server.upgrade()` / `publish()` / `subscriberCount()` for bun websockets, and `event.pathParameters`, `requestContext.requestId` / `authorizer` / `stage`, `context.clientContext` for Lambda handlers. Two narrowings remain, both one cast away:

- `runtime.serviceWorker.event` no longer resolves to the full `FetchEvent`, so `preloadResponse` / `resultingClientId` need `event as FetchEvent` (only affects consumers who install `@types/serviceworker`).
- Rarely-read members of `Bun.Server`, `Deno.HttpServer` and the Lambda event still need a cast to the official type, as documented in the guide.

**One real breaking change:** `request.runtime.cloudflare.env` was inferred from `cloudflare:workers`, which `wrangler types` generates, so Workers users with bindings now get `unknown` until they add:

```ts
declare module "srvx" {
  interface CloudflareEnv extends Env {}
}
```

That one is inherent to this approach rather than an oversight — preserving the inference requires the `cloudflare:workers` reference that breaks every non-Workers consumer, which is the whole bug. #286's split is the only option that keeps both. Worth a minor bump either way.

If keeping full precision when the official packages *are* installed matters more, the shims could each sit behind a `typeof globalThis extends { Bun: … } ? real : shim` probe without reintroducing an import — more machinery than this PR, and easy to layer on later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added self-contained, built-in TypeScript definitions and standardized event/context shapes for Bun, Deno, Cloudflare Workers, AWS Lambda, and service workers.
  * Introduced and exported `ResponseBody` for consistent request/response body typing.
* **Documentation**
  * Expanded the guide explaining the bundled typings and how to extend them.
* **Improvements**
  * Updated adapter/handler typings to use the bundled runtime types (including AWS Lambda, Cloudflare, service worker, and Node response body typing).
* **Tests**
  * Refined type tests for optional Cloudflare environment properties.
* **Chores**
  * Tightened lint import-restriction rules and adjusted bundler externalization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
