### PR TITLE
fix(node): handle promises independently of the global constructor

### DIFF
--- a/src/_middleware.ts
+++ b/src/_middleware.ts
@@ -15,9 +15,3 @@ export function wrapFetch(server: Server): ServerHandler {
   }
   return composed;
 }
-
-export function isAsyncResponse(
-  response: Response | Promise<Response>,
-): response is Promise<Response> {
-  return typeof (response as Promise<Response>).then === "function";
-}

--- a/src/_middleware.ts
+++ b/src/_middleware.ts
@@ -15,3 +15,9 @@ export function wrapFetch(server: Server): ServerHandler {
   }
   return composed;
 }
+
+export function isAsyncResponse(
+  response: Response | Promise<Response>,
+): response is Promise<Response> {
+  return typeof (response as Promise<Response>).then === "function";
+}

--- a/src/_plugins.ts
+++ b/src/_plugins.ts
@@ -1,4 +1,3 @@
-import { isAsyncResponse } from "./_middleware.ts";
 import * as c from "./cli/_utils.ts";
 import type { ServerPlugin } from "./types.ts";
 
@@ -8,7 +7,9 @@ export const errorPlugin: ServerPlugin = (server) => {
   server.options.middleware.unshift((_req, next) => {
     try {
       const res = next();
-      return isAsyncResponse(res) ? res.then(undefined, (error) => errorHandler(error)) : res;
+      return "then" in res && typeof res.then === "function"
+        ? res.then(undefined, (error) => errorHandler(error))
+        : res;
     } catch (error) {
       return errorHandler(error);
     }

--- a/src/_plugins.ts
+++ b/src/_plugins.ts
@@ -1,3 +1,4 @@
+import { isAsyncResponse } from "./_middleware.ts";
 import * as c from "./cli/_utils.ts";
 import type { ServerPlugin } from "./types.ts";
 
@@ -7,7 +8,7 @@ export const errorPlugin: ServerPlugin = (server) => {
   server.options.middleware.unshift((_req, next) => {
     try {
       const res = next();
-      return "then" in res ? res.then(undefined, (error) => errorHandler(error)) : res;
+      return isAsyncResponse(res) ? res.then(undefined, (error) => errorHandler(error)) : res;
     } catch (error) {
       return errorHandler(error);
     }

--- a/src/_plugins.ts
+++ b/src/_plugins.ts
@@ -7,8 +7,8 @@ export const errorPlugin: ServerPlugin = (server) => {
   server.options.middleware.unshift((_req, next) => {
     try {
       const res = next();
-      return "then" in res && typeof res.then === "function"
-        ? res.then(undefined, (error) => errorHandler(error))
+      return typeof (res as Promise<Response>)?.then === "function"
+        ? (res as Promise<Response>).then(undefined, (error) => errorHandler(error))
         : res;
     } catch (error) {
       return errorHandler(error);

--- a/src/_plugins.ts
+++ b/src/_plugins.ts
@@ -7,7 +7,7 @@ export const errorPlugin: ServerPlugin = (server) => {
   server.options.middleware.unshift((_req, next) => {
     try {
       const res = next();
-      return res instanceof Promise ? res.catch((error) => errorHandler(error)) : res;
+      return "then" in res ? res.then(undefined, (error) => errorHandler(error)) : res;
     } catch (error) {
       return errorHandler(error);
     }

--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -1,3 +1,4 @@
+import { isAsyncResponse } from "../../_middleware.ts";
 import type {
   FetchHandler,
   NodeHttpHandler,
@@ -34,7 +35,7 @@ export function toNodeHandler(
       trustProxy: options?.trustProxy,
     });
     const res = handler(request);
-    return "then" in res
+    return isAsyncResponse(res)
       ? res.then((resolvedRes) => send(nodeRes, resolvedRes))
       : send(nodeRes, res);
   }

--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -34,7 +34,7 @@ export function toNodeHandler(
       trustProxy: options?.trustProxy,
     });
     const res = handler(request);
-    return res instanceof Promise
+    return "then" in res
       ? res.then((resolvedRes) => send(nodeRes, resolvedRes))
       : send(nodeRes, res);
   }

--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -1,4 +1,3 @@
-import { isAsyncResponse } from "../../_middleware.ts";
 import type {
   FetchHandler,
   NodeHttpHandler,
@@ -35,9 +34,9 @@ export function toNodeHandler(
       trustProxy: options?.trustProxy,
     });
     const res = handler(request);
-    return isAsyncResponse(res)
+    return "then" in res && typeof res.then === "function"
       ? res.then((resolvedRes) => send(nodeRes, resolvedRes))
-      : send(nodeRes, res);
+      : send(nodeRes, res as Response);
   }
 
   (convertedNodeHandler as AdapterMeta).__fetchHandler = handler;

--- a/src/adapters/_node/adapter.ts
+++ b/src/adapters/_node/adapter.ts
@@ -34,8 +34,8 @@ export function toNodeHandler(
       trustProxy: options?.trustProxy,
     });
     const res = handler(request);
-    return "then" in res && typeof res.then === "function"
-      ? res.then((resolvedRes) => send(nodeRes, resolvedRes))
+    return typeof (res as Promise<Response>)?.then === "function"
+      ? (res as Promise<Response>).then((resolvedRes) => send(nodeRes, resolvedRes))
       : send(nodeRes, res as Response);
   }
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -99,7 +99,7 @@ class NodeServer implements Server {
       }
       // node:http ignores the listener's return value — use the detached
       // variant to skip the per-response end-tracking Promise.
-      return res instanceof Promise
+      return "then" in res
         ? res.then(
             (resolvedRes) => sendNodeResponseDetached(nodeRes, resolvedRes, this.options.silent),
             // Rejection handler (not `.catch`) so send failures, which

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -8,7 +8,7 @@ import {
   resolvePortAndHost,
   createWaitUntil,
 } from "../_utils.ts";
-import { wrapFetch, isAsyncResponse } from "../_middleware.ts";
+import { wrapFetch } from "../_middleware.ts";
 import { errorPlugin, gracefulShutdownPlugin } from "../_plugins.ts";
 
 import nodeHTTP from "node:http";
@@ -99,14 +99,14 @@ class NodeServer implements Server {
       }
       // node:http ignores the listener's return value — use the detached
       // variant to skip the per-response end-tracking Promise.
-      return isAsyncResponse(res)
+      return "then" in res && typeof res.then === "function"
         ? res.then(
             (resolvedRes) => sendNodeResponseDetached(nodeRes, resolvedRes, this.options.silent),
             // Rejection handler (not `.catch`) so send failures, which
             // `sendNodeResponseDetached` already answers, aren't handled twice.
             (error) => sendErrorResponse(nodeRes, error, this.options.silent),
           )
-        : sendNodeResponseDetached(nodeRes, res, this.options.silent);
+        : sendNodeResponseDetached(nodeRes, res as Response, this.options.silent);
     };
 
     this.node = { handler, server: undefined };

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -99,8 +99,8 @@ class NodeServer implements Server {
       }
       // node:http ignores the listener's return value — use the detached
       // variant to skip the per-response end-tracking Promise.
-      return "then" in res && typeof res.then === "function"
-        ? res.then(
+      return typeof (res as Promise<Response>)?.then === "function"
+        ? (res as Promise<Response>).then(
             (resolvedRes) => sendNodeResponseDetached(nodeRes, resolvedRes, this.options.silent),
             // Rejection handler (not `.catch`) so send failures, which
             // `sendNodeResponseDetached` already answers, aren't handled twice.

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -8,7 +8,7 @@ import {
   resolvePortAndHost,
   createWaitUntil,
 } from "../_utils.ts";
-import { wrapFetch } from "../_middleware.ts";
+import { wrapFetch, isAsyncResponse } from "../_middleware.ts";
 import { errorPlugin, gracefulShutdownPlugin } from "../_plugins.ts";
 
 import nodeHTTP from "node:http";
@@ -99,7 +99,7 @@ class NodeServer implements Server {
       }
       // node:http ignores the listener's return value — use the detached
       // variant to skip the per-response end-tracking Promise.
-      return "then" in res
+      return isAsyncResponse(res)
         ? res.then(
             (resolvedRes) => sendNodeResponseDetached(nodeRes, resolvedRes, this.options.silent),
             // Rejection handler (not `.catch`) so send failures, which

--- a/test/node-promises.test.ts
+++ b/test/node-promises.test.ts
@@ -81,6 +81,27 @@ for (const customError of [false, true]) {
   });
 }
 
+// A handler that returns a non-object must stay on the sync path and get the
+// send layer's 500 — probing `then` with `in` instead threw a TypeError out of
+// the node:http listener, taking the process down on `--unhandled-rejections`.
+for (const result of [undefined, null, "not a response"] as const) {
+  test(`answers 500 for a handler returning ${JSON.stringify(result)}`, async () => {
+    const server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      silent: true,
+      fetch: (() => result) as unknown as FetchHandler,
+    });
+    await server.ready();
+    try {
+      const response = await fetch(server.url!, { signal: AbortSignal.timeout(2000) });
+      expect(response.status).toBe(500);
+    } finally {
+      await server.close(true);
+    }
+  });
+}
+
 async function check(url: string) {
   for (let i = 0; i < 3; i++) {
     const response = await fetch(url, { signal: AbortSignal.timeout(2000) });

--- a/test/node-promises.test.ts
+++ b/test/node-promises.test.ts
@@ -13,12 +13,15 @@ class ReplacementPromise<T> extends NativePromise<T> {}
 
 for (const adapter of ["serve", "toNodeHandler"] as const) {
   describe(`${adapter} promise responses`, () => {
-    for (const kind of ["native", "cross-realm", "sync"] as const) {
+    for (const kind of ["native", "cross-realm", "sync", "non-callable-then"] as const) {
       test(`handles ${kind} responses with a replaced global Promise`, async () => {
         vi.stubGlobal("Promise", ReplacementPromise);
-        const response = () => new Response("ok");
+        const response = () =>
+          kind === "non-callable-then"
+            ? Object.assign(new Response("ok"), { then: undefined })
+            : new Response("ok");
         const handler: FetchHandler =
-          kind === "sync"
+          kind === "sync" || kind === "non-callable-then"
             ? response
             : kind === "native"
               ? async () => response()

--- a/test/node-promises.test.ts
+++ b/test/node-promises.test.ts
@@ -1,0 +1,87 @@
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { runInNewContext } from "node:vm";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { serve, toNodeHandler } from "../src/adapters/node.ts";
+import type { FetchHandler, NodeHttp1Handler } from "../src/types.ts";
+
+const NativePromise = Promise;
+afterEach(() => vi.unstubAllGlobals());
+
+// Like Zone.js, a replacement constructor does not own native async results.
+class ReplacementPromise<T> extends NativePromise<T> {}
+
+for (const adapter of ["serve", "toNodeHandler"] as const) {
+  describe(`${adapter} promise responses`, () => {
+    for (const kind of ["native", "cross-realm", "sync"] as const) {
+      test(`handles ${kind} responses with a replaced global Promise`, async () => {
+        vi.stubGlobal("Promise", ReplacementPromise);
+        const response = () => new Response("ok");
+        const handler: FetchHandler =
+          kind === "sync"
+            ? response
+            : kind === "native"
+              ? async () => response()
+              : () => runInNewContext("Promise.resolve(response())", { response });
+        if (kind === "native")
+          expect(handler(new Request("http://localhost"))).not.toBeInstanceOf(Promise);
+        if (adapter === "serve") {
+          const server = serve({ port: 0, hostname: "127.0.0.1", silent: true, fetch: handler });
+          await server.ready();
+          try {
+            await check(server.url!);
+          } finally {
+            await server.close(true);
+          }
+        } else {
+          const server = createServer(toNodeHandler(handler) as NodeHttp1Handler);
+          server.listen(0, "127.0.0.1");
+          await once(server, "listening");
+          try {
+            const address = server.address();
+            if (!address || typeof address === "string") throw new Error("Missing address");
+            await check(`http://127.0.0.1:${address.port}`);
+          } finally {
+            server.closeAllConnections();
+            await new NativePromise<void>((resolve, reject) =>
+              server.close((error) => (error ? reject(error) : resolve())),
+            );
+          }
+        }
+      });
+    }
+  });
+}
+
+for (const customError of [false, true]) {
+  test(`handles native rejections with replaced Promise (error handler: ${customError})`, async () => {
+    vi.stubGlobal("Promise", ReplacementPromise);
+    const error = vi.fn(() => new Response("handled", { status: 503 }));
+    const server = serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      silent: true,
+      fetch: async () => {
+        throw new Error("expected rejection");
+      },
+      ...(customError ? { error } : {}),
+    });
+    await server.ready();
+    try {
+      const response = await fetch(server.url!, { signal: AbortSignal.timeout(2000) });
+      expect(response.status).toBe(customError ? 503 : 500);
+      expect(await response.text()).toBe(customError ? "handled" : "");
+      expect(error).toHaveBeenCalledTimes(customError ? 1 : 0);
+    } finally {
+      await server.close(true);
+    }
+  });
+}
+
+async function check(url: string) {
+  for (let i = 0; i < 3; i++) {
+    const response = await fetch(url, { signal: AbortSignal.timeout(2000) });
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("ok");
+  }
+}


### PR DESCRIPTION
## Problem and change

When Zone.js replaces global Promise, native async functions still return intrinsic native promises. The Node adapter's `instanceof Promise` check then treats a promise as a Response and returns an empty 500 on subsequent requests.

Closes [Node responses after Zone.js replaces Promise — h3js/srvx#302](https://github.com/h3js/srvx/issues/302).

Discriminate the existing Response/Promise union through a **callable** `then` property in both Node adapter paths. Apply the same change to custom error middleware, using the rejection arm of `then`, so native/cross-realm rejections still reach the configured error handler. Synchronous responses retain the direct send path; no new dependency or global patch is introduced.

## Sample and use case

```js
const server = serve({
  async fetch() {
    await import('zone.js/node');
    return new Response('ok');
  },
});
```

Repeated requests should return `200 "ok"`. This affects Angular/Analog SSR development under Nitro, where loading Zone.js changes the global constructor after server startup. The linked issue contains the complete standalone reproduction.

The new tests replace global Promise with a subclass to reproduce the relevant constructor mismatch without adding Zone.js as a dependency, restore it after each test, and also exercise promises created in a separate VM realm.

## Validation

Node 24.15.0, repository-pinned pnpm 11.11.0:

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `env -u NO_COLOR -u FORCE_COLOR pnpm test`: lint, formatting, typecheck and coverage suite passed; **1,478 tests passed, 39 skipped**, no type errors.
- New focused suite: 10 passed, including Responses with a non-callable `then` property. Against unmodified upstream source, the same suite produced 5 failures and 2 unhandled-rejection errors.

Tests cover three successive requests through `serve` and `toNodeHandler`, native and cross-realm promises, synchronous responses, and rejections with/without a custom error handler. The initial full run inherited conflicting terminal-color variables and failed logger assertions, plus one TLS test; the clean-environment full rerun passed all tests. Build precedes typecheck to resolve package self-imports through `dist`.

## Suggested AI follow-up prompt

> Audit async response boundaries for assumptions about a mutable global Promise constructor. Preserve synchronous response fast paths and existing rejection behavior. Reproduce native async and cross-realm results with isolated tests, including configured error handlers, without globally normalizing or buffering responses.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of asynchronous responses across Node-based integrations, including cross-environment promises and thenable values.
  - Prevented invalid or empty handler results from causing unexpected runtime errors; these now produce a standard 500 response.
  - Preserved correct error handling for rejected asynchronous responses, including custom error responses when configured.
  - Responses with non-callable `then` properties are now handled as regular responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
