### PR TITLE
fix(node): allow body reads when stream is pre-drained with rawBody

### DIFF
--- a/src/adapters/_node/request.ts
+++ b/src/adapters/_node/request.ts
@@ -360,6 +360,9 @@ export const NodeRequest: {
     // continuation (`.toString()` / `JSON.parse`) so no extra promise or
     // microtask hop is introduced vs. inlining the read.
     #readBuffered() {
+      if ("rawBody" in this.#req && Buffer.isBuffer(this.#req.rawBody)) {
+        return readBody(this.#req, this.#maxRequestBodySize);
+      }
       // A source that is already finished emits no further `data` / `end` /
       // `error`, so `readBody()` would wait forever on a body that can no longer
       // arrive. Beyond a disconnect that means a stream someone else consumed:

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -748,32 +748,64 @@ describe("request signal", () => {
   });
 
   test("should read body when stream was pre-drained by middleware with rawBody", async () => {
-    const server = serve({
-      port: 0,
-      async fetch(request) {
-        return new Response(await request.text());
-      },
+    let rawBodyDone: () => void;
+    const rawBodyPromise = new Promise<void>((resolve) => {
+      rawBodyDone = resolve;
     });
 
-    // Inject connect/express middleware that drains the stream and stores rawBody
-    server.node!.server!.on("request", async (req: any) => {
+    const handler = toNodeHandler(async (request) => {
+      await rawBodyPromise;
+      return new Response(await request.text());
+    });
+
+    const server = createServer(async (req: any, res) => {
       const chunks: Buffer[] = [];
       for await (const c of req) {
         chunks.push(c);
       }
       req.rawBody = Buffer.concat(chunks);
+      rawBodyDone();
+      handler(req, res as any);
     });
 
-    await server.ready();
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as any).port;
 
-    const res = await fetch(server.url!, {
+    const res = await fetch(`http://localhost:${port}`, {
       method: "POST",
       body: JSON.stringify({ hello: "world" }),
     });
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ hello: "world" });
 
-    await server.close();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  test("should parse json body when stream was pre-drained by middleware with rawBody", async () => {
+    const handler = toNodeHandler(async (request) => {
+      return Response.json(await request.json());
+    });
+
+    const server = createServer(async (req: any, res) => {
+      const chunks: Buffer[] = [];
+      for await (const c of req) {
+        chunks.push(c);
+      }
+      req.rawBody = Buffer.concat(chunks);
+      handler(req, res as any);
+    });
+
+    await new Promise<void>((resolve) => server.listen(0, resolve));
+    const port = (server.address() as any).port;
+
+    const res = await fetch(`http://localhost:${port}`, {
+      method: "POST",
+      body: JSON.stringify({ test: 123 }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ test: 123 });
+
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   });
 
   // `IncomingMessage` is `autoDestroy`, so a fully read body leaves `req`

--- a/test/node-adapters.test.ts
+++ b/test/node-adapters.test.ts
@@ -747,6 +747,35 @@ describe("request signal", () => {
     expect(abortFired).toBe(false);
   });
 
+  test("should read body when stream was pre-drained by middleware with rawBody", async () => {
+    const server = serve({
+      port: 0,
+      async fetch(request) {
+        return new Response(await request.text());
+      },
+    });
+
+    // Inject connect/express middleware that drains the stream and stores rawBody
+    server.node!.server!.on("request", async (req: any) => {
+      const chunks: Buffer[] = [];
+      for await (const c of req) {
+        chunks.push(c);
+      }
+      req.rawBody = Buffer.concat(chunks);
+    });
+
+    await server.ready();
+
+    const res = await fetch(server.url!, {
+      method: "POST",
+      body: JSON.stringify({ hello: "world" }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ hello: "world" });
+
+    await server.close();
+  });
+
   // `IncomingMessage` is `autoDestroy`, so a fully read body leaves `req`
   // destroyed while the response is still open. Touching `signal` only *after*
   // the read is the order that catches a disconnect check keying off


### PR DESCRIPTION
## Summary

Fixes #294

When running behind middleware or hosting environments that pre-drain request streams into a `req.rawBody` buffer (e.g. Google Cloud Functions / Firebase Functions / Express body parsers), `req.readableEnded` is already `true` when srvx handles the request.

In `NodeRequest.#readBuffered()`, `isBodySourceFinished(this.#req)` checks `req.readableEnded` and rejects immediately with `TypeError: Body is unusable`, preventing the execution from reaching `readBody()` where the `req.rawBody` buffer is handled.

## Background

`readBody()` already supports `rawBody` buffers provided by environments like Cloud Functions:
```ts
if ("rawBody" in req && Buffer.isBuffer(req.rawBody)) {
  if (maxRequestBodySize !== undefined && req.rawBody.length > maxRequestBodySize) {
    return Promise.reject(createBodyTooLargeError(maxRequestBodySize));
  }
  return Promise.resolve(req.rawBody);
}
```
When `rawBody` is present on the incoming request, the body has already been completely received and buffered. Checking for `rawBody` before evaluating `isBodySourceFinished` allows these environments to read the body without being incorrectly rejected as an unusable/exhausted stream.

## Verification

- Added regression test in `test/node-adapters.test.ts` verifying that pre-drained streams containing `req.rawBody` can be read via `request.text()` and `request.json()`.
- Verified `pnpm vitest run test/node-adapters.test.ts` passes (95 tests).
- `oxlint`, `oxfmt`, and `typecheck` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed request handling when middleware has already buffered the request body.
  * Ensured pre-read JSON payloads remain available to Fetch-based handlers.
  * Continued enforcing maximum request body size limits for buffered requests.

* **Tests**
  * Added coverage for requests whose bodies are drained and stored before handler processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->