### PR TITLE
docs: fix typos in guide

### DIFF
--- a/docs/1.guide/02.handler.md
+++ b/docs/1.guide/02.handler.md
@@ -110,7 +110,7 @@ serve({
 ```
 
 > [!TIP]
-> srvx implementation of [Request][Request] proxy directly uses the underlying [node:IncomingMessage][IncomingMessage] as source of trust. Any changes to [Request][Request] will be reflected to the underlying [node:IncomingMessage][IncomingMessage] and vise-versa.
+> srvx implementation of [Request][Request] proxy directly uses the underlying [node:IncomingMessage][IncomingMessage] as source of truth. Any changes to [Request][Request] will be reflected to the underlying [node:IncomingMessage][IncomingMessage] and vice versa.
 
 :read-more{to="/guide/node" title="Node.js support"}
 

--- a/docs/1.guide/03.server.md
+++ b/docs/1.guide/03.server.md
@@ -29,7 +29,7 @@ console.log(`🚀 Server is ready at ${server.url}`);
 
 ### `server.options`
 
-Access to the sever options set during initialization.
+Access to the server options set during initialization.
 
 :read-more{to="/guide/options"}
 

--- a/docs/1.guide/05.options.md
+++ b/docs/1.guide/05.options.md
@@ -26,7 +26,7 @@ serve({
 });
 ```
 
-There are two kind of options:
+There are two kinds of options:
 
 - Generic options: Top level options are intended to have exactly same functionality regardless of runtime
 - Runtime specific: Allow customizing more runtime specific options

--- a/docs/1.guide/07.bundler.md
+++ b/docs/1.guide/07.bundler.md
@@ -12,7 +12,7 @@ Typically `srvx` is to be imported like this.
 import { serve } from "srvx";
 ```
 
-The import above automatically resolves the the correct entrypoint for each runtime. Node.js, Deno, Cloudflare, and Bun use [ESM conditions](https://nodejs.org/api/esm.html#resolution-algorithm-specification) to resolve the correct entrypoint.
+The import above automatically resolves the correct entrypoint for each runtime. Node.js, Deno, Cloudflare, and Bun use [ESM conditions](https://nodejs.org/api/esm.html#resolution-algorithm-specification) to resolve the correct entrypoint.
 
 Normally, when you are directly using `srvx` in your project without bundling it should work as expected.
 
@@ -103,4 +103,4 @@ esbuild main.ts \
 
 ::
 
-By doing this, the bundler will resolve the correct version on srvx for your runtime.
+By doing this, the bundler will resolve the correct version of srvx for your runtime.

--- a/docs/1.guide/08.node.md
+++ b/docs/1.guide/08.node.md
@@ -9,7 +9,7 @@ icon: akar-icons:node-fill
 > [!NOTE]
 > This is an advanced section, explaining internal mechanism of srvx for Node.js support.
 
-When you want to create a HTTP server using [Node.js][Node.js], you have to use [node:http](https://nodejs.org/api/http.html) builtin.
+When you want to create an HTTP server using [Node.js][Node.js], you have to use [node:http](https://nodejs.org/api/http.html) builtin.
 
 **Example:** Simple Node.js server.
 
@@ -21,7 +21,7 @@ createServer((req, res) => {
 }).listen(3000);
 ```
 
-Whenever a new request is received, the request event is called with two objects: a request `req` object ([node:IncomingMessage][IncomingMessage]) to access HTTP request details and a response `res` object ([node:ServerResponse][ServerResponse]) that can be used to prepare and send a HTTP response. Popular framework such as [Express](https://expressjs.com/) and [Fastify](https://fastify.dev/) are also based on Node.js server API.
+Whenever a new request is received, the request event is called with two objects: a request `req` object ([node:IncomingMessage][IncomingMessage]) to access HTTP request details and a response `res` object ([node:ServerResponse][ServerResponse]) that can be used to prepare and send an HTTP response. Popular frameworks such as [Express](https://expressjs.com/) and [Fastify](https://fastify.dev/) are also based on Node.js server API.
 
 Recent JavaScript server runtimes like [Deno][Deno] and [Bun][Bun] have a different way to define a server which is similar to web [fetch][fetch] API.
 
@@ -39,15 +39,15 @@ Bun.serve({ port: 3000, fetch: (req) => new Response("Hello, Bun!") });
 
 As you probably noticed, there is a difference between [Node.js][Node.js] and [Deno][Deno] and [Bun][Bun]. The incoming request is a web [Request][Request] object and server response is a web [Response][Response] object. Accessing headers, request path, and preparing response is completely different between [Node.js][Node.js] and other runtimes.
 
-While [Deno][Deno] and [Bun][Bun] servers are both based on web standards, There are differences between them. The way to provide options, server lifecycle, access to request info such as client IP which is not part of [Request][Request] standard are some examples.
+While [Deno][Deno] and [Bun][Bun] servers are both based on web standards, there are differences between them. The way to provide options, server lifecycle, access to request info such as client IP which is not part of [Request][Request] standard are some examples.
 
 ## How Node.js Compatibility Works
 
 srvx internally uses a lightweight proxy system that wraps [node:IncomingMessage][IncomingMessage] as [Request][Request] and converts the final state of [node:ServerResponse][ServerResponse] to a [Response][Response] object.
 
-For each incoming request, instead of _fully cloning_ [Node.js][Node.js] request object with into a new [Request][Request] instance, srvx creates a proxy that _translates_ all property access and method calls between two interfaces.
+For each incoming request, instead of _fully cloning_ [Node.js][Node.js] request object into a new [Request][Request] instance, srvx creates a proxy that _translates_ all property access and method calls between two interfaces.
 
-With this method, we add **minimum amount of overhead** and can **optimize** internal implementation to leverage most of the possibilities with [Node.js][Node.js] native primitives. This method also has the advantage that there is **only one source of trust** ([Node.js][Node.js] request instance) and any changes to each interface will reflect the other ([node:IncomingMessage][IncomingMessage] <> [Request][Request]), **maximizing compatibility**. srvx will **never patch of modify** the global [Request][Request] and [Response][Response] constructors, keeping runtime natives untouched.
+With this method, we add **minimum amount of overhead** and can **optimize** internal implementation to leverage most of the possibilities with [Node.js][Node.js] native primitives. This method also has the advantage that there is **only one source of truth** ([Node.js][Node.js] request instance) and any changes to each interface will reflect the other ([node:IncomingMessage][IncomingMessage] <> [Request][Request]), **maximizing compatibility**. srvx will **never patch or modify** the global [Request][Request] and [Response][Response] constructors, keeping runtime natives untouched.
 
 Internally, the fetch wrapper looks like this:
 
@@ -116,7 +116,7 @@ await server.ready();
 console.log(`Server running at ${server.url}`);
 ```
 
-You can locally run benchmarks by cloning [srvx repository](https://github.com/h3js/srvx) and running `npm run bench:node [--all]` script. Speedup in v22.8.0 was roughly **%94**!
+You can locally run benchmarks by cloning [srvx repository](https://github.com/h3js/srvx) and running `npm run bench:node [--all]` script. Speedup in v22.8.0 was roughly **94%**!
 
 ### Adding headers to a response
 


### PR DESCRIPTION
Fixes a batch of spelling and grammar typos found while reading through `docs/1.guide/`. Docs-only, no behavior change.

- `source of trust` → `source of truth` (`02.handler.md`, `08.node.md`)
- `vise-versa` → `vice versa` (`02.handler.md`)
- `sever` → `server` (`03.server.md`)
- `two kind of options` → `two kinds of options` (`05.options.md`)
- `resolves the the correct entrypoint` → `resolves the correct entrypoint` (`07.bundler.md`)
- `correct version on srvx` → `correct version of srvx` (`07.bundler.md`)
- `never patch of modify` → `never patch or modify` (`08.node.md`)
- `request object with into a new Request instance` → `request object into a new Request instance` (`08.node.md`)
- `roughly **%94**` → `roughly **94%**` (`08.node.md`)
- `a HTTP server` / `a HTTP response` → `an HTTP …` (`08.node.md`)
- `Popular framework such as` → `Popular frameworks such as` (`08.node.md`)
- stray mid-sentence capital in `web standards, There are differences` (`08.node.md`)

I also noticed a few things that look like genuine documentation bugs rather than typos, and left them out of this PR to keep it purely mechanical. Happy to open a follow-up for any of them:

- `02.handler.md` documents `request.deno?.info`, but the property is `request.runtime.deno?.info`.
- `05.options.md` links `manual` to `/guide/server#serverserve`, but `03.server.md` has no `server.serve()` section (the method does exist in `types.ts`).
- `07.bundler.md` shows the esbuild CLI flag as `--conditions:node`; esbuild uses `--conditions=node`.
- `9.aws-lambda.md` says options `host` and `port` are ignored; the option is named `hostname`.
- The `loadServerEntry` reload example in `10.cli.md` calls `resolve()` without importing it.
- `gracefulShutdown` appears only in the per-runtime table in `05.options.md`, never as a documented option.
- `02.handler.md` documents `request.runtime.deno?.server`, which the Deno adapter does set, but `ServerRuntimeContext["deno"]` only declares `info` — so it fails to type check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G1vpa8Q9Ryk9Ne9Rq3vPqQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling, grammar, punctuation, and wording throughout the Fetch Handler, Server Options, Bundler, and Node.js guides.
  - Clarified references to HTTP servers, option categories, request objects, framework examples, and benchmark percentages.
  - Improved documentation accuracy and readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->