### PR TITLE
perf(url): avoid full parse when reading hash on the fast path

### DIFF
--- a/src/_url.ts
+++ b/src/_url.ts
@@ -43,6 +43,7 @@ const _searchNeedsNormRE = /[#"'<>\x00-\x20\x7f-\uffff]/;
  *  - `url.search`
  *  - `url.searchParams`
  *  - `url.protocol`
+ *  - `url.hash`
  *
  * **NOTES:**
  *
@@ -281,6 +282,13 @@ export const FastURL: { new (url: string | URLInit): URL & { _url: URL } } =
           this.#protocol = url.slice(0, protocolIndex + 1);
         }
         return this.#protocol;
+      }
+
+      get hash() {
+        if (this.#url) {
+          return this.#url.hash;
+        }
+        return "";
       }
 
       toString(): string {

--- a/test/url.test.ts
+++ b/test/url.test.ts
@@ -573,15 +573,18 @@ describe("FastURL", () => {
         expect(url.pathname, ".pathname").toBe(pathname);
         expect(url.search, ".search").toBe(search);
         expect(url.searchParams.getAll("id"), ".searchParams id").toEqual([...ids]);
+        expect(url.hash, ".hash").toBe(std.hash);
       });
 
       test(`FastURL "${input}" stays consistent after deopt`, () => {
+        const std = new URL(`http://localhost${input}`);
         const url = new NodeRequestURL({
           req: { url: input, headers: { host: "localhost" } } as any,
         });
         void url.hostname; // force deopt to native URL
         expect(url.pathname, ".pathname").toBe(pathname);
         expect(url.search, ".search").toBe(search);
+        expect(url.hash, ".hash").toBe(std.hash);
       });
     }
 
@@ -589,6 +592,38 @@ describe("FastURL", () => {
       const url = new FastURL("/p#frag");
       expect(url.pathname).toBe("/p");
       expect(url.search).toBe("");
+    });
+  });
+
+  describe(".hash", () => {
+    test("is empty without a full parse for object-form input", () => {
+      const url = new NodeRequestURL({
+        req: { url: "/p?a=1", headers: { host: "localhost" } } as any,
+      });
+      expect(url.hash).toBe("");
+      expect(url.pathname).toBe("/p"); // still on the fast path
+      expect(url.search).toBe("?a=1");
+    });
+
+    test("is empty without a full parse for origin-form string input", () => {
+      const url = new FastURL("/p?a=1");
+      expect(url.hash).toBe("");
+      expect(url.pathname).toBe("/p");
+      expect(url.search).toBe("?a=1");
+    });
+
+    test("is preserved for absolute-form string input", () => {
+      expect(new FastURL("https://example.com/a#b").hash).toBe("#b");
+      expect(new FastURL("https://example.com/a?q=1#b=c").hash).toBe("#b=c");
+      expect(new FastURL("https://example.com/a").hash).toBe("");
+    });
+
+    test("setter is reflected in .hash and .href", () => {
+      const url = new FastURL("/p?a=1");
+      url.hash = "#frag";
+      expect(url.hash).toBe("#frag");
+      expect(url.href).toBe("http://localhost/p?a=1#frag");
+      expect(url.pathname).toBe("/p");
     });
   });
 


### PR DESCRIPTION
**context**: found this profiling Nuxt's SSR path, where we build the render URL as `pathname + search + hash`

reading `url.hash` on a `FastURL` costs a full parse, because there's no `hash` getter

but ... there's nothing to _find_ in that parse on the fast path. so in that case we can optimise by returning `''`. quick measurement: 500k iterations, node 22, object-form input:

```
hash (object form)               316 ns -> 40 ns
hash (origin-form string)        229 ns -> 25 ns
hash (absolute string with '#')  228 ns -> 228 ns
pathname (already fast)           40 ns
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `hash` property to URL handling, enabling access to URL fragments.
  * Fragment values are preserved for absolute URLs and reflected when updated.

* **Bug Fixes**
  * Improved fragment parsing consistency across URL formats.
  * Ensured fragment values remain consistent before and after URL processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->