### PR TITLE
fix(aws-lambda): query params, set-cookie, v1 response shape, drain hang

### DIFF
--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -176,9 +176,9 @@ export function awsResponseHeaders(
   const headers = Object.create(null);
   for (const [key, value] of response.headers) {
     // `Headers` iteration yields one entry per `set-cookie`, so a flat record
-    // can only keep the last one. The full list is carried by `cookies` /
-    // `multiValueHeaders` below, both of which AWS applies *in addition to*
-    // `headers` — keeping a copy here would send that last cookie twice.
+    // can only keep the last one. The full list is carried below by `cookies`
+    // (v2) or `multiValueHeaders` (v1), both of which AWS applies *in addition
+    // to* `headers` — keeping a copy here would send that last cookie twice.
     if (key === "set-cookie") {
       continue;
     }
@@ -197,9 +197,12 @@ export function awsResponseHeaders(
     (event as AWSLambdaProxyEventV2)?.version === "2.0" ||
     !!(event as AWSLambdaProxyEventV2)?.requestContext?.http;
 
-  return isV2
-    ? { headers, cookies }
-    : { headers, cookies, multiValueHeaders: { "set-cookie": cookies } };
+  // `cookies` is a payload 2.0 field (HTTP API / Function URL). API Gateway
+  // REST (v1) and ALB accept only `statusCode`, `headers`, `multiValueHeaders`,
+  // `body` and `isBase64Encoded`; any extra top-level key fails the invocation
+  // with a 502 "Malformed Lambda proxy response", so v1 gets `multiValueHeaders`
+  // alone. See https://github.com/unjs/nitro/issues/504.
+  return isV2 ? { headers, cookies } : { headers, multiValueHeaders: { "set-cookie": cookies } };
 }
 
 // AWS Lambda proxy integrations requires base64 encoded buffers

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -175,6 +175,13 @@ export function awsResponseHeaders(
 ): AWSResponseHeaders {
   const headers = Object.create(null);
   for (const [key, value] of response.headers) {
+    // `Headers` iteration yields one entry per `set-cookie`, so a flat record
+    // can only keep the last one. The full list is carried by `cookies` /
+    // `multiValueHeaders` below, both of which AWS applies *in addition to*
+    // `headers` — keeping a copy here would send that last cookie twice.
+    if (key === "set-cookie") {
+      continue;
+    }
     if (value) {
       headers[key] = Array.isArray(value) ? value.join(",") : String(value);
     }
@@ -255,13 +262,45 @@ async function streamToNodeStream(
     while (!result.done) {
       const canContinue = writer.write(result.value);
       if (!canContinue) {
-        await new Promise<void>((resolve) => writer.once("drain", resolve));
+        await waitForDrain(writer);
       }
       result = await reader.read();
     }
   } finally {
     reader.releaseLock();
   }
+}
+
+// `drain` is only emitted by a live stream: if the response stream is torn down
+// while buffered above its high-water mark (client disconnect, socket reset), it
+// never fires. Awaiting it alone would leave the invocation pending until the
+// Lambda timeout — billing wall-clock and holding a concurrency slot — so
+// `error`/`close` settle the wait too.
+function waitForDrain(writer: NodeJS.WritableStream): Promise<void> {
+  const closedError = () => new Error("Response stream closed before it could drain");
+  const stream = writer as NodeJS.WritableStream & { destroyed?: boolean; writableEnded?: boolean };
+  if (stream.destroyed || stream.writableEnded) {
+    // Already gone: `close` has fired and will not fire again.
+    return Promise.reject(closedError());
+  }
+  return new Promise<void>((resolve, reject) => {
+    const settle = (error?: Error) => {
+      writer.removeListener("drain", onDrain);
+      writer.removeListener("error", onError);
+      writer.removeListener("close", onClose);
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    };
+    const onDrain = () => settle();
+    const onError = (error: Error) => settle(error);
+    const onClose = () => settle(closedError());
+    writer.once("drain", onDrain);
+    writer.once("error", onError);
+    writer.once("close", onClose);
+  });
 }
 
 function isTextType(contentType = "") {
@@ -289,19 +328,24 @@ function toBuffer(data: ReadableStream): Promise<Buffer> {
   });
 }
 
+// The gateway has already lossily parsed the query into `queryStringParameters`
+// (v1/ALB only; v2 carries `rawQueryString`), so the raw string cannot be
+// reconstructed exactly. `URLSearchParams` alone makes it worse though: it has
+// no way to express a valueless param, so `?foo` round-trips as `?foo=`. That
+// is invisible to anything re-parsing the query but not to route rules, cache
+// keys, canonical URLs or a signature computed over `request.url`, so a bare key
+// is emitted for empty values instead.
 function stringifyQuery(obj: Record<string, unknown>) {
-  const params = new URLSearchParams();
+  const parts: string[] = [];
   for (const [key, value] of Object.entries(obj)) {
-    if (value == null) continue;
-    if (Array.isArray(value)) {
-      for (const v of value) {
-        params.append(key, String(v));
-      }
-    } else {
-      params.append(key, String(value));
+    for (const item of Array.isArray(value) ? value : [value]) {
+      // Encode through `URLSearchParams` to keep escaping identical, then drop
+      // the trailing `=` it always appends for an empty value.
+      const pair = new URLSearchParams([[key, item == null ? "" : String(item)]]).toString();
+      parts.push(item == null || item === "" ? pair.slice(0, -1) : pair);
     }
   }
-  return params.toString();
+  return parts.join("&");
 }
 
 // Reverse: Web Request => AWS Event (v1/v2 compatible)

--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -202,7 +202,25 @@ export function awsResponseHeaders(
   // `body` and `isBase64Encoded`; any extra top-level key fails the invocation
   // with a 502 "Malformed Lambda proxy response", so v1 gets `multiValueHeaders`
   // alone. See https://github.com/unjs/nitro/issues/504.
-  return isV2 ? { headers, cookies } : { headers, multiValueHeaders: { "set-cookie": cookies } };
+  if (isV2) {
+    return { headers, cookies };
+  }
+
+  // ALB only reads `multiValueHeaders` when the target group has multi-value
+  // headers enabled ("You must use `multiValueHeaders` if you have enabled
+  // multi-value headers and `headers` otherwise"). That same setting renames
+  // the *request* fields, so an ALB event without `multiValueHeaders` means the
+  // flat record is the only channel back and dropping `set-cookie` from it
+  // would lose the cookie entirely. Only one fits; ALB itself keeps the last
+  // value when a header repeats, so match that instead of sending none.
+  // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers
+  const albEvent = event as AWSLambdaProxyEvent | undefined;
+  if (albEvent?.requestContext?.elb && !albEvent.multiValueHeaders) {
+    headers["set-cookie"] = cookies[cookies.length - 1];
+    return { headers };
+  }
+
+  return { headers, multiValueHeaders: { "set-cookie": cookies } };
 }
 
 // AWS Lambda proxy integrations requires base64 encoded buffers

--- a/src/types/aws-lambda.ts
+++ b/src/types/aws-lambda.ts
@@ -40,6 +40,8 @@ export interface AWSLambdaProxyEvent {
     apiId?: string;
     authorizer?: any;
     domainName?: string;
+    /** Present only on Application Load Balancer events. */
+    elb?: { targetGroupArn?: string };
     httpMethod?: string;
     identity?: { sourceIp?: string };
     path?: string;

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -878,6 +878,69 @@ describe("[AWS Lambda] Request Utils", () => {
       }
     });
 
+    // ALB reads `multiValueHeaders` only when the target group has multi-value
+    // headers enabled, and `headers` otherwise. The same setting renames the
+    // request fields, so `multiValueHeaders` on the event is what tells the two
+    // configurations apart.
+    describe("ALB (`requestContext.elb`)", () => {
+      const albEvent = (multiValue: boolean) =>
+        ({
+          httpMethod: "GET",
+          path: "/",
+          headers: { host: "lb.elb.amazonaws.com" },
+          body: null,
+          isBase64Encoded: false,
+          ...(multiValue
+            ? { multiValueHeaders: { host: ["lb.elb.amazonaws.com"] } }
+            : { queryStringParameters: {} }),
+          requestContext: {
+            elb: { targetGroupArn: "arn:aws:elasticloadbalancing:us-east-1:0:targetgroup/tg/1" },
+          },
+        }) as unknown as APIGatewayProxyEvent;
+
+      const responseWith = (...cookies: string[]) =>
+        new Response("{}", {
+          status: 200,
+          headers: [
+            ["content-type", "application/json"],
+            ...cookies.map((cookie) => ["set-cookie", cookie] as [string, string]),
+          ],
+        });
+
+      test("keeps a single set-cookie in the flat record when multi-value is off", () => {
+        const awsResponse = awsResponseHeaders(responseWith("a=1; Path=/"), albEvent(false));
+
+        // `multiValueHeaders` would be ignored by this target group, so the flat
+        // record is the only way the cookie reaches the client.
+        expect(Object.keys(awsResponse).sort()).toEqual(["headers"]);
+        expect(awsResponse.headers["set-cookie"]).toBe("a=1; Path=/");
+        expect(awsResponse.headers["content-type"]).toBe("application/json");
+      });
+
+      test("keeps the last cookie when multi-value is off, matching ALB's own last-wins rule", () => {
+        const awsResponse = awsResponseHeaders(responseWith("a=1", "b=2"), albEvent(false));
+
+        expect(awsResponse.headers["set-cookie"]).toBe("b=2");
+        expect(awsResponse.cookies).toBeUndefined();
+        expect(awsResponse.multiValueHeaders).toBeUndefined();
+      });
+
+      test("uses multiValueHeaders when the event carries them", () => {
+        const awsResponse = awsResponseHeaders(responseWith("a=1", "b=2"), albEvent(true));
+
+        expect(Object.keys(awsResponse).sort()).toEqual(["headers", "multiValueHeaders"]);
+        expect(awsResponse.headers["set-cookie"]).toBeUndefined();
+        expect(awsResponse.multiValueHeaders).toEqual({ "set-cookie": ["a=1", "b=2"] });
+      });
+
+      test("leaves cookie-less ALB responses untouched", () => {
+        const awsResponse = awsResponseHeaders(new Response("{}"), albEvent(false));
+
+        expect(awsResponse.headers["set-cookie"]).toBeUndefined();
+        expect(Object.keys(awsResponse).sort()).toEqual(["headers"]);
+      });
+    });
+
     test("should not put the v1-only `multiValueHeaders` field on a v2 result", () => {
       const response = new Response("{}", {
         status: 200,

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -845,13 +845,56 @@ describe("[AWS Lambda] Request Utils", () => {
 
       const awsResponse = awsResponseHeaders(response);
 
-      expect(awsResponse.cookies).toEqual([
-        "sessionId=abc123; HttpOnly; Secure",
-        "theme=dark; Path=/",
-      ]);
+      // v1: `multiValueHeaders` only, see the "malformed proxy response" tests below.
+      expect(awsResponse.cookies).toBeUndefined();
       expect(awsResponse.multiValueHeaders).toEqual({
         "set-cookie": ["sessionId=abc123; HttpOnly; Secure", "theme=dark; Path=/"],
       });
+    });
+
+    // API Gateway REST (v1) and ALB accept only `statusCode`, `headers`,
+    // `multiValueHeaders`, `body` and `isBase64Encoded`. Any extra top-level
+    // key fails the invocation with a 502 "Malformed Lambda proxy response",
+    // and `cookies` is a payload 2.0 field. See unjs/nitro#504.
+    test("should not put the v2-only `cookies` field on a v1 result", () => {
+      const response = new Response("{}", {
+        status: 200,
+        headers: [["set-cookie", "a=1"]],
+      });
+
+      const v1Event = {
+        httpMethod: "GET",
+        path: "/x",
+        headers: {},
+        requestContext: {},
+      } as unknown as APIGatewayProxyEvent;
+
+      for (const awsResponse of [
+        awsResponseHeaders(response),
+        awsResponseHeaders(response, v1Event),
+      ]) {
+        expect(Object.keys(awsResponse).sort()).toEqual(["headers", "multiValueHeaders"]);
+        expect(awsResponse.multiValueHeaders).toEqual({ "set-cookie": ["a=1"] });
+      }
+    });
+
+    test("should not put the v1-only `multiValueHeaders` field on a v2 result", () => {
+      const response = new Response("{}", {
+        status: 200,
+        headers: [["set-cookie", "a=1"]],
+      });
+
+      const fromVersion = awsResponseHeaders(response, {
+        version: "2.0",
+      } as APIGatewayProxyEventV2);
+      const fromRequestContext = awsResponseHeaders(response, {
+        requestContext: { http: { method: "GET" } },
+      } as APIGatewayProxyEventV2);
+
+      for (const awsResponse of [fromVersion, fromRequestContext]) {
+        expect(Object.keys(awsResponse).sort()).toEqual(["cookies", "headers"]);
+        expect(awsResponse.cookies).toEqual(["a=1"]);
+      }
     });
 
     // `Headers` iteration yields one entry per `set-cookie`, so a flat record
@@ -870,7 +913,6 @@ describe("[AWS Lambda] Request Utils", () => {
       const v1 = awsResponseHeaders(response);
       expect(v1.headers["set-cookie"]).toBeUndefined();
       expect(v1.headers["content-type"]).toBe("application/json");
-      expect(v1.cookies).toEqual(["a=1; Path=/", "b=2; HttpOnly"]);
       expect(v1.multiValueHeaders).toEqual({ "set-cookie": ["a=1; Path=/", "b=2; HttpOnly"] });
 
       const v2 = awsResponseHeaders(response, { version: "2.0" } as APIGatewayProxyEventV2);
@@ -1977,6 +2019,47 @@ describe("[AWS Lambda] Request Utils", () => {
         expect(
           metadata.headers["transfer-encoding"] || metadata.headers["content-length"],
         ).toBeTruthy();
+      });
+
+      test("carries cookies in the prelude as multiValueHeaders, never as `cookies`", async () => {
+        const { mockStream, getMetadata } = createMockResponseStream();
+
+        const fetchHandler = vi.fn().mockResolvedValue(
+          new Response("ok", {
+            headers: [
+              ["content-type", "text/plain"],
+              ["set-cookie", "a=1"],
+              ["set-cookie", "b=2"],
+            ],
+          }),
+        );
+
+        const v1Event: APIGatewayProxyEvent = {
+          httpMethod: "GET",
+          path: "/stream",
+          headers: { host: "api.example.com" },
+          body: null,
+          isBase64Encoded: false,
+          multiValueHeaders: {},
+          multiValueQueryStringParameters: {},
+          pathParameters: null,
+          stageVariables: null,
+          requestContext: {} as any,
+          resource: "",
+          queryStringParameters: null,
+        };
+
+        await handleLambdaEventWithStream(fetchHandler, v1Event, mockStream, createMockContext());
+
+        const metadata = getMetadata() as any;
+
+        expect(Object.keys(metadata).sort()).toEqual([
+          "headers",
+          "multiValueHeaders",
+          "statusCode",
+        ]);
+        expect(metadata.multiValueHeaders).toEqual({ "set-cookie": ["a=1", "b=2"] });
+        expect(metadata.headers["set-cookie"]).toBeUndefined();
       });
     });
   });

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -1,3 +1,4 @@
+import { Writable } from "node:stream";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   awsRequest,
@@ -737,6 +738,60 @@ describe("[AWS Lambda] Request Utils", () => {
 
       expect(request.url).toBe("https://api.example.com/api/users?page=1&limit=10");
     });
+
+    // v1/ALB events only expose the parsed `queryStringParameters`, so the raw
+    // query has to be rebuilt. `?foo` must not turn into `?foo=`: anything
+    // reading the raw URL (route rules, cache keys, canonical URLs, a signature
+    // over the query) sees a different string.
+    describe("v1 query reconstruction", () => {
+      const v1QueryEvent = (
+        queryStringParameters: Record<string, unknown> | null,
+        multiValueQueryStringParameters?: Record<string, unknown>,
+      ) =>
+        ({
+          httpMethod: "GET",
+          path: "/x",
+          headers: { host: "api.example.com" },
+          body: null,
+          isBase64Encoded: false,
+          multiValueHeaders: {},
+          multiValueQueryStringParameters,
+          pathParameters: null,
+          stageVariables: null,
+          requestContext: {} as any,
+          resource: "",
+          queryStringParameters,
+        }) as unknown as APIGatewayProxyEvent;
+
+      const urlOf = (event: APIGatewayProxyEvent) =>
+        awsRequest(event, createMockContext()).url.replace("https://api.example.com", "");
+
+      test("keeps a valueless param bare", () => {
+        expect(urlOf(v1QueryEvent({ foo: "" }))).toBe("/x?foo");
+      });
+
+      test("keeps valueless and valued params side by side", () => {
+        expect(urlOf(v1QueryEvent({ foo: "", page: "1" }))).toBe("/x?foo&page=1");
+      });
+
+      test("keeps a null value bare instead of dropping the key", () => {
+        expect(urlOf(v1QueryEvent({ foo: null }))).toBe("/x?foo");
+      });
+
+      test("preserves valued params and their escaping", () => {
+        expect(urlOf(v1QueryEvent({ q: "a b", "&": "=" }))).toBe("/x?q=a+b&%26=%3D");
+      });
+
+      test("expands multi-value params, bare entries included", () => {
+        expect(urlOf(v1QueryEvent({ tag: "b" }, { tag: ["a", "", "b"] }))).toBe(
+          "/x?tag=a&tag&tag=b",
+        );
+      });
+
+      test("emits no query at all when there are no params", () => {
+        expect(urlOf(v1QueryEvent(null))).toBe("/x");
+      });
+    });
   });
 
   describe("awsResponseHeaders", () => {
@@ -797,6 +852,42 @@ describe("[AWS Lambda] Request Utils", () => {
       expect(awsResponse.multiValueHeaders).toEqual({
         "set-cookie": ["sessionId=abc123; HttpOnly; Secure", "theme=dark; Path=/"],
       });
+    });
+
+    // `Headers` iteration yields one entry per `set-cookie`, so a flat record
+    // keeps only the last one - and AWS applies `headers` on top of
+    // `cookies`/`multiValueHeaders`, sending that last cookie twice.
+    test("should not leak set-cookie into the flat headers record", () => {
+      const response = new Response("{}", {
+        status: 200,
+        headers: [
+          ["content-type", "application/json"],
+          ["set-cookie", "a=1; Path=/"],
+          ["set-cookie", "b=2; HttpOnly"],
+        ],
+      });
+
+      const v1 = awsResponseHeaders(response);
+      expect(v1.headers["set-cookie"]).toBeUndefined();
+      expect(v1.headers["content-type"]).toBe("application/json");
+      expect(v1.cookies).toEqual(["a=1; Path=/", "b=2; HttpOnly"]);
+      expect(v1.multiValueHeaders).toEqual({ "set-cookie": ["a=1; Path=/", "b=2; HttpOnly"] });
+
+      const v2 = awsResponseHeaders(response, { version: "2.0" } as APIGatewayProxyEventV2);
+      expect(v2.headers["set-cookie"]).toBeUndefined();
+      expect(v2.cookies).toEqual(["a=1; Path=/", "b=2; HttpOnly"]);
+      expect(v2.multiValueHeaders).toBeUndefined();
+    });
+
+    test("should keep a single set-cookie out of the flat record too", () => {
+      const response = new Response("{}", { status: 200, headers: [["set-cookie", "a=1"]] });
+
+      const awsResponse = awsResponseHeaders(response, {
+        version: "2.0",
+      } as APIGatewayProxyEventV2);
+
+      expect(awsResponse.headers["set-cookie"]).toBeUndefined();
+      expect(awsResponse.cookies).toEqual(["a=1"]);
     });
 
     test("should handle array headers by joining with commas", () => {
@@ -1346,6 +1437,7 @@ describe("[AWS Lambda] Request Utils", () => {
             drainCallback = callback;
           }
         }),
+        removeListener: vi.fn(),
       };
 
       const mockStream = {} as AWSLambdaResponseStream;
@@ -1496,6 +1588,106 @@ describe("[AWS Lambda] Request Utils", () => {
       const metadata = getMetadata() as any;
       expect(metadata.cookies).toEqual(["session=abc"]);
     });
+
+    // `drain` is only emitted by a live stream. If the response stream is torn
+    // down while buffered above its high-water mark, waiting on `drain` alone
+    // never settles and the invocation hangs until the Lambda timeout.
+    describe("backpressure teardown", () => {
+      function useWriter(writer: Writable) {
+        (globalThis as any).awslambda = {
+          HttpResponseStream: { from: () => writer },
+        };
+        return {} as AWSLambdaResponseStream;
+      }
+
+      function stalledWriter() {
+        // Never invokes the write callback, so the stream stays backpressured.
+        const writer = new Writable({ highWaterMark: 1, write() {} });
+        writer.on("error", () => {});
+        return writer;
+      }
+
+      function chunkedResponse(count = 2) {
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              for (let i = 0; i < count; i++) {
+                controller.enqueue(new Uint8Array(64).fill(i));
+              }
+              controller.close();
+            },
+          }),
+        );
+      }
+
+      test("rejects instead of hanging when the stream errors mid-backpressure", async () => {
+        const writer = stalledWriter();
+        const streaming = awsStreamResponse(chunkedResponse(), useWriter(writer));
+
+        await vi.waitFor(() => expect(writer.listenerCount("drain")).toBe(1));
+        writer.destroy(new Error("ECONNRESET"));
+
+        await expect(streaming).rejects.toThrow("ECONNRESET");
+        expect(writer.listenerCount("drain")).toBe(0);
+        expect(writer.listenerCount("close")).toBe(0);
+      });
+
+      test("rejects when the stream closes without an error mid-backpressure", async () => {
+        const writer = stalledWriter();
+        const streaming = awsStreamResponse(chunkedResponse(), useWriter(writer));
+
+        await vi.waitFor(() => expect(writer.listenerCount("drain")).toBe(1));
+        writer.destroy();
+
+        await expect(streaming).rejects.toThrow("Response stream closed before it could drain");
+        expect(writer.listenerCount("drain")).toBe(0);
+      });
+
+      test("rejects when the stream is already gone before the wait starts", async () => {
+        const writer = new Writable({
+          highWaterMark: 1,
+          write() {
+            this.destroy(new Error("gone"));
+          },
+        });
+        writer.on("error", () => {});
+
+        await expect(awsStreamResponse(chunkedResponse(), useWriter(writer))).rejects.toThrow(
+          "Response stream closed before it could drain",
+        );
+      });
+
+      test("resumes on drain and leaves no listeners behind", async () => {
+        const chunks: Buffer[] = [];
+        const writer = new Writable({
+          highWaterMark: 1,
+          write(chunk, _encoding, callback) {
+            chunks.push(Buffer.from(chunk));
+            // Flush asynchronously so every write is followed by a real `drain`.
+            setTimeout(callback, 0);
+          },
+        });
+
+        const response = new Response(
+          new ReadableStream({
+            start(controller) {
+              const encoder = new TextEncoder();
+              controller.enqueue(encoder.encode("chunk-1"));
+              controller.enqueue(encoder.encode("chunk-2"));
+              controller.enqueue(encoder.encode("chunk-3"));
+              controller.close();
+            },
+          }),
+        );
+
+        await awsStreamResponse(response, useWriter(writer));
+
+        expect(Buffer.concat(chunks).toString()).toBe("chunk-1chunk-2chunk-3");
+        for (const event of ["drain", "error", "close"]) {
+          expect(writer.listenerCount(event)).toBe(0);
+        }
+      });
+    });
   });
 
   describe("handleLambdaEventWithStream", () => {
@@ -1510,6 +1702,7 @@ describe("[AWS Lambda] Request Utils", () => {
         }),
         end: vi.fn(),
         once: vi.fn(),
+        removeListener: vi.fn(),
       };
 
       const mockStream = {} as AWSLambdaResponseStream;


### PR DESCRIPTION
Fixes the three AWS Lambda adapter bugs reported in #299, plus a fourth found while reviewing nitrojs/nitro#4576. All four were reproduced against `main` before fixing, and every new test fails on `main` (the three streaming ones by hanging until the 15s test timeout — the reported symptom).

### 1. `stringifyQuery` dropped valueless query params

v1/ALB events only carry the parsed `queryStringParameters`, so the raw query has to be rebuilt. `URLSearchParams` cannot express a valueless param, so `/x?foo` reached the handler as `/x?foo=`, and `if (value == null) continue` dropped the key outright.

Both forms parse back to `{foo: ""}`, but anything reading the raw URL — route rules, cache keys, canonical URLs, an HMAC over the query — sees a different string. Now a bare key is emitted for empty/null values, while valued params keep identical `URLSearchParams` escaping. v2 is unaffected (it short-circuits on `rawQueryString`).

### 2. `awsResponseHeaders` collapsed multiple `set-cookie` into the flat record

`Headers` iteration yields one entry per `set-cookie`, so assigning into a flat object kept only the last one:

```js
const h = new Headers();
h.append("set-cookie", "a=1");
h.append("set-cookie", "b=2");
Object.fromEntries(h)  // { "set-cookie": "b=2" }
h.getSetCookie()       // ["a=1", "b=2"]
```

Both `headers` and `cookies` ship in the result and API Gateway v2 / Function URLs apply both, so `b=2` went out twice and `a=1` once. `set-cookie` is now skipped in the flat loop — `cookies` (v2) and `multiValueHeaders` (v1) already carry the complete list. Same class of bug as #144, different adapter.

ALB is the one exception, handled separately: a target group *without* multi-value headers ignores `multiValueHeaders` (["You must use `multiValueHeaders` if you have enabled multi-value headers and `headers` otherwise"](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers)), so skipping the flat entry would have dropped the cookie rather than de-duplicating it. The same target-group setting renames the *request* fields, so `requestContext.elb` with no `multiValueHeaders` identifies that configuration; only one cookie fits it, and ALB itself keeps the last value when a header repeats, so the last one is sent rather than none.

### 3. `streamToNodeStream` could hang forever on backpressure

```js
if (!canContinue) {
  await new Promise((resolve) => writer.once("drain", resolve));
}
```

`drain` is only emitted by a live stream. If the response stream was destroyed while buffered above its high-water mark (client disconnect, socket reset), it never fired: the promise never settled, `writer.end()` in the caller's `finally` never ran, `reader.releaseLock()` was never reached, and the invocation stayed pending until the Lambda timeout — billing wall-clock and holding a concurrency slot.

The wait is now raced against `error`/`close`, plus an early bail when the stream is already destroyed (`close` has fired and will not fire again). All listeners are removed on settle so long streams don't accumulate them.

### 4. The v2-only `cookies` field leaked into v1 responses

Not from #299 — spotted while reading nitrojs/nitro#4576.

API Gateway REST (v1) and ALB accept only `statusCode`, `headers`, `multiValueHeaders`, `body` and `isBase64Encoded` in a proxy response; any extra top-level key fails the invocation with `Execution failed due to configuration error: Malformed Lambda proxy response` (502). `cookies` is a payload 2.0 field, and the v1 branch emitted it alongside `multiValueHeaders`:

```js
return isV2
  ? { headers, cookies }
  : { headers, cookies, multiValueHeaders: { "set-cookie": cookies } };
//    ^^^^^^^ 502s a REST API / ALB deployment that sets any cookie
```

It was redundant there too, since `multiValueHeaders` already carried the full list. This is the same bug, and the same fix, as unjs/nitro#504 — introduced in Nitro by unjs/nitro#357, re-fixed in v3 by nitrojs/nitro#4576. The streaming prelude shares this function and had the same leak.

srvx's existing `isV2` detection (`version === "2.0" || requestContext.http`) is kept as-is; it's sounder than matching on `"cookies" in event`, since a v2 request without cookies still has `requestContext.http`.

### Tests

`test/aws.test.ts`: v1 query reconstruction (bare key, mixed bare/valued, null, escaping, multi-value, no params); `set-cookie` kept out of the flat record for v1 and v2; exact top-level key sets for v1 and v2 results plus the v1 streaming prelude; ALB with and without multi-value headers enabled; and a `backpressure teardown` group driving `awsStreamResponse` with a real `node:stream` `Writable` — destroyed with and without an error mid-backpressure, destroyed before the wait starts, and a regression guard that a normal drain still delivers every chunk and leaves no listeners behind.

Full suite green (1448 passed), lint and typecheck clean.

🤖 Generated with AI assistant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate `set-cookie` response headers in AWS Lambda integrations.
  - Improved cookie handling across Lambda response versions and Application Load Balancer configurations.
  - Improved handling of query parameters without values and parameters with multiple values.
  - Fixed streaming responses that could remain pending after the connection was closed, ended, or encountered an error.
  - Improved response-stream backpressure handling for more reliable request completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->