### PR TITLE
fix(aws-lambda): review follow-ups on the streaming and query paths

### DIFF
--- a/src/adapters/_aws/utils.ts
+++ b/src/adapters/_aws/utils.ts
@@ -15,6 +15,7 @@ import type {
 export interface AWSLambdaStreamResponseMetadata {
   statusCode: number;
   headers?: Record<string, string>;
+  multiValueHeaders?: Record<string, string[]>;
   cookies?: string[];
 }
 
@@ -176,9 +177,11 @@ export function awsResponseHeaders(
   const headers = Object.create(null);
   for (const [key, value] of response.headers) {
     // `Headers` iteration yields one entry per `set-cookie`, so a flat record
-    // can only keep the last one. The full list is carried below by `cookies`
-    // (v2) or `multiValueHeaders` (v1), both of which AWS applies *in addition
-    // to* `headers` — keeping a copy here would send that last cookie twice.
+    // can only keep the last one, while the full list is carried below by
+    // `cookies` (v2) or `multiValueHeaders` (v1). v2 applies `cookies` *and*
+    // `headers`, so keeping a copy here would send that last cookie twice; v1
+    // merges the two records with `multiValueHeaders` winning per key, so there
+    // the copy is merely redundant. Neither wants it.
     if (key === "set-cookie") {
       continue;
     }
@@ -197,11 +200,12 @@ export function awsResponseHeaders(
     (event as AWSLambdaProxyEventV2)?.version === "2.0" ||
     !!(event as AWSLambdaProxyEventV2)?.requestContext?.http;
 
-  // `cookies` is a payload 2.0 field (HTTP API / Function URL). API Gateway
-  // REST (v1) and ALB accept only `statusCode`, `headers`, `multiValueHeaders`,
-  // `body` and `isBase64Encoded`; any extra top-level key fails the invocation
-  // with a 502 "Malformed Lambda proxy response", so v1 gets `multiValueHeaders`
-  // alone. See https://github.com/unjs/nitro/issues/504.
+  // `cookies` is a payload 2.0 field (HTTP API / Function URL). The API Gateway
+  // REST (v1) proxy result is `statusCode`, `headers`, `multiValueHeaders`,
+  // `body` and `isBase64Encoded` — "If the function output is of a different
+  // format, API Gateway returns a 502 Bad Gateway error response" — so a stray
+  // `cookies` key 502s the whole invocation (unjs/nitro#504). ALB takes the same
+  // fields plus `statusDescription` and likewise has no `cookies`.
   if (isV2) {
     return { headers, cookies };
   }
@@ -211,8 +215,9 @@ export function awsResponseHeaders(
   // multi-value headers and `headers` otherwise"). That same setting renames
   // the *request* fields, so an ALB event without `multiValueHeaders` means the
   // flat record is the only channel back and dropping `set-cookie` from it
-  // would lose the cookie entirely. Only one fits; ALB itself keeps the last
-  // value when a header repeats, so match that instead of sending none.
+  // would lose the cookie entirely. Only one fits, and the docs state the
+  // last-wins rule for requests only, so the last cookie is sent on the same
+  // principle — and because it is what this adapter sent before.
   // https://docs.aws.amazon.com/elasticloadbalancing/latest/application/lambda-functions.html#multi-value-headers
   const albEvent = event as AWSLambdaProxyEvent | undefined;
   if (albEvent?.requestContext?.elb && !albEvent.multiValueHeaders) {
@@ -287,6 +292,12 @@ async function streamToNodeStream(
       }
       result = await reader.read();
     }
+  } catch (error) {
+    // The writer is gone, so tell the source (a proxied `fetch`, a database
+    // cursor, a file handle) to stop rather than leaving it producing into a
+    // stream nobody will read. Releasing the lock alone does not signal it.
+    reader.cancel(error).catch(() => {});
+    throw error;
   } finally {
     reader.releaseLock();
   }
@@ -299,10 +310,15 @@ async function streamToNodeStream(
 // `error`/`close` settle the wait too.
 function waitForDrain(writer: NodeJS.WritableStream): Promise<void> {
   const closedError = () => new Error("Response stream closed before it could drain");
-  const stream = writer as NodeJS.WritableStream & { destroyed?: boolean; writableEnded?: boolean };
+  const stream = writer as NodeJS.WritableStream & {
+    destroyed?: boolean;
+    writableEnded?: boolean;
+    errored?: Error | null;
+  };
   if (stream.destroyed || stream.writableEnded) {
-    // Already gone: `close` has fired and will not fire again.
-    return Promise.reject(closedError());
+    // Already gone: `close` has fired and will not fire again. Prefer the
+    // stream's own error, which says *why* it went away.
+    return Promise.reject(stream.errored ?? closedError());
   }
   return new Promise<void>((resolve, reject) => {
     const settle = (error?: Error) => {
@@ -363,7 +379,10 @@ function stringifyQuery(obj: Record<string, unknown>) {
       // Encode through `URLSearchParams` to keep escaping identical, then drop
       // the trailing `=` it always appends for an empty value.
       const pair = new URLSearchParams([[key, item == null ? "" : String(item)]]).toString();
-      parts.push(item == null || item === "" ? pair.slice(0, -1) : pair);
+      // `pair` is always `key=`; drop the `=` for a valueless param — unless the
+      // key is empty too (`"="`), where dropping it would erase the param.
+      const bare = (item == null || item === "") && key !== "";
+      parts.push(bare ? pair.slice(0, -1) : pair);
     }
   }
   return parts.join("&");

--- a/test/aws.test.ts
+++ b/test/aws.test.ts
@@ -788,6 +788,12 @@ describe("[AWS Lambda] Request Utils", () => {
         );
       });
 
+      test("keeps an empty-named param rather than erasing it", () => {
+        // `?a=1&=` parses to `{ a: "1", "": "" }`; stripping the `=` off a bare
+        // `=` would drop the parameter instead of preserving it.
+        expect(urlOf(v1QueryEvent({ a: "1", "": "" }))).toBe("/x?a=1&=");
+      });
+
       test("emits no query at all when there are no params", () => {
         expect(urlOf(v1QueryEvent(null))).toBe("/x");
       });
@@ -1749,17 +1755,57 @@ describe("[AWS Lambda] Request Utils", () => {
       });
 
       test("rejects when the stream is already gone before the wait starts", async () => {
+        // Destroyed with no error, so `close` has already fired and there is
+        // nothing left to wait for and no underlying error to report.
         const writer = new Writable({
           highWaterMark: 1,
           write() {
-            this.destroy(new Error("gone"));
+            this.destroy();
           },
         });
-        writer.on("error", () => {});
 
         await expect(awsStreamResponse(chunkedResponse(), useWriter(writer))).rejects.toThrow(
           "Response stream closed before it could drain",
         );
+      });
+
+      test("reports the stream's own error when it is already gone", async () => {
+        const writer = new Writable({
+          highWaterMark: 1,
+          write() {
+            this.destroy(new Error("ECONNRESET"));
+          },
+        });
+        writer.on("error", () => {});
+
+        // The generic "closed before it could drain" message would hide why.
+        await expect(awsStreamResponse(chunkedResponse(), useWriter(writer))).rejects.toThrow(
+          "ECONNRESET",
+        );
+      });
+
+      test("cancels the response body so the source stops producing", async () => {
+        const writer = stalledWriter();
+        let cancelledWith: unknown;
+
+        const response = new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new Uint8Array(64));
+              controller.enqueue(new Uint8Array(64));
+            },
+            cancel(reason) {
+              cancelledWith = reason;
+            },
+          }),
+        );
+
+        const streaming = awsStreamResponse(response, useWriter(writer));
+        await vi.waitFor(() => expect(writer.listenerCount("drain")).toBe(1));
+        writer.destroy(new Error("ECONNRESET"));
+
+        await expect(streaming).rejects.toThrow("ECONNRESET");
+        expect((cancelledWith as Error)?.message).toBe("ECONNRESET");
       });
 
       test("resumes on drain and leaves no listeners behind", async () => {


### PR DESCRIPTION
Follow-ups to #300, from an independent review pass after it merged. Four small defects and three inaccurate comments. No behaviour from #300 is reverted.

### Fixes

**`waitForDrain` discarded the stream's real error.** When the response stream was already destroyed, the early bail rejected with the generic `Response stream closed before it could drain`, throwing away `stream.errored` — the one thing that says *why* it went away. It now prefers the stream's own error and falls back to the generic message only when there isn't one (a plain `destroy()` with no error).

**The response body was never cancelled on the error path.** `streamToNodeStream` released the reader but never cancelled the body, leaving the source — a proxied `fetch`, a database cursor, a file handle — producing into a stream nobody would read. This path only became reachable in #300, once the drain wait stopped hanging outright.

**`stringifyQuery` erased empty-named params.** `?a=1&=` parses to `{a: "1", "": ""}`; stripping the `=` off a bare `=` produced `a=1&`, which re-parses with the parameter *gone* rather than reshaped. The `=` is now only dropped when the key is non-empty.

**`AWSLambdaStreamResponseMetadata` was missing `multiValueHeaders`**, which v1 now emits, and which [API Gateway documents](https://docs.aws.amazon.com/apigateway/latest/developerguide/response-transfer-mode-lambda.html#response-transfer-mode-lambda-format) as one of the four supported prelude keys.

### Comment corrections

Three comments added in #300 overstated AWS behaviour:

- v1 does not apply `headers` *in addition to* `multiValueHeaders` — it [merges them, with `multiValueHeaders` winning per key](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format). The duplicate-cookie symptom that motivated the fix was v2-only; on v1 the flat copy was merely redundant. The fix stands, the stated reason was half wrong.
- ALB accepts `statusDescription` too, so "REST v1 and ALB accept only ..." was wrong for ALB. The 502 evidence cited is API Gateway's, not ALB's.
- ALB's last-wins rule for repeated headers is documented for *requests*; #300 asserted it for responses. Sending the last cookie is still the right call — it is what the adapter did before — but on that basis, not a documented one.

### Not changed

An independent review flagged the v1 streaming prelude as a blocking regression, on the theory that the prelude ignores `multiValueHeaders` and so v1 streaming responses would lose cookies. That does not hold — API Gateway's streaming format documentation is explicit:

> The metadata must be valid JSON. Only `headers`, `multiValueHeaders`, `cookies` and the `statusCode` keys are supported.

`multiValueHeaders` is a supported prelude key, so v1 streaming cookies are delivered. No change needed beyond the type fix above.

### Tests

Three new cases, each verified to fail without its fix: the empty-named param, the stream's own error surviving the early bail, and the body being cancelled with the writer's error as the reason. The existing "already gone" test now destroys without an error, so it still covers the generic-message path.

Full suite green (1452 passed), lint and typecheck clean.

🤖 Generated with AI assistant

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved empty query parameter values during AWS request processing.
  * Improved streaming response reliability by propagating stream errors, cancelling interrupted responses, and preventing teardown hangs.
  * Ensured the most relevant stream error is reported when a stream closes unexpectedly.
  * Improved handling of `set-cookie` headers across AWS response formats.
* **Compatibility**
  * Added support for multi-value headers in AWS streaming response metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->