### PR TITLE
docs(guide): change server entry file from server.ts to server.mjs

### DIFF
--- a/docs/1.guide/01.index.md
+++ b/docs/1.guide/01.index.md
@@ -51,7 +51,7 @@ Instead of using the `srvx` CLI, you can directly import the `serve` method to d
 
 Create a server entry:
 
-```js [server.ts]
+```js [server.mjs]
 import { serve } from "srvx";
 
 const server = serve({


### PR DESCRIPTION
Updated server entry example to use server.mjs instead of server.ts.
All the code below references server.mjs


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Quick Start API example to use the JavaScript module (`mjs`) syntax designation instead of TypeScript.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->