### PR TITLE
types(bun): derive `HeadersInit` from the ambient `Headers`

### DIFF
--- a/src/types/bun.ts
+++ b/src/types/bun.ts
@@ -1,6 +1,13 @@
 // Minimal Bun types. See `src/types/README.md` for why these are inlined.
 
 /**
+ * Headers accepted by the runtime `Headers` constructor (`HeadersInit`).
+ *
+ * Derived from the ambient `Headers` so that it does not require `lib: ["dom"]`.
+ */
+type ResponseHeaders = NonNullable<ConstructorParameters<typeof globalThis.Headers>[0]>;
+
+/**
  * Options forwarded to `Bun.serve()`.
  *
  * @docs https://bun.sh/docs/api/http
@@ -31,7 +38,7 @@ export interface BunHttpServer {
   requestIP(request: Request): { address: string; family: "IPv4" | "IPv6"; port: number } | null;
   timeout(request: Request, seconds: number): void;
   /** Upgrade an incoming request to a WebSocket connection. */
-  upgrade(request: Request, options?: { headers?: HeadersInit; data?: any }): boolean;
+  upgrade(request: Request, options?: { headers?: ResponseHeaders; data?: any }): boolean;
   /** Publish a message to every client subscribed to `topic`. */
   publish(
     topic: string,


### PR DESCRIPTION
Follow-up to #284 / #287.

`BunHttpServer.upgrade()` still referenced the DOM global `HeadersInit`. `@types/node` does not declare it, so a Node-only consumer with `lib: ["esnext"]` still had to add `lib: ["dom"]` or `skipLibCheck` to type-check srvx's own declarations — the one case #287 missed.

Derived from the ambient `Headers` constructor, the same way `ResponseBody` already handles `BodyInit`:

```ts
type ResponseHeaders = NonNullable<ConstructorParameters<typeof globalThis.Headers>[0]>;
```

Structurally identical to the DOM definition — `string[][]`, `Record<string, string>` and `Headers` are all accepted. Kept local to `src/types/bun.ts` since it is the only user, and `src/types.ts` already imports from there.

Verified with a Node-only project (`lib: ["esnext"]`, `@types/node` 26, TypeScript 7.0.2, no `skipLibCheck`, no extra type packages) installing the packed tarball: **1 error before, 0 after**. `pnpm lint`, `pnpm typecheck` are green.

On your point about consumers requiring node and dom types — fair in general, but `lib: ["dom"]` also pulls in browser globals that a server project has no business seeing, and it is a repo-wide switch. Zigbee2MQTT for instance keeps a small `dom.shim.d.ts` precisely to avoid it. Happy to drop this if you would rather keep the DOM requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when providing response headers during server connection upgrades.
  * Updated the public API typing to accurately accept supported header input formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->